### PR TITLE
Remove unnecessary err check

### DIFF
--- a/mp4/file.go
+++ b/mp4/file.go
@@ -163,9 +163,6 @@ LoopBoxes:
 			return nil, err
 		}
 		boxType, boxSize := box.Type(), box.Size()
-		if err != nil {
-			return nil, err
-		}
 		switch boxType {
 		case "mdat":
 			if f.isFragmented {


### PR DESCRIPTION
This code does nothing since `err` is not changed after the previous check three lines up