### PR TITLE
feat: RemoveBoxDecoder makes it possible to make a specific box unknown

### DIFF
--- a/mp4/box.go
+++ b/mp4/box.go
@@ -135,6 +135,22 @@ func init() {
 	}
 }
 
+// RemoveBoxDecoder removes the decode of boxType. It will be treated as unknown instead.
+//
+// This is a global change, so use with care.
+func RemoveBoxDecoder(boxType string) {
+	delete(decoders, boxType)
+	delete(decodersSR, boxType)
+}
+
+// SetBoxDecoder sets decoder functions for a specific boxType.
+//
+// This is a global change, so use with care.
+func SetBoxDecoder(boxType string, dec BoxDecoder, decSR BoxDecoderSR) {
+	decoders[boxType] = dec
+	decodersSR[boxType] = decSR
+}
+
 // BoxHeader - 8 or 16 bytes depending on size
 type BoxHeader struct {
 	Name   string

--- a/mp4/box_test.go
+++ b/mp4/box_test.go
@@ -1,0 +1,52 @@
+package mp4
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// TestBadBoxAndRemoveBoxDecoder checks that we can avoid decoder error by removing a BoxDecode.
+//
+// The box is then interpreted as an UnknownBox and its data is not further processed with decoded.
+func TestBadBoxAndRemoveBoxDecoder(t *testing.T) {
+	badMetaBox := (`000000416d6574610000002168646c7200000000000000006d64746100000000` +
+		`000000000000000000000000106b657973000000000000000000000008696c7374`)
+	data, err := hex.DecodeString(badMetaBox)
+	if err != nil {
+		t.Error(err)
+	}
+	sr := bits.NewFixedSliceReader(data)
+	_, err = DecodeBoxSR(0, sr)
+	if err == nil {
+		t.Errorf("reading bad meta box should have failed")
+	}
+	sr = bits.NewFixedSliceReader(data)
+	RemoveBoxDecoder("meta")
+	defer SetBoxDecoder("meta", DecodeMeta, DecodeMetaSR)
+	box, err := DecodeBoxSR(0, sr)
+	if err != nil {
+		t.Error(err)
+	}
+	_, ok := box.(*MetaBox)
+	if ok {
+		t.Errorf("box should not be MetaBox")
+	}
+	unknown, ok := box.(*UnknownBox)
+	if !ok {
+		t.Errorf("box should be unknown")
+	}
+	if unknown.Type() != "meta" {
+		t.Errorf("unknown type %q instead of meta", unknown.Type())
+	}
+	b := bytes.Buffer{}
+	err = unknown.Encode(&b)
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(data, b.Bytes()) {
+		t.Errorf("written unknown differs")
+	}
+}


### PR DESCRIPTION
Add new function RemoveBoxDecoder that turns off decoding of a specific box type by deleting its mapping.
This makes it possible to get around problems with certain uninteresting box types.
A test with a malformed `meta` box was added to exemplify how this can be used.