### PR TITLE
fix: handle stts case with single trailing zero duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - discard of parsing HEVC SPS data
+- `SttsBox.GetSampleNrAtTime` now supports a final zero sample duration
 
 ## [0.36.0] - 2023-06-07
 

--- a/mp4/stts_test.go
+++ b/mp4/stts_test.go
@@ -17,26 +17,37 @@ func TestGetSampleNrAtTime(t *testing.T) {
 		SampleTimeDelta: []uint32{10, 14},
 	}
 
+	sttsZero := SttsBox{
+		SampleCount:     []uint32{2, 1},
+		SampleTimeDelta: []uint32{10, 0}, // Single zero duration at end
+	}
+
 	testCases := []struct {
+		stts        SttsBox
 		startTime   uint64
 		sampleNr    uint32
 		expectError bool
 	}{
-		{0, 1, false},
-		{1, 2, false},
-		{10, 2, false},
-		{20, 3, false},
-		{30, 4, false},
-		{31, 5, false},
-		{43, 5, false},
-		{44, 5, false},
-		{45, 6, false},
-		{57, 6, false},
-		{58, 0, true},
+		{stts, 0, 1, false},
+		{stts, 1, 2, false},
+		{stts, 10, 2, false},
+		{stts, 20, 3, false},
+		{stts, 30, 4, false},
+		{stts, 31, 5, false},
+		{stts, 43, 5, false},
+		{stts, 44, 5, false},
+		{stts, 45, 6, false},
+		{stts, 57, 6, false},
+		{stts, 58, 0, true},
+		{sttsZero, 0, 1, false},
+		{sttsZero, 10, 2, false},
+		{sttsZero, 19, 3, false},
+		{sttsZero, 20, 3, false},
+		{sttsZero, 21, 0, true},
 	}
 
 	for _, tc := range testCases {
-		gotNr, err := stts.GetSampleNrAtTime(tc.startTime)
+		gotNr, err := tc.stts.GetSampleNrAtTime(tc.startTime)
 		if tc.expectError {
 			if err == nil {
 				t.Errorf("Did not get error for startTime %d", tc.startTime)


### PR DESCRIPTION
This fixes `GetSampleNrAtTime()` to return the last sample number for the rather  odd case of having a final zero sample duration in the `stts` box.

This solves #259.