### PR TITLE
SPS Hrd Parameters parser

### DIFF
--- a/hevc/sps_test.go
+++ b/hevc/sps_test.go
@@ -11,6 +11,8 @@ const (
 	spsNalu = ("420101022000000300b0000003000003007ba0078200887db6718b92448053888892" +
 		"cf24a69272c9124922dc91aa48fca223ff000100016a02020201")
 	spsNaluHdr10 = "420101022000000300b0000003000003009ca001e020021c4d8815ee4595602d4244024020"
+	spsNaluHrd   = ("42010101400000030000030000030000030096a001e02002207c4e5ad290964b8c04040000" +
+		"03000400000300658017794400014fb1000004c4b3c40")
 )
 
 func TestSPSParser1(t *testing.T) {
@@ -250,6 +252,116 @@ func TestSPSParser2(t *testing.T) {
 		StrongIntraSmoothingEnabledFlag:      false,
 		VUIParametersPresentFlag:             true,
 		VUI:                                  &wantedVUI,
+	}
+	got, err := ParseSPSNALUnit(byteData)
+	if err != nil {
+		t.Error("Error parsing SPS")
+	}
+
+	if diff := deep.Equal(*got, wanted); diff != nil {
+		t.Error(diff)
+	}
+	gotWidth, gotHeight := got.ImageSize()
+	var expWidth, expHeight uint32 = 3840, 2160
+	if gotWidth != expWidth || gotHeight != expHeight {
+		t.Errorf("Got %dx%d instead of %dx%d", gotWidth, gotHeight, expWidth, expHeight)
+	}
+}
+
+func TestSPSParser3(t *testing.T) {
+	byteData, _ := hex.DecodeString(spsNaluHrd)
+
+	wantedHrd := HrdParameters{
+		NalHrdParametersPresentFlag:        true,
+		InitialCpbRemovalDelayLengthMinus1: 23,
+		AuCpbRemovalDelayLengthMinus1:      15,
+		DpbOutputDelayLengthMinus1:         5,
+		SubLayerHrd: []SubLayerHrd{
+			{
+				NalHrdParameters: []SubLayerHrdParameters{
+					{
+						BitRateValueMinus1: 171873,
+						CpbSizeValueMinus1: 1249998,
+					},
+				},
+			},
+		},
+	}
+
+	wantedVUI := VUIParameters{
+		SampleAspectRatioWidth:     1,
+		SampleAspectRatioHeight:    1,
+		VideoSignalTypePresentFlag: false,
+		VideoFormat:                0,
+		ColourDescriptionFlag:      false,
+		ColourPrimaries:            0,
+		TransferCharacteristics:    0,
+		MatrixCoefficients:         0,
+		TimingInfoPresentFlag:      true,
+		NumUnitsInTick:             1,
+		TimeScale:                  25,
+		HrdParametersPresentFlag:   true,
+		HrdParameters:              &wantedHrd,
+	}
+	wanted := SPS{
+		VpsID:                 0,
+		MaxSubLayersMinus1:    0,
+		TemporalIDNestingFlag: true,
+		ProfileTierLevel: ProfileTierLevel{
+			GeneralProfileSpace:              0,
+			GeneralProfileIDC:                1,
+			GeneralProfileCompatibilityFlags: 1073741824,
+			GeneralLevelIDC:                  150,
+		},
+		SpsID:                   0,
+		ChromaFormatIDC:         1,
+		SeparateColourPlaneFlag: false,
+		ConformanceWindowFlag:   true,
+		PicWidthInLumaSamples:   3840,
+		PicHeightInLumaSamples:  2176,
+		ConformanceWindow: ConformanceWindow{
+			LeftOffset:   0,
+			RightOffset:  0,
+			TopOffset:    0,
+			BottomOffset: 8,
+		},
+		Log2MaxPicOrderCntLsbMinus4:     4,
+		SubLayerOrderingInfoPresentFlag: true,
+		SubLayeringOrderingInfos: []SubLayerOrderingInfo{
+			{
+				MaxDecPicBufferingMinus1: 1,
+				MaxNumReorderPics:        0,
+				MaxLatencyIncreasePlus1:  0,
+			},
+		},
+		Log2MinLumaCodingBlockSizeMinus3:     1,
+		Log2DiffMaxMinLumaCodingBlockSize:    1,
+		Log2MinLumaTransformBlockSizeMinus2:  0,
+		Log2DiffMaxMinLumaTransformBlockSize: 3,
+		MaxTransformHierarchyDepthInter:      3,
+		MaxTransformHierarchyDepthIntra:      0,
+		ScalingListEnabledFlag:               false,
+		ScalingListDataPresentFlag:           false,
+		AmpEnabledFlag:                       true,
+		SampleAdaptiveOffsetEnabledFlag:      true,
+		PCMEnabledFlag:                       false,
+		NumShortTermRefPicSets:               1,
+		ShortTermRefPicSets: []ShortTermRPS{
+			{
+				DeltaPocS0:      []uint32{1},
+				DeltaPocS1:      []uint32{},
+				UsedByCurrPicS0: []bool{true},
+				UsedByCurrPicS1: []bool{},
+				NumNegativePics: 1,
+				NumPositivePics: 0,
+				NumDeltaPocs:    1,
+			},
+		},
+		LongTermRefPicsPresentFlag:      false,
+		SpsTemporalMvpEnabledFlag:       false,
+		StrongIntraSmoothingEnabledFlag: false,
+		VUIParametersPresentFlag:        true,
+		VUI:                             &wantedVUI,
 	}
 	got, err := ParseSPSNALUnit(byteData)
 	if err != nil {


### PR DESCRIPTION
Good day!

While implementing SPS extension parser i added ReadRbspTrailingBits() in the tail of ParseSPSNALUnit function, but didn't pay attention on incomplete VUI parser. Please consider this PR as bug fix.
I used `ffmpeg -i ./filename.h265 -c copy -bsf:v trace_headers -f null -` to check correctness of implementation. Tests included.