### PR TITLE
HEVC SPS extensions parser

### DIFF
--- a/hevc/sps.go
+++ b/hevc/sps.go
@@ -54,16 +54,17 @@ type SPS struct {
 	VUIParametersPresentFlag             bool
 	VUI                                  *VUIParameters
 	ExtensionPresentFlag                 bool
-	RangeExtensionFlag                   bool
-	MultilayerExtensionFlag              bool
-	D3ExtensionFlag                      bool
-	SccExtensionFlag                     bool
 	Extension4bits                       uint8
+	RangeExtensionFlag                   bool
 	RangeExtension                       *SPSRangeExtension
+	MultilayerExtensionFlag              bool
 	MultilayerExtension                  *SPSMultilayerExtension
-	D3Extension                          *SPS3dExtension
-	SccExtension                         *SPSSccExtension
-	ExtensionDataFlag                    []bool
+	// SPS 3D extension
+	D3ExtensionFlag   bool
+	D3Extension       *SPS3dExtension
+	SccExtensionFlag  bool
+	SccExtension      *SPSSccExtension
+	ExtensionDataFlag []bool
 }
 
 // ProfileTierLevel according to ISO/IEC 23008-2 Section 7.3.3


### PR DESCRIPTION
Good day!

This PR introduce parser for HEVC SPS extensions. 
Details:
- SccExtension is one of dependencies for the slice header parser. All other extensions done just because ;)
- Another dependency is LongTermRPS. Implemented struct have extra fields to reuse it in slice header parser.
- In the 3d extension i decided to put all fields in one struct and mark duplicated entries with suffix (0/1).
- SPS extensions now have prefix SPS to separate it from PPS extensions.
- Some slices initialised via make() to remove overhead on unnecessary calls to grow.
- SPS parser now correctly process final data and checks on trail bit.