### PR TITLE
Move repo to Eyevinn/mp4ff

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-MIT License
+# MIT License
 
-Copyright (c) 2019-2020 Edgeware
+`Copyright (c) 2019-2022 Edgeware AB, 2023- Eyevinn Technology AB`.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ prepare:
 	go mod vendor
 
 mp4ff-info mp4ff-nallister mp4ff-pslister mp4ff-wvttlister:
-	go build -ldflags "-X github.com/edgeware/mp4ff/mp4.commitVersion=$$(git describe --tags HEAD) -X github.com/edgeware/mp4ff/mp4.commitDate=$$(git log -1 --format=%ct)" -o out/$@ ./cmd/$@/main.go
+	go build -ldflags "-X github.com/Eyevinn/mp4ff/mp4.commitVersion=$$(git describe --tags HEAD) -X github.com/Eyevinn/mp4ff/mp4.commitDate=$$(git log -1 --format=%ct)" -o out/$@ ./cmd/$@/main.go
 
 .PHONY: examples
 examples: initcreator multitrack resegmenter segmenter

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![Logo](images/logo.png)
 
-![Test](https://github.com/edgeware/mp4ff/workflows/Go/badge.svg)
-![golangci-lint](https://github.com/edgeware/mp4ff/workflows/golangci-lint/badge.svg?branch=master)
-[![GoDoc](https://godoc.org/github.com/edgeware/mp4ff?status.svg)](http://godoc.org/github.com/edgeware/mp4ff)
-[![Go Report Card](https://goreportcard.com/badge/github.com/edgeware/mp4ff)](https://goreportcard.com/report/github.com/edgeware/mp4ff)
-[![license](https://img.shields.io/github/license/edgeware/mp4ff.svg)](https://github.com/edgeware/mp4ff/blob/master/LICENSE.md)
+![Test](https://github.com/Eyevinn/mp4ff/workflows/Go/badge.svg)
+![golangci-lint](https://github.com/Eyevinn/mp4ff/workflows/golangci-lint/badge.svg?branch=master)
+[![GoDoc](https://godoc.org/github.com/Eyevinn/mp4ff?status.svg)](http://godoc.org/github.com/Eyevinn/mp4ff)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Eyevinn/mp4ff)](https://goreportcard.com/report/github.com/Eyevinn/mp4ff)
+[![license](https://img.shields.io/github/license/Eyevinn/mp4ff.svg)](https://github.com/Eyevinn/mp4ff/blob/master/LICENSE.md)
 
 Package mp4ff implements MP4 media file parsing and writing for AVC and HEVC video, AAC and AC-3 audio,  and stpp and wvtt subtitles.
 It is focused on fragmented files as used for streaming in DASH, MSS and HLS fMP4, but can also decode and encode all boxes needed for
@@ -27,7 +27,7 @@ Some useful command line tools are available in `cmd`.
 
 You can install these tools by going to their respective directory and run `go install .` or directly from the repo with
 
-    go install github.com/edgeware/mp4ff/cmd/mp4ff-info@latest
+    go install github.com/Eyevinn/mp4ff/cmd/mp4ff-info@latest
 
 ## Example code
 

--- a/Versions.md
+++ b/Versions.md
@@ -2,6 +2,7 @@
 
 | Version | Highlight |
 | ------  | --------- |
+| 0.32.0 | Repo moved to github.com/Eyevinn/mp4ff.
 | 0.31.0 | Support multiple sidx. Optimize stsc lookups. New return type for NewNaluArray. Bug fixes in prft, adts and avc interlace.
 | 0.30.1 | Fix optimized sample copying introduced in v0.30.0 |
 | 0.30.0 | Full AVC slice header parsing. Enhanced SEI Messages. Optimizations in ctts and sample copying. Bug fixes in HEVC nalu, tfdt, emsg |

--- a/aac/aac.go
+++ b/aac/aac.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 const (

--- a/aac/adts.go
+++ b/aac/adts.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // ADTSHeader - data for an unencrypted ADTS Header with one AAC frame.

--- a/avc/avcdecoderconfigurationrecord.go
+++ b/avc/avcdecoderconfigurationrecord.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // AVC parsing errors

--- a/avc/pps.go
+++ b/avc/pps.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // PPS - Picture Parameter Set

--- a/avc/slice.go
+++ b/avc/slice.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // Errors for parsing and handling AVC slices

--- a/avc/sps.go
+++ b/avc/sps.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // ExtendedSAR - Extended Sample Aspect Ratio Code

--- a/bits/LICENSE.md
+++ b/bits/LICENSE.md
@@ -1,12 +1,11 @@
 # Copyright
 
-`Copyright (c) 2019-2020 Edgeware AB`.
+`Copyright (c) 2019-2022 Edgeware AB, 2023- Eyevinn Technology AB`.
 
 Some code in this directory comes from or is based on https://github.com/tcnksm/go-casper/tree/master/internal/bits
 `Copyright (c) 2017 Taichi Nakashima`.
 
 All code has the same MIT License.
-
 
 # License
 

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -7,7 +7,6 @@ Install like
 
 or remotely as
 
-	go get -u github.com/edgeware/mp4ff/cmd/mp4ff-info
-
+	go get -u github.com/Eyevinn/mp4ff/cmd/mp4ff-info
 */
 package cmd

--- a/cmd/mp4ff-crop/main.go
+++ b/cmd/mp4ff-crop/main.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 var usg = `Usage of %s:

--- a/cmd/mp4ff-crop/main_test.go
+++ b/cmd/mp4ff-crop/main_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 // TestCroppedFileDuration - simple test to check that cropped file has right duration

--- a/cmd/mp4ff-crop/stblcrop.go
+++ b/cmd/mp4ff-crop/stblcrop.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 func cropStblChildren(traks []*mp4.TrakBox, trakOuts map[uint32]*trakOut) (err error) {

--- a/cmd/mp4ff-info/Makefile
+++ b/cmd/mp4ff-info/Makefile
@@ -1,8 +1,8 @@
 build:
-	go build -ldflags "-X github.com/edgeware/mp4ff/mp4.commitVersion=$$(git describe --tags HEAD) -X github.com/edgeware/mp4ff/mp4.commitDate=$$(git log -1 --format=%ct)" .
+	go build -ldflags "-X github.com/Eyevinn/mp4ff/mp4.commitVersion=$$(git describe --tags HEAD) -X github.com/Eyevinn/mp4ff/mp4.commitDate=$$(git log -1 --format=%ct)" .
 
 install:
-	go install -ldflags "-X github.com/edgeware/mp4ff/mp4.commitVersion=$$(git describe --tags HEAD) -X github.com/edgeware/mp4ff/mp4.commitDate=$$(git log -1 --format=%ct)" .
+	go install -ldflags "-X github.com/Eyevinn/mp4ff/mp4.commitVersion=$$(git describe --tags HEAD) -X github.com/Eyevinn/mp4ff/mp4.commitDate=$$(git log -1 --format=%ct)" .
 
 linux-build:
 	GOOS=linux GOARCH=amd64 go build -ldflags "-X main.commitVersion=$$(git describe --tags HEAD) -X main.commitDate=$$(git log -1 --format=%ct)" 

--- a/cmd/mp4ff-info/main.go
+++ b/cmd/mp4ff-info/main.go
@@ -1,4 +1,4 @@
-//mp4ff-info prints the box tree of input mp4 (ISOBMFF) file.
+// mp4ff-info prints the box tree of input mp4 (ISOBMFF) file.
 package main
 
 import (
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 var usg = `Usage of mp4ff-info:

--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -11,10 +11,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/edgeware/mp4ff/avc"
-	"github.com/edgeware/mp4ff/hevc"
-	"github.com/edgeware/mp4ff/mp4"
-	"github.com/edgeware/mp4ff/sei"
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/sei"
 )
 
 var usg = `Usage of mp4ff-nallister:

--- a/cmd/mp4ff-pslister/main.go
+++ b/cmd/mp4ff-pslister/main.go
@@ -14,9 +14,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/edgeware/mp4ff/avc"
-	"github.com/edgeware/mp4ff/hevc"
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 var usg = `Usage of mp4ff-pslister:

--- a/cmd/mp4ff-wvttlister/main.go
+++ b/cmd/mp4ff-wvttlister/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 var usg = `Usage of mp4ff-wvttlister:

--- a/examples/decrypt-cenc/main.go
+++ b/examples/decrypt-cenc/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 func main() {

--- a/examples/initcreator/main.go
+++ b/examples/initcreator/main.go
@@ -7,9 +7,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/edgeware/mp4ff/aac"
-	"github.com/edgeware/mp4ff/bits"
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/aac"
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 const (

--- a/examples/multitrack/main.go
+++ b/examples/multitrack/main.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/edgeware/mp4ff/avc"
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 const (

--- a/examples/multitrack/multitrack_test.go
+++ b/examples/multitrack/multitrack_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/go-test/deep"
 )
 

--- a/examples/resegmenter/main.go
+++ b/examples/resegmenter/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 func main() {

--- a/examples/resegmenter/resegment.go
+++ b/examples/resegmenter/resegment.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 // Resegment file into multiple segments

--- a/examples/segmenter/main.go
+++ b/examples/segmenter/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 func main() {

--- a/examples/segmenter/segment.go
+++ b/examples/segmenter/segment.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 func makeSingleTrackSegments(segmenter *Segmenter, parsedMp4 *mp4.File, rs io.ReadSeeker, outFilePath string) error {

--- a/examples/segmenter/segmenter.go
+++ b/examples/segmenter/segmenter.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/mp4"
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 // Segmenter - segment the progressive inFIle

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/edgeware/mp4ff
+module github.com/Eyevinn/mp4ff
 
 go 1.14
 

--- a/hevc/hevcdecoderconfigurationrecord.go
+++ b/hevc/hevcdecoderconfigurationrecord.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // HEVC errors

--- a/hevc/sps.go
+++ b/hevc/sps.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/edgeware/mp4ff/avc"
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SPS - HEVC SPS parameters

--- a/mp4/LICENSE.md
+++ b/mp4/LICENSE.md
@@ -1,6 +1,6 @@
 # Copyright
 
-Most code is `Copyright (c) 2019-2020 Edgeware AB`.
+Most code is `Copyright (c) 2019-2022 Edgeware AB, 2023- Eyevinn Technology AB`.
 
 Some code in this directory comes from or is based on https://github.com/jfbus/mp4 which has
 `Copyright (c) 2015 Jean-François Bustarret`.

--- a/mp4/audiosampleentry_test.go
+++ b/mp4/audiosampleentry_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestWriteReadOfAudioSampleEntry(t *testing.T) {

--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // AudioSampleEntryBox according to ISO/IEC 14496-12

--- a/mp4/avcc.go
+++ b/mp4/avcc.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/avc"
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // AvcCBox - AVCConfigurationBox (ISO/IEC 14496-15 5.4.2.1.2 and 5.3.3.1.2)

--- a/mp4/benchmarks_srw_test.go
+++ b/mp4/benchmarks_srw_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestDecodEncodeFileSRW(t *testing.T) {

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 const (

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"fmt"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 var decodersSR map[string]BoxDecoderSR

--- a/mp4/boxsr_test.go
+++ b/mp4/boxsr_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // Test decode + encode file with slice reader and writer

--- a/mp4/btrt.go
+++ b/mp4/btrt.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // BtrtBox - BitRateBox - ISO/IEC 14496-12 Section 8.5.2.2

--- a/mp4/cdat.go
+++ b/mp4/cdat.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // CdatBox - Closed Captioning Sample Data according to QuickTime spec:

--- a/mp4/clap.go
+++ b/mp4/clap.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // ClapBox - Clean Aperture Box, ISO/IEC 14496-12 2020 Sec. 12.1.4

--- a/mp4/co64.go
+++ b/mp4/co64.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // Co64Box - Chunk Large Offset Box

--- a/mp4/container.go
+++ b/mp4/container.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // ContainerBox is interface for ContainerBoxes

--- a/mp4/cslg.go
+++ b/mp4/cslg.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // CslgBox - CompositionToDecodeBox -ISO/IEC 14496-12 2015 Sec. 8.6.1.4

--- a/mp4/ctts.go
+++ b/mp4/ctts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // CttsBox - Composition Time to Sample Box (ctts - optional)

--- a/mp4/dac3.go
+++ b/mp4/dac3.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // AC3SampleRates - Sample rates as defined in  ETSI TS 102 366 V1.4.1 (2017) section 4.4.1.3

--- a/mp4/dac3_test.go
+++ b/mp4/dac3_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestEncodeDedodeAC3(t *testing.T) {

--- a/mp4/dec3.go
+++ b/mp4/dec3.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // dec3

--- a/mp4/dec3_test.go
+++ b/mp4/dec3_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestEncDecDec3(t *testing.T) {

--- a/mp4/descriptors.go
+++ b/mp4/descriptors.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"fmt"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 /* Elementary Stream Descriptors are defined in ISO/IEC 14496-1.
@@ -37,35 +37,35 @@ type Descriptor interface {
 /*
 ESDescriptor is defined in ISO/IEC 14496-1 7.2.6.5
 
-class ES_Descriptor extends BaseDescriptor : bit(8) tag=ES_DescrTag {
-  bit(16) ES_ID;
-  bit(1) streamDependenceFlag;
-  bit(1) URL_Flag;
-  bit(1) OCRstreamFlag;
-  bit(5) streamPriority;
-  if (streamDependenceFlag)
-    bit(16) dependsOn_ES_ID;
-  if (URL_Flag) {
-    bit(8) URLlength;
-    bit(8) URLstring[URLlength];
-  }
-  if (OCRstreamFlag)
-    bit(16) OCR_ES_Id;
-  DecoderConfigDescriptor decConfigDescr;
-  if (ODProfileLevelIndication==0x01) //no SL extension.
-  {
-    SLConfigDescriptor slConfigDescr;
-  } else  { // SL extension is possible.
-    SLConfigDescriptor slConfigDescr;
-  }
-  IPI_DescrPointer ipiPtr[0 .. 1];
-  IP_IdentificationDataSet ipIDS[0 .. 255];
-  IPMP_DescriptorPointer ipmpDescrPtr[0 .. 255];
-  LanguageDescriptor langDescr[0 .. 255];
-  QoS_Descriptor qosDescr[0 .. 1];
-  RegistrationDescriptor regDescr[0 .. 1];
-  ExtensionDescriptor extDescr[0 .. 255];
-}
+	class ES_Descriptor extends BaseDescriptor : bit(8) tag=ES_DescrTag {
+	  bit(16) ES_ID;
+	  bit(1) streamDependenceFlag;
+	  bit(1) URL_Flag;
+	  bit(1) OCRstreamFlag;
+	  bit(5) streamPriority;
+	  if (streamDependenceFlag)
+	    bit(16) dependsOn_ES_ID;
+	  if (URL_Flag) {
+	    bit(8) URLlength;
+	    bit(8) URLstring[URLlength];
+	  }
+	  if (OCRstreamFlag)
+	    bit(16) OCR_ES_Id;
+	  DecoderConfigDescriptor decConfigDescr;
+	  if (ODProfileLevelIndication==0x01) //no SL extension.
+	  {
+	    SLConfigDescriptor slConfigDescr;
+	  } else  { // SL extension is possible.
+	    SLConfigDescriptor slConfigDescr;
+	  }
+	  IPI_DescrPointer ipiPtr[0 .. 1];
+	  IP_IdentificationDataSet ipIDS[0 .. 255];
+	  IPMP_DescriptorPointer ipmpDescrPtr[0 .. 255];
+	  LanguageDescriptor langDescr[0 .. 255];
+	  QoS_Descriptor qosDescr[0 .. 1];
+	  RegistrationDescriptor regDescr[0 .. 1];
+	  ExtensionDescriptor extDescr[0 .. 255];
+	}
 */
 type ESDescriptor struct {
 	EsID                uint16

--- a/mp4/descriptors_test.go
+++ b/mp4/descriptors_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestDecodeDescriptor(t *testing.T) {

--- a/mp4/dinf.go
+++ b/mp4/dinf.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // DinfBox - Data Information Box (dinf - mandatory)

--- a/mp4/dref.go
+++ b/mp4/dref.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // DrefBox - Data Reference Box (dref - mandatory)

--- a/mp4/edts.go
+++ b/mp4/edts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // EdtsBox - Edit Box (edts - optional)

--- a/mp4/elng.go
+++ b/mp4/elng.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // ElngBox - Extended Language Box

--- a/mp4/elst.go
+++ b/mp4/elst.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // ElstBox - Edit List Box (elst - optional)

--- a/mp4/emsg.go
+++ b/mp4/emsg.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // EmsgBox - DASHEventMessageBox as defined in ISO/IEC 23009-1

--- a/mp4/emsg_test.go
+++ b/mp4/emsg_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-test/deep"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestEmsg(t *testing.T) {

--- a/mp4/esds.go
+++ b/mp4/esds.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // EsdsBox as used for MPEG-audio, see ISO 14496-1 Section 7.2.6.6  for DecoderConfigDescriptor

--- a/mp4/esds_test.go
+++ b/mp4/esds_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 const (

--- a/mp4/ffmpeg.go
+++ b/mp4/ffmpeg.go
@@ -4,7 +4,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // CTooBox - ©too box defines the ffmpeg encoding tool information

--- a/mp4/ffmpeg_test.go
+++ b/mp4/ffmpeg_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestDecodeFFMpeg(t *testing.T) {

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // File - an MPEG-4 file asset

--- a/mp4/file_test.go
+++ b/mp4/file_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestDecodeFileWithLazyMdatOption(t *testing.T) {

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"sort"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // Fragment - MP4 Fragment ([prft] + moof + mdat)

--- a/mp4/free.go
+++ b/mp4/free.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // FreeBox - Free Space Box (free or skip)

--- a/mp4/frma.go
+++ b/mp4/frma.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // FrmaBox - Original Format Box

--- a/mp4/ftyp.go
+++ b/mp4/ftyp.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // FtypBox - File Type Box (ftyp - mandatory in full file/init segment)

--- a/mp4/hdlr.go
+++ b/mp4/hdlr.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // HdlrBox - Handler Reference Box (hdlr - mandatory)

--- a/mp4/helpers_test.go
+++ b/mp4/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 	"github.com/go-test/deep"
 )
 

--- a/mp4/hvcc.go
+++ b/mp4/hvcc.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
-	"github.com/edgeware/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/hevc"
 )
 
 // HvcCBox - HEVCConfigurationBox (ISO/IEC 14496-15 8.4.1.1.2)

--- a/mp4/ilst.go
+++ b/mp4/ilst.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // IlstBox - iTunes Metadata Item List Atom (ilst)
@@ -58,7 +58,7 @@ func (b *IlstBox) GetChildren() []Box {
 	return b.Children
 }
 
-/// Encode - write ilst container to w
+// Encode - write ilst container to w
 func (b *IlstBox) Encode(w io.Writer) error {
 	return EncodeContainer(b, w)
 }

--- a/mp4/initsegment.go
+++ b/mp4/initsegment.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/aac"
-	"github.com/edgeware/mp4ff/avc"
-	"github.com/edgeware/mp4ff/bits"
-	"github.com/edgeware/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/aac"
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/hevc"
 )
 
 // InitSegment - MP4/CMAF init segment

--- a/mp4/kind.go
+++ b/mp4/kind.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // KindBox - Track Kind Box

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MdatBox - Media Data Box (mdat)

--- a/mp4/mdhd.go
+++ b/mp4/mdhd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 const charOffset = 0x60 // According to Section 8.4.2.3 of 14496-12

--- a/mp4/mdia.go
+++ b/mp4/mdia.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MdiaBox - Media Box (mdia)

--- a/mp4/mediasegment.go
+++ b/mp4/mediasegment.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MediaSegment is an MP4 Media Segment with one or more Fragments.

--- a/mp4/mehd.go
+++ b/mp4/mehd.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MehdBox - Movie Extends Header Box

--- a/mp4/meta.go
+++ b/mp4/meta.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MetaBox - MetaBox meta ISO/IEC 14496-12 Ed. 6 2020 Section 8.11

--- a/mp4/mfhd.go
+++ b/mp4/mfhd.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MfhdBox - Media Fragment Header Box (mfhd)

--- a/mp4/mfra.go
+++ b/mp4/mfra.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MfraBox - Movie Fragment Random Access Box (mfra)

--- a/mp4/mfro.go
+++ b/mp4/mfro.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MfroBox - Movie Fragment Random Access Offset Box (mfro)

--- a/mp4/mime.go
+++ b/mp4/mime.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MimeBox - MIME Box as defined in ISO/IEC 14496-12 2020 Section 12.3.3.2

--- a/mp4/minf.go
+++ b/mp4/minf.go
@@ -3,13 +3,12 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MinfBox -  Media Information Box (minf - mandatory)
 //
 // Contained in : Media Box (mdia)
-//
 type MinfBox struct {
 	Vmhd     *VmhdBox
 	Smhd     *SmhdBox

--- a/mp4/moof.go
+++ b/mp4/moof.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MoofBox -  Movie Fragment Box (moof)

--- a/mp4/moov.go
+++ b/mp4/moov.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MoovBox - Movie Box (moov - mandatory)

--- a/mp4/mvex.go
+++ b/mp4/mvex.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MvexBox - MovieExtendsBox (mevx)

--- a/mp4/mvhd.go
+++ b/mp4/mvhd.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // MvhdBox - Movie Header Box (mvhd - mandatory)
@@ -14,7 +14,6 @@ import (
 // Contains all media information (duration, ...).
 //
 // Duration is measured in "time units", and timescale defines the number of time units per second.
-//
 type MvhdBox struct {
 	Version          byte
 	Flags            uint32

--- a/mp4/nmhd.go
+++ b/mp4/nmhd.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // NmhdBox - Null Media Header Box (nmhd - often used instead of sthd for subtitle tracks)

--- a/mp4/pasp.go
+++ b/mp4/pasp.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // PaspBox - Pixel Aspect Ratio Box, ISO/IEC 14496-12 2020 Sec. 12.1.4

--- a/mp4/prft.go
+++ b/mp4/prft.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // PrftBox - Producer Reference Box (prft)

--- a/mp4/prft_test.go
+++ b/mp4/prft_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestPrft(t *testing.T) {

--- a/mp4/pssh.go
+++ b/mp4/pssh.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // UUIDs for different DRM systems

--- a/mp4/saio.go
+++ b/mp4/saio.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SaioBox - Sample Auxiliary Information Offsets Box (saiz) (in stbl or traf box)

--- a/mp4/saiz.go
+++ b/mp4/saiz.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SaizBox - Sample Auxiliary Information Sizes Box (saiz)  (in stbl or traf box)

--- a/mp4/samplegroupentries.go
+++ b/mp4/samplegroupentries.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SampleGroupEntry - like a box, but size and type are not in a header

--- a/mp4/sbgp.go
+++ b/mp4/sbgp.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 const (

--- a/mp4/schi.go
+++ b/mp4/schi.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SchiBox -  Schema Information Box

--- a/mp4/schm.go
+++ b/mp4/schm.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SchmBox - Scheme Type Box

--- a/mp4/sdtp.go
+++ b/mp4/sdtp.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SdtpBox - Sample Dependency Box (sdtp - optional)

--- a/mp4/senc.go
+++ b/mp4/senc.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // UseSubSampleEncryption - flag for subsample encryption
@@ -223,7 +223,7 @@ func (s *SencBox) Type() string {
 	return "senc"
 }
 
-//setSubSamplesUsedFlag - set flag if subsamples are used
+// setSubSamplesUsedFlag - set flag if subsamples are used
 func (s *SencBox) setSubSamplesUsedFlag() {
 	for _, subSamples := range s.SubSamples {
 		if len(subSamples) > 0 {

--- a/mp4/sgpd.go
+++ b/mp4/sgpd.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SgpdBox - Sample Group Description Box, ISO/IEC 14496-12 6'th edition 2020 Section 8.9.3

--- a/mp4/sidx.go
+++ b/mp4/sidx.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 /*
@@ -160,7 +160,7 @@ func (b *SidxBox) EncodeSW(sw bits.SliceWriter) error {
 	return sw.AccError()
 }
 
-//Info - more info for level 1
+// Info - more info for level 1
 func (b *SidxBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
 	bd := newInfoDumper(w, indent, b, int(b.Version), b.Flags)
 	bd.write(" - referenceID: %d", b.ReferenceID)

--- a/mp4/sinf.go
+++ b/mp4/sinf.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SinfBox -  Protection Scheme Information Box according to ISO/IEC 23001-7

--- a/mp4/smhd.go
+++ b/mp4/smhd.go
@@ -3,13 +3,12 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SmhdBox - Sound Media Header Box (smhd - mandatory for sound tracks)
 //
 // Contained in : Media Information Box (minf)
-//
 type SmhdBox struct {
 	Version byte
 	Flags   uint32

--- a/mp4/stbl.go
+++ b/mp4/stbl.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // StblBox - Sample Table Box (stbl - mandatory)

--- a/mp4/stco.go
+++ b/mp4/stco.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // StcoBox - Chunk Offset Box (stco - mandatory)

--- a/mp4/sthd.go
+++ b/mp4/sthd.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SthdBox - Subtitle Media Header Box (sthd - for subtitle tracks)

--- a/mp4/stpp.go
+++ b/mp4/stpp.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // StppBox - XMLSubtitleSampleEntryr Box (stpp)

--- a/mp4/stsc.go
+++ b/mp4/stsc.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // StscBox is Sample To Chunk Box in progressive file.

--- a/mp4/stsd.go
+++ b/mp4/stsd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // StsdBox - Sample Description Box (stsd - manatory)

--- a/mp4/stss.go
+++ b/mp4/stss.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // StssBox - Sync Sample Box (stss - optional)

--- a/mp4/stsz.go
+++ b/mp4/stsz.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // StszBox - Sample Size Box (stsz - mandatory)

--- a/mp4/stts.go
+++ b/mp4/stts.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // SttsBox -  Decoding Time to Sample Box (stts - mandatory)

--- a/mp4/styp.go
+++ b/mp4/styp.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // StypBox - Segment Type Box (styp)

--- a/mp4/subs.go
+++ b/mp4/subs.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 /*

--- a/mp4/tenc.go
+++ b/mp4/tenc.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TencBox - Track Encryption Box

--- a/mp4/tfdt.go
+++ b/mp4/tfdt.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TfdtBox - Track Fragment Decode Time (tfdt)

--- a/mp4/tfhd.go
+++ b/mp4/tfhd.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 const baseDataOffsetPresent uint32 = 0x000001

--- a/mp4/tfra.go
+++ b/mp4/tfra.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TfraBox - Track Fragment Random Access Box (tfra)
@@ -180,7 +180,7 @@ func (b *TfraBox) EncodeSW(sw bits.SliceWriter) error {
 	return sw.AccError()
 }
 
-//Info - box-specific info. More for level 1
+// Info - box-specific info. More for level 1
 func (b *TfraBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
 	bd := newInfoDumper(w, indent, b, int(b.Version), b.Flags)
 	bd.write(" - trackID: %d", b.TrackID)

--- a/mp4/tkhd.go
+++ b/mp4/tkhd.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TkhdBox - Track Header Box (tkhd - mandatory)

--- a/mp4/traf.go
+++ b/mp4/traf.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TrafBox - Track Fragment Box (traf)
 //
 // Contained in : Movie Fragment Box (moof)
-//
 type TrafBox struct {
 	Tfhd     *TfhdBox
 	Tfdt     *TfdtBox
@@ -251,7 +250,7 @@ func (t *TrafBox) OptimizeTfhdTrun() error {
 	return nil
 }
 
-//RemoveEncryptionBoxes - remove encryption boxes and return number of bytes removed
+// RemoveEncryptionBoxes - remove encryption boxes and return number of bytes removed
 func (t *TrafBox) RemoveEncryptionBoxes() uint64 {
 	remainingChildren := make([]Box, 0, len(t.Children))
 	var nrBytesRemoved uint64 = 0

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // DefaultTrakID - trakID used when generating new fragmented content

--- a/mp4/tref.go
+++ b/mp4/tref.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TrefBox -  // TrackReferenceBox - ISO/IEC 14496-12 Ed. 9 Sec. 8.3

--- a/mp4/trep.go
+++ b/mp4/trep.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TrepBox - Track Extension Properties Box (trep)

--- a/mp4/trex.go
+++ b/mp4/trex.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TrexBox - Track Extends Box

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TrunBox - Track Fragment Run Box (trun)
 //
-// Contained in :  Track Fragmnet Box (traf)
-//
+// Contained in :  Track Fragment Box (traf)
 type TrunBox struct {
 	Version          byte
 	Flags            uint32

--- a/mp4/udta.go
+++ b/mp4/udta.go
@@ -3,13 +3,12 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // UdtaBox - User Data Box is a container for User Data
 //
 // Contained in : moov, trak, moof, or traf
-//
 type UdtaBox struct {
 	Children []Box
 }

--- a/mp4/unknown.go
+++ b/mp4/unknown.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // UnknownBox - box that we don't know how to parse

--- a/mp4/url.go
+++ b/mp4/url.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // URLBox - DataEntryUrlBox ('url ')

--- a/mp4/uuid.go
+++ b/mp4/uuid.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 const (
@@ -18,7 +18,7 @@ const (
 	UUIDTfrf = "d4807ef2-ca39-4695-8e54-26cb9e46a79f"
 )
 
-//uuid - compact representation of UUID
+// uuid - compact representation of UUID
 type uuid [16]byte
 
 // String - UUID-formatted string

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.31.0"    // May be updated using build flags
-	commitDate    string = "1672185600" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.32.0"    // May be updated using build flags
+	commitDate    string = "1672933527" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile

--- a/mp4/visualsampleentry.go
+++ b/mp4/visualsampleentry.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
-	"github.com/edgeware/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/hevc"
 )
 
 // VisualSampleEntryBox - Video Sample Description box (avc1/avc3)

--- a/mp4/vmhd.go
+++ b/mp4/vmhd.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // VmhdBox - Video Media Header Box (vhmd - mandatory for video tracks)

--- a/mp4/wvtt.go
+++ b/mp4/wvtt.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // Boxes needed for wvtt according to ISO/IEC 14496-30

--- a/sei/sei.go
+++ b/sei/sei.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 const (

--- a/sei/sei136.go
+++ b/sei/sei136.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/edgeware/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 // TimeCodeSEI carries the data of an SEI 136 TimeCode message.

--- a/sei/sei_test.go
+++ b/sei/sei_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/edgeware/mp4ff/sei"
+	"github.com/Eyevinn/mp4ff/sei"
 )
 
 func TestSEIStrings(t *testing.T) {


### PR DESCRIPTION
Change all imports and other paths to github.com/Eyevinn/mp4ff from github.com/edgeware/mp4ff.

Also make a new version 0.32.0 which points to Eyevinn.

Old versions, up to 0.31.0 should still work at edgeware/mp4ff, and Github should provide redirects for all URLs.