### PR TITLE
Version 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mp4ff-pslister` now provides PPS details for HEVC
 - `mp4ff-pslister` now extracts inband parameter sets in progressive mp4 files
 - Complete parsing of HEVC SPS extensions
+- Parsing of HEVC slice header
 
 ## [0.34.1] - 2023-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-
+
+## [0.35.0] - 2023-04-18
+
 ### Fixed
 
 - `stpp` box handles optional empty lists properly (a single zero byte)
@@ -14,12 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Exported function: bits.CeilLog2
+- Exported function: `bits.CeilLog2`
 - PPS parsing for HEVC
 - `mp4ff-pslister` now provides PPS details for HEVC
 - `mp4ff-pslister` now extracts inband parameter sets in progressive mp4 files
 - Complete parsing of HEVC SPS extensions
 - Parsing of HEVC slice header
+- `SetType` method for `mp4.AudioSampleEntryBox`
 
 ## [0.34.1] - 2023-03-09
 
@@ -383,7 +388,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.34.1...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.35.0...HEAD
+[0.35.0]: https://github.com/Eyevinn/mp4ff/compare/v0.34.1...v0.35.0
 [0.34.1]: https://github.com/Eyevinn/mp4ff/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/Eyevinn/mp4ff/compare/v0.33.2...v0.34.0
 [0.33.2]: https://github.com/Eyevinn/mp4ff/compare/v0.33.1...v0.33.2

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.34.1"    // May be updated using build flags
-	commitDate    string = "1678361120" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.35.0"    // May be updated using build flags
+	commitDate    string = "1681806686" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Fixed

- `stpp` box handles optional empty lists properly (a single zero byte)
- AVC slice size value

### Added

- Exported function: `bits.CeilLog2`
- PPS parsing for HEVC
- `mp4ff-pslister` now provides PPS details for HEVC
- `mp4ff-pslister` now extracts inband parameter sets in progressive mp4 files
- Complete parsing of HEVC SPS extensions
- Parsing of HEVC slice header
- `SetType` method for `mp4.AudioSampleEntryBox`