### PR TITLE
Fix kind box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SPS.ChromaArrayType method
 - Makefile now builds all CLI applications with version
+- DecryptInit extracts pssh boxes
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed bits.SliceWriterError to bits.ErrSliceWrite
 - colr box supports unknown colrType
 
+### Fixed
+
+- kind box full-box header
+
 ## [0.42.0] - 2024-01-26
 
 ### Fixed

--- a/mp4/kind_test.go
+++ b/mp4/kind_test.go
@@ -1,10 +1,35 @@
 package mp4
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 )
 
 func TestKind(t *testing.T) {
-	kind := &KindBox{SchemeURI: "urn:mpeg:dash:role:2011", Value: "forced-subtitle"}
-	boxDiffAfterEncodeAndDecode(t, kind)
+	t.Run("encode and decode", func(t *testing.T) {
+		kind := &KindBox{SchemeURI: "urn:mpeg:dash:role:2011", Value: "forced-subtitle"}
+		boxDiffAfterEncodeAndDecode(t, kind)
+	})
+	t.Run("decode with full box header", func(t *testing.T) {
+		rawHex := ("000000296b696e64" +
+			"0000000075726e3a6d7065673a646173" +
+			"683a726f6c653a32303131006d61696e00")
+		rawBytes, err := hex.DecodeString(rawHex)
+		if err != nil {
+			t.Error(err)
+		}
+		buffer := bytes.NewReader(rawBytes)
+		box, err := DecodeBox(0, buffer)
+		if err != nil {
+			t.Errorf("Error decoding kind box: %v", err)
+		}
+		kind := box.(*KindBox)
+		if kind.SchemeURI != "urn:mpeg:dash:role:2011" {
+			t.Errorf("Expected scheme URI 'urn:mpeg:dash:role:2011', got '%s'", kind.SchemeURI)
+		}
+		if kind.Value != "main" {
+			t.Errorf("Expected value 'main', got '%s'", kind.Value)
+		}
+	})
 }


### PR DESCRIPTION
The kind box was implemented without the extra full box header bytes.
Now fixed to read, store and write these four bytes.

Solves #332.