### PR TITLE
Fix stpp empty utf-8 lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.34.1] - 2023-03-09
 
-### [Fixed]
+### Fixed
 
 - Only start new segment at start or styp box
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Fixed
+
+- stpp box handles optional empty lists properly (a single zero byte)
 
 ## [0.34.1] - 2023-03-09
 
 ### Fixed
 
 - Only start new segment at start or styp box
+
+### Changed
+
+-
 
 ## [0.34.0] - 2023-02-28
 

--- a/mp4/stpp_test.go
+++ b/mp4/stpp_test.go
@@ -1,19 +1,87 @@
 package mp4
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
+
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
-func TestStpp(t *testing.T) {
-
-	stpp := NewStppBox("The namespace", "schema location", "image/png,image/jpg")
-	btrt := &BtrtBox{} //Note, we only handle btrt box when both optional fields are present
-	stpp.AddChild(btrt)
-	if stpp.Btrt != btrt {
-		t.Error("Btrt link is broken")
+func TestStppEncDec(t *testing.T) {
+	testCases := []struct {
+		namespace      string
+		schemaLocation string
+		mimeTypes      string
+		hasBtrt        bool
+	}{
+		{
+			namespace:      "NS",
+			schemaLocation: "location",
+			mimeTypes:      "image/png image/jpg",
+			hasBtrt:        false,
+		},
+		{
+			namespace:      "NS",
+			schemaLocation: "location",
+			mimeTypes:      "image/png image/jpg",
+			hasBtrt:        true,
+		},
+		{
+			namespace:      "NS",
+			schemaLocation: "",
+			mimeTypes:      "",
+			hasBtrt:        false,
+		},
+		{
+			namespace:      "NS",
+			schemaLocation: "",
+			mimeTypes:      "",
+			hasBtrt:        true,
+		},
 	}
-	boxDiffAfterEncodeAndDecode(t, stpp)
+	for _, tc := range testCases {
+		stpp := NewStppBox(tc.namespace, tc.schemaLocation, tc.mimeTypes)
+		if tc.hasBtrt {
+			btrt := &BtrtBox{}
+			stpp.AddChild(btrt)
+			if stpp.Btrt != btrt {
+				t.Error("Btrt link is broken")
+			}
+		}
+		boxDiffAfterEncodeAndDecode(t, stpp)
+	}
+}
 
-	stppWithoutOptionalFields := NewStppBox("The namespace", "", "")
-	boxDiffAfterEncodeAndDecode(t, stppWithoutOptionalFields)
+func TestStppWithEmtptyLists(t *testing.T) {
+	const hexData = ("00000040737470700000000000000001" +
+		"687474703a2f2f7777772e77332e6f72" +
+		"672f6e732f74746d6c00000000000014" +
+		"62747274000003ce00003b5800000430")
+	data, err := hex.DecodeString(hexData)
+	if err != nil {
+		t.Error(err)
+	}
+	sr := bits.NewFixedSliceReader(data)
+	box, err := DecodeBoxSR(0, sr)
+	if err != nil {
+		t.Error(err)
+	}
+	stpp, ok := box.(*StppBox)
+	if !ok {
+		t.Error("not an stpp box")
+	}
+	if int(stpp.Size()) != len(data) {
+		t.Errorf("stpp size %d not same as %d", stpp.Size(), len(data))
+	}
+	buf := bytes.Buffer{}
+	err = stpp.Encode(&buf)
+	if err != nil {
+		t.Error(err)
+	}
+	outData := buf.Bytes()
+	if !bytes.Equal(data, outData) {
+		t.Error("written stpp box differs from read")
+	}
+
 }


### PR DESCRIPTION
The `schema_location` and `auxiliary_mime_types` are both optional utf8-lists in `stpp` box.
It was assumed that they were not present if empty, but #228 reported on a case where they are present but empty.
A careful reading of ISO/IEC 14496-12 reveals that the field should have. a single zero-termination byte, even if
not set. This now changed so that reading and writing is consistent.

Fixes #228.