### PR TITLE
feat: description boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Added
+
+- Loudness boxes `ludt`, `tlou`, and `alou`
+- Description boxes `desc`, `©cpy`, `©nam`, `©ART` boxes
+- `GenericContainerBox` struct
+
+### Changed
+
+- Made `©too` use `GenericContainerBox`
 
 ## [0.37.0] - 2023-08-14
 

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -36,6 +36,7 @@ func init() {
 		"dac3":    DecodeDac3,
 		"data":    DecodeData,
 		"dec3":    DecodeDec3,
+		"desc":    DecodeGenericContainerBox,
 		"dinf":    DecodeDinf,
 		"dpnd":    DecodeTrefType,
 		"dref":    DecodeDref,
@@ -135,7 +136,10 @@ func init() {
 		"vttC":    DecodeVttC,
 		"vtte":    DecodeVtte,
 		"wvtt":    DecodeWvtt,
-		"\xa9too": DecodeCToo,
+		"\xa9cpy": DecodeGenericContainerBox,
+		"\xa9nam": DecodeGenericContainerBox,
+		"\xa9too": DecodeGenericContainerBox,
+		"\xa9ART": DecodeGenericContainerBox,
 	}
 }
 

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -27,6 +27,7 @@ func init() {
 		"dac3":    DecodeDac3SR,
 		"data":    DecodeDataSR,
 		"dec3":    DecodeDec3SR,
+		"desc":    DecodeGenericContainerBoxSR,
 		"dinf":    DecodeDinfSR,
 		"dpnd":    DecodeTrefTypeSR,
 		"dref":    DecodeDrefSR,
@@ -126,7 +127,10 @@ func init() {
 		"vttC":    DecodeVttCSR,
 		"vtte":    DecodeVtteSR,
 		"wvtt":    DecodeWvttSR,
-		"\xa9too": DecodeCTooSR,
+		"\xa9cpy": DecodeGenericContainerBoxSR,
+		"\xa9nam": DecodeGenericContainerBoxSR,
+		"\xa9too": DecodeGenericContainerBoxSR,
+		"\xa9ART": DecodeGenericContainerBoxSR,
 	}
 }
 

--- a/mp4/ffmpeg.go
+++ b/mp4/ffmpeg.go
@@ -12,67 +12,6 @@ type CTooBox struct {
 	Children []Box
 }
 
-// DecodeCToo - box-specific decode
-func DecodeCToo(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
-	if err != nil {
-		return nil, err
-	}
-	b := &CTooBox{}
-	for _, c := range children {
-		b.AddChild(c)
-	}
-	return b, nil
-}
-
-// DecodeCTooSR - box-specific decode
-func DecodeCTooSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
-	if err != nil {
-		return nil, err
-	}
-	b := &CTooBox{}
-	for _, c := range children {
-		b.AddChild(c)
-	}
-	return b, nil
-}
-
-// AddChild - Add a child box and update SampleCount
-func (b *CTooBox) AddChild(child Box) {
-	b.Children = append(b.Children, child)
-}
-
-// Type - box type
-func (b *CTooBox) Type() string {
-	return "\xa9too"
-}
-
-// Size - calculated size of box
-func (b *CTooBox) Size() uint64 {
-	return containerSize(b.Children)
-}
-
-// GetChildren - list of child boxes
-func (b *CTooBox) GetChildren() []Box {
-	return b.Children
-}
-
-// Encode - write minf container to w
-func (b *CTooBox) Encode(w io.Writer) error {
-	return EncodeContainer(b, w)
-}
-
-// Encode - write minf container to sw
-func (b *CTooBox) EncodeSW(sw bits.SliceWriter) error {
-	return EncodeContainerSW(b, sw)
-}
-
-// Info - box-specific Info
-func (b *CTooBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
-	return ContainerInfo(b, w, specificBoxLevels, indent, indentStep)
-}
-
 // DataBox - data box used by ffmpeg for providing information.
 type DataBox struct {
 	Data []byte


### PR DESCRIPTION
Quite a few boxes for metadata in QuickTime and ffmpeg have the structure of a ContainerBox wrapping an `data` box.

Therefore, a `GenericContainerBox` has been introduced and mapped to the boxes

```
  desc
  ©cpy
  ©nam
  ©too
  ©ART
```

to it. It can also for other container boxes that don't want direct pointers to children.

The previous implementation of CTooBox has been removed.