### PR TITLE
fix: use Stsz.GetSampleSize() everywhere

### DIFF
--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -95,7 +95,7 @@ func parseProgressiveMp4(f *mp4.File, maxNrSamples int, codec string) error {
 		}
 		offset := getChunkOffset(stbl, chunkNr)
 		for sNr := sampleNrAtChunkStart; sNr < sampleNr; sNr++ {
-			offset += int64(stbl.Stsz.SampleSize[sNr-1])
+			offset += int64(stbl.Stsz.GetSampleSize(sNr))
 		}
 		size := stbl.Stsz.GetSampleSize(sampleNr)
 		decTime, _ := stbl.Stts.GetDecodeTime(uint32(sampleNr))

--- a/cmd/mp4ff-wvttlister/main.go
+++ b/cmd/mp4ff-wvttlister/main.go
@@ -118,7 +118,7 @@ func parseProgressiveMp4(f *mp4.File, trackID uint32, maxNrSamples int) error {
 			offset = int64(stbl.Co64.ChunkOffset[chunkNr-1])
 		}
 		for sNr := sampleNrAtChunkStart; sNr < sampleNr; sNr++ {
-			offset += int64(stbl.Stsz.SampleSize[sNr-1])
+			offset += int64(stbl.Stsz.GetSampleSize(sNr))
 		}
 		size := stbl.Stsz.GetSampleSize(sampleNr)
 		decTime, dur := stbl.Stts.GetDecodeTime(uint32(sampleNr))

--- a/examples/segmenter/segment.go
+++ b/examples/segmenter/segment.go
@@ -285,7 +285,7 @@ func copyMediaData(trak *mp4.TrakBox, startSampleNr, endSampleNr uint32, rs io.R
 		endNr = startNr + chunk.NrSamples - 1
 		if i == 0 {
 			for sNr := chunk.StartSampleNr; sNr < startSampleNr; sNr++ {
-				offset += uint64(stbl.Stsz.SampleSize[sNr-1])
+				offset += uint64(stbl.Stsz.GetSampleSize(int(sNr)))
 			}
 			startNr = startSampleNr
 		}

--- a/examples/segmenter/segmenter.go
+++ b/examples/segmenter/segmenter.go
@@ -140,7 +140,7 @@ func (s *Segmenter) GetFullSamplesForInterval(mp4f *mp4.File, tr *Track, startSa
 		}
 
 		for sNr := sampleNrAtChunkStart; sNr < int(sampleNr); sNr++ {
-			offset += int64(stbl.Stsz.SampleSize[sNr-1])
+			offset += int64(stbl.Stsz.GetSampleSize(sNr))
 		}
 		size := stbl.Stsz.GetSampleSize(int(sampleNr))
 		decTime, dur := stbl.Stts.GetDecodeTime(sampleNr)

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -396,7 +396,7 @@ func (f *File) CopySampleData(w io.Writer, rs io.ReadSeeker, trak *TrakBox, star
 		offset = chunkOffsets[chunk.ChunkNr-1]
 		if i == 0 {
 			for sNr := chunk.StartSampleNr; sNr < startSampleNr; sNr++ {
-				offset += uint64(stbl.Stsz.SampleSize[sNr-1])
+				offset += uint64(stbl.Stsz.GetSampleSize(int(sNr)))
 			}
 			startNr = startSampleNr
 		}


### PR DESCRIPTION
Use GetSampleSize() to handle case where a fixed size is used.