### PR TITLE
fix: make mfro search return silently if not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.38.1] - 2023-09-22
+
+### Fixed
+  - ReadMP4File() failed when mfro not present
+
 ## [0.38.0] - 2023-09-06
 
 ### Added
@@ -436,7 +443,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.38.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.38.1...HEAD
+[0.38.1]: https://github.com/Eyevinn/mp4ff/compare/v0.37.0...v0.38.0
 [0.38.0]: https://github.com/Eyevinn/mp4ff/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/Eyevinn/mp4ff/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/Eyevinn/mp4ff/compare/v0.35.0...v0.36.0

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -326,6 +326,7 @@ func (f *File) startSegmentIfNeeded(b Box, boxStartPos uint64) {
 }
 
 // findAndReadMfra tries to find a tfra box inside an mfra box at the end of the file
+// If no mfro box is found, no error is reported.
 func (f *File) findAndReadMfra(r io.Reader) error {
 	rs, ok := r.(io.ReadSeeker)
 	if !ok {
@@ -338,7 +339,9 @@ func (f *File) findAndReadMfra(r io.Reader) error {
 	}
 	b, err := DecodeBox(uint64(pos), rs) // mfro
 	if err != nil {
-		return fmt.Errorf("could not decode mfro box: %w", err)
+		// Not an mfro box here, just reset and return
+		_, err = rs.Seek(0, io.SeekStart)
+		return err
 	}
 	mfro, ok := b.(*MfroBox)
 	if !ok {

--- a/mp4/file_test.go
+++ b/mp4/file_test.go
@@ -276,7 +276,7 @@ func TestGetSegmentBoundariesFromSidx(t *testing.T) {
 		t.Error(err)
 	}
 
-	parsedFile, err := DecodeFile(file)
+	parsedFile, err := DecodeFile(file, WithDecodeFlags(DecISMFlag))
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Make mfro discovery robust.
Updated changelog for v0.38.1

Fixes #270 