### PR TITLE
docs: update for v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.40.0] - 2023-10-28
+
 ### Added
 
 - New CLI app: mp4ff-encrypt to encrypt segments
@@ -490,7 +494,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.39.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.40.0...HEAD
+[0.40.0]: https://github.com/Eyevinn/mp4ff/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/Eyevinn/mp4ff/compare/v0.38.0...v0.39.0
 [0.38.1]: https://github.com/Eyevinn/mp4ff/compare/v0.37.0...v0.38.0
 [0.38.0]: https://github.com/Eyevinn/mp4ff/compare/v0.37.0...v0.38.0

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.35.0"    // May be updated using build flags
-	commitDate    string = "1681806686" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.40.+"    // May be updated using build flags
+	commitDate    string = "1698471348" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Added

- New CLI app: mp4ff-encrypt to encrypt segments
- New CLI app: mp4ff-decrypt to decrypt segments
- New encyption-related functions in mp4
  - GetAVCProtectRanges to fine protection ranges for AVC video
  - CryptSampleCenc for encrypting of decrypting with cenc scheme
  - EncryptSampleCbcs - for encrypting with cbcs scheme
  - DecryptSampleCbcs - for decrypting with cbcs scheme
  - InitProtect to protect an init segment
  - EncryptFragment to encrypt a fragment
  - DecryptInit to extract and remove  decryption info from an init segment
  - DecryptFragment to decrypt a fragment
  - ExtractInitProtect to generate data needed for encryption
- AccErrEBSPReader.NrBitsRead method
- PsshBoxesFromBase64 and PsshBoxesFromBytes functions

### Fixed

- SPS.ChromaArrayType method
- Makefile now builds all CLI applications with version