### PR TITLE
Fix avc ChromeArrayType 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- nothing yet
+### Fixed
+
+- SPS.ChromaArrayType method
+
+### Added
+
+- AccErrEBSPReader.NrBitsRead method
 
 ## [0.39.0] - 2023-10-13
 

--- a/avc/slice_test.go
+++ b/avc/slice_test.go
@@ -116,3 +116,32 @@ func TestParseSliceHeader_TwoFrames(t *testing.T) {
 		t.Errorf("Got NON_IDR Slice Header: %+v\n Diff is: %v", *gotNonIdrHdr, diff)
 	}
 }
+
+func TestParseSliceHeaderLength(t *testing.T) {
+	spsHex := "6764001eacd940a02ff9610000030001000003003c8f162d96"
+	ppsHex := "68ebecb22c"
+	naluStartHex := "419a6649e10f2653022fff8700000302c8a32d32"
+	spsData, _ := hex.DecodeString(spsHex)
+	sps, err := ParseSPSNALUnit(spsData, true)
+	if err != nil {
+		t.Error(err)
+	}
+	spsMap := make(map[uint32]*SPS, 1)
+	spsMap[uint32(sps.ParameterID)] = sps
+	ppsData, _ := hex.DecodeString(ppsHex)
+	pps, err := ParsePPSNALUnit(ppsData, spsMap)
+	if err != nil {
+		t.Error(err)
+	}
+	ppsMap := make(map[uint32]*PPS, 1)
+	ppsMap[uint32(pps.PicParameterSetID)] = pps
+	naluStart, _ := hex.DecodeString(naluStartHex)
+	sh, err := ParseSliceHeader(naluStart, spsMap, ppsMap)
+	if err != nil {
+		t.Error(err)
+	}
+	wantedSliceHeaderSize := uint32(11)
+	if sh.Size != wantedSliceHeaderSize {
+		t.Errorf("got %d want %d", sh.Size, wantedSliceHeaderSize)
+	}
+}

--- a/avc/sps.go
+++ b/avc/sps.go
@@ -261,9 +261,9 @@ func (s *SPS) PicStructPresent() bool {
 	return s.VUI.PicStructPresentFlag
 }
 
-// ChromaArrayType as defined in Section 7.4.2.1.1
+// ChromaArrayType as defined in Section 7.4.2.1.1 under separate_colour_plane_flag
 func (s *SPS) ChromaArrayType() byte {
-	if s.SeparateColourPlaneFlag {
+	if !s.SeparateColourPlaneFlag {
 		return byte(s.ChromaFormatIDC)
 	}
 	return 0

--- a/bits/aeebspreader.go
+++ b/bits/aeebspreader.go
@@ -34,6 +34,15 @@ func (r *AccErrEBSPReader) NrBytesRead() int {
 	return r.pos + 1 // Starts at -1
 }
 
+// NrBitsRead - how many bits read into parser
+func (r *AccErrEBSPReader) NrBitsRead() int {
+	nrBits := r.NrBytesRead() * 8
+	if r.NrBitsReadInCurrentByte() != 8 {
+		nrBits += r.NrBitsReadInCurrentByte() - 8
+	}
+	return nrBits
+}
+
 // NrBitsReadInCurrentByte - how many bits have been read
 func (r *AccErrEBSPReader) NrBitsReadInCurrentByte() int {
 	return 8 - r.n

--- a/bits/aeebspreader_test.go
+++ b/bits/aeebspreader_test.go
@@ -10,18 +10,19 @@ import (
 
 func TestAccErrEBSPReader(t *testing.T) {
 	testCases := []struct {
-		hexData             string
-		readBits            int
-		expectedValue       uint
-		expectedNrBytesRead int
-		expectedNrBitsRead  int
+		hexData                         string
+		readBits                        int
+		expectedValue                   uint
+		expectedNrBytesRead             int
+		expectedNrBitsRead              int
+		expectedNrBitsReadInCurrentByte int
 	}{
-		{"00", 0, 0, 0, 8},
-		{"0001", 1, 0, 1, 1},
-		{"0001", 8, 0x00, 1, 8},
-		{"0010", 12, 0x001, 2, 4},
-		{"0102", 16, 0x0102, 2, 8},
-		{"00000304", 24, 0x000004, 4, 8},
+		{"00", 0, 0, 0, 0, 8},
+		{"0001", 1, 0, 1, 1, 1},
+		{"0001", 8, 0x00, 1, 8, 8},
+		{"0010", 12, 0x001, 2, 12, 4},
+		{"0102", 16, 0x0102, 2, 16, 8},
+		{"00000304", 24, 0x000004, 4, 32, 8}, // Note the start-code emulation 0x03
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
@@ -41,8 +42,11 @@ func TestAccErrEBSPReader(t *testing.T) {
 			if r.NrBytesRead() != tc.expectedNrBytesRead {
 				t.Errorf("expected %d bytes read, got %d", tc.expectedNrBytesRead, r.NrBytesRead())
 			}
-			if r.NrBitsReadInCurrentByte() != tc.expectedNrBitsRead {
-				t.Errorf("expected %d bits read, got %d", tc.expectedNrBitsRead, r.NrBitsReadInCurrentByte())
+			if r.NrBitsRead() != tc.expectedNrBitsRead {
+				t.Errorf("expected %d bits read, got %d", tc.expectedNrBitsRead, r.NrBitsRead())
+			}
+			if r.NrBitsReadInCurrentByte() != tc.expectedNrBitsReadInCurrentByte {
+				t.Errorf("expected %d bits read in current byte, got %d", tc.expectedNrBitsReadInCurrentByte, r.NrBitsReadInCurrentByte())
 			}
 		})
 	}


### PR DESCRIPTION
Fix the size of AVC slice header parsed by fixing AVC ChromeArrayType to follow standard.
Also add new NrBitsRead method to AccErESBSPReader