### PR TITLE
feat: InitSegment.TweakSingleTrakLive to tweak init segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Added
+
+- InitSegment.TweakSingleTrakLive changes an init segment to fit live streaming
 
 ## [0.42.0] - 2024-01-26
 

--- a/mp4/initsegment.go
+++ b/mp4/initsegment.go
@@ -248,6 +248,29 @@ func (s *InitSegment) GetMediaType() string {
 	}
 }
 
+// TweakSingleTrakLive assures that there is only one track and removes any mehd box.
+func (s *InitSegment) TweakSingleTrakLive() error {
+	if len(s.Moov.Traks) != 1 {
+		return fmt.Errorf("only one track allowed for live")
+	}
+	mvex := s.Moov.Mvex
+	if mvex == nil {
+		return fmt.Errorf("no mvex box found")
+
+	}
+	mehd := mvex.Mehd
+	if mehd != nil {
+		for i, c := range mvex.Children {
+			if c == mehd {
+				mvex.Children = append(mvex.Children[:i], mvex.Children[i+1:]...)
+				mvex.Mehd = nil
+				break
+			}
+		}
+	}
+	return nil
+}
+
 // SetAACDescriptor - Modify a TrakBox by adding AAC SampleDescriptor
 // objType is one of AAClc, HEAACv1, HEAACv2
 // For HEAAC, the samplingFrequency is the base frequency (normally 24000)


### PR DESCRIPTION
Live streams should not have an mehd box in the init segment.
This PR adds a method to remove such a box if present.

Replaces #323 