### PR TITLE
feat: Make ADTS parsing somewhat more robust

### DIFF
--- a/aac/adts_test.go
+++ b/aac/adts_test.go
@@ -68,3 +68,19 @@ func TestAdtsHdrLengthWithCRC(t *testing.T) {
 		t.Errorf("Got header length %d instead of 9", gotHdr.HeaderLength)
 	}
 }
+
+func TestAdtsHeaderParsingWithDoubleFF(t *testing.T) {
+	hexData := "48fffff94cb02b5ffc21aa14"
+	data, err := hex.DecodeString(hexData)
+	if err != nil {
+		t.Error(err)
+	}
+	_, gotOffset, err := DecodeADTSHeader(bytes.NewBuffer(data))
+	if err != nil {
+		t.Error(err)
+	}
+	wantedOffset := 2
+	if gotOffset != wantedOffset {
+		t.Errorf("Got offset %d instead of %d", gotOffset, wantedOffset)
+	}
+}


### PR DESCRIPTION
There are cases where it is not enough to look for the 12-bit ADTS start pattern 0xfff. This PR makes the search somewhat more robust by also looking at the two level bits and requesting that they are zero.