### PR TITLE
Version 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2023-02-28
+
 ### Added
 
 - New function: `mp4.NewMediaSegmentWithStyp()`
@@ -361,7 +363,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.33.2...HEAD
+[unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.34.0...HEAD
+[0.34.0]: https://github.com/Eyevinn/mp4ff/compare/v0.33.2...v0.34.0
 [0.33.2]: https://github.com/Eyevinn/mp4ff/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/Eyevinn/mp4ff/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/Eyevinn/mp4ff/compare/v0.32.0...v0.33.0

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.33.2"    // May be updated using build flags
-	commitDate    string = "1674682900" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.34.0"    // May be updated using build flags
+	commitDate    string = "1677600951" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Added

- New function: `mp4.NewMediaSegmentWithStyp()`
- Associate emsg boxes with fragments
- New Fragment method: `AddEmsg()`
- `colr` box support
- CHANGELOG.md (this file) instead of Versions.md
- More tests

### Fixed

- Bugs in FixedSliceReader: ReadUint24 and LookAhead

### Changed

- Optimized translation from Annex B (start-code separated) video byte streams into length-field
  separated one
- Output of cenc example changed with styp boxes not included
- ADTS parsing somewhat more robust
- LastFragment() returns nil if no fragment in Segment
- Makefile target `coverage`