### PR TITLE
change: report ErrRbspTrailingBitsMissing when parsing SEI NALUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- SEI NAL unit allows missing a final byte with RBSP trailing bits
+- SEI NAL unit parser reports ErrRbspTrailingBitsMissing error together with NAL units.
+- mp4ff-nallister reports error and SEI data when `rbsp_trailing_bits` are missing.
 
 ### Fixed
 

--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -340,7 +340,9 @@ func printSEINALus(seiNALUs [][]byte, codec string, seiLevel int) {
 			seiDatas, err := sei.ExtractSEIData(buf)
 			if err != nil {
 				fmt.Printf("  SEI: Got error %q\n", err)
-				continue
+				if err != sei.ErrRbspTrailingBitsMissing {
+					continue
+				}
 			}
 			for _, seiData := range seiDatas {
 				sei, err := sei.DecodeSEIMessage(&seiData, seiCodec)


### PR DESCRIPTION
Introduced a specific error for the case where SEI NALUs lack the rbsp_trailing_bits byte.
Updatet mp4ff-nallister to handle this error by printing the data and an error message.