### PR TITLE
fix: accidental box start at mfro position

### DIFF
--- a/mp4/file.go
+++ b/mp4/file.go
@@ -354,7 +354,9 @@ func (f *File) findAndReadMfra(r io.Reader) error {
 	}
 	mfro, ok := b.(*MfroBox)
 	if !ok {
-		return fmt.Errorf("expecting mfro box, but got %T", b)
+		// Not an mfro box here, just reset and return
+		_, err = rs.Seek(0, io.SeekStart)
+		return err
 	}
 	mfraSize := int64(mfro.ParentSize)
 	pos, err = rs.Seek(-mfraSize, io.SeekEnd)


### PR DESCRIPTION
Then searching for an mfro box, there may be another valid box starting there. This should not be an error.