### PR TITLE
fix: allow absent optional fields in stpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - kind box full-box header
+- stpp support when the optional fields do not even have a zero-termination byte
 
 ## [0.42.0] - 2024-01-26
 

--- a/mp4/stpp_test.go
+++ b/mp4/stpp_test.go
@@ -9,105 +9,103 @@ import (
 	"github.com/Eyevinn/mp4ff/bits"
 )
 
-func TestStppEncDec(t *testing.T) {
-	testCases := []struct {
-		namespace      string
-		schemaLocation string
-		mimeTypes      string
-		hasBtrt        bool
-	}{
-		{
-			namespace:      "NS",
-			schemaLocation: "location",
-			mimeTypes:      "image/png image/jpg",
-			hasBtrt:        false,
-		},
-		{
-			namespace:      "NS",
-			schemaLocation: "location",
-			mimeTypes:      "image/png image/jpg",
-			hasBtrt:        true,
-		},
-		{
-			namespace:      "NS",
-			schemaLocation: "",
-			mimeTypes:      "",
-			hasBtrt:        false,
-		},
-		{
-			namespace:      "NS",
-			schemaLocation: "",
-			mimeTypes:      "",
-			hasBtrt:        true,
-		},
-	}
-	for _, tc := range testCases {
-		t.Logf("Test case: %+v", tc)
-		stpp := NewStppBox(tc.namespace, tc.schemaLocation, tc.mimeTypes)
-		if tc.hasBtrt {
-			btrt := &BtrtBox{}
-			stpp.AddChild(btrt)
-			if stpp.Btrt != btrt {
-				t.Error("Btrt link is broken")
-			}
+func TestStpp(t *testing.T) {
+	t.Run("encode and decode", func(t *testing.T) {
+		testCases := []struct {
+			namespace      string
+			schemaLocation string
+			mimeTypes      string
+			hasBtrt        bool
+		}{
+			{
+				namespace:      "NS",
+				schemaLocation: "location",
+				mimeTypes:      "image/png image/jpg",
+				hasBtrt:        false,
+			},
+			{
+				namespace:      "NS",
+				schemaLocation: "location",
+				mimeTypes:      "image/png image/jpg",
+				hasBtrt:        true,
+			},
+			{
+				namespace:      "NS",
+				schemaLocation: "",
+				mimeTypes:      "",
+				hasBtrt:        false,
+			},
+			{
+				namespace:      "NS",
+				schemaLocation: "",
+				mimeTypes:      "",
+				hasBtrt:        true,
+			},
 		}
-		boxDiffAfterEncodeAndDecode(t, stpp)
-	}
-}
-
-func TestStppWithEmtptyLists(t *testing.T) {
-	const hexData = ("00000040737470700000000000000001" +
-		"687474703a2f2f7777772e77332e6f72" +
-		"672f6e732f74746d6c00000000000014" +
-		"62747274000003ce00003b5800000430")
-	data, err := hex.DecodeString(hexData)
-	if err != nil {
-		t.Error(err)
-	}
-	sr := bits.NewFixedSliceReader(data)
-	box, err := DecodeBoxSR(0, sr)
-	if err != nil {
-		t.Error(err)
-	}
-	stpp, ok := box.(*StppBox)
-	if !ok {
-		t.Error("not an stpp box")
-	}
-	if int(stpp.Size()) != len(data) {
-		t.Errorf("stpp size %d not same as %d", stpp.Size(), len(data))
-	}
-	buf := bytes.Buffer{}
-	err = stpp.Encode(&buf)
-	if err != nil {
-		t.Error(err)
-	}
-	outData := buf.Bytes()
-	if !bytes.Equal(data, outData) {
-		t.Error("written stpp box differs from read")
-	}
-}
-
-// TestDecodeStppWithMissingAuxiliaryMimeTypes tests decoding of stpp
-// where the auxiliary mime types are missing (not even a zero byte).
-func TestDecodeStppWithMissingAuxiliaryMimeTypes(t *testing.T) {
-	hexData := ("0000002b737470700000000000000001" +
-		"687474703a2f2f7777772e77332e6f72" +
-		"672f6e732f74746d6c0000")
-	hexData = strings.Replace(hexData, " ", "", -1)
-	data, err := hex.DecodeString(hexData)
-	if err != nil {
-		t.Error(err)
-	}
-	sr := bits.NewFixedSliceReader(data)
-	box, err := DecodeBoxSR(0, sr)
-	if err != nil {
-		t.Error(err)
-	}
-	stpp, ok := box.(*StppBox)
-	if !ok {
-		t.Error("not an stpp box")
-	}
-	if int(stpp.Size()) != len(data) {
-		t.Errorf("stpp size %d not same as %d", stpp.Size(), len(data))
-	}
+		for _, tc := range testCases {
+			t.Logf("Test case: %+v", tc)
+			stpp := NewStppBox(tc.namespace, tc.schemaLocation, tc.mimeTypes)
+			if tc.hasBtrt {
+				btrt := &BtrtBox{}
+				stpp.AddChild(btrt)
+				if stpp.Btrt != btrt {
+					t.Error("Btrt link is broken")
+				}
+			}
+			boxDiffAfterEncodeAndDecode(t, stpp)
+		}
+	})
+	t.Run("empty lists", func(t *testing.T) {
+		const hexData = ("00000040737470700000000000000001" +
+			"687474703a2f2f7777772e77332e6f72" +
+			"672f6e732f74746d6c00000000000014" +
+			"62747274000003ce00003b5800000430")
+		data, err := hex.DecodeString(hexData)
+		if err != nil {
+			t.Error(err)
+		}
+		sr := bits.NewFixedSliceReader(data)
+		box, err := DecodeBoxSR(0, sr)
+		if err != nil {
+			t.Error(err)
+		}
+		stpp, ok := box.(*StppBox)
+		if !ok {
+			t.Error("not an stpp box")
+		}
+		if int(stpp.Size()) != len(data) {
+			t.Errorf("stpp size %d not same as %d", stpp.Size(), len(data))
+		}
+		buf := bytes.Buffer{}
+		err = stpp.Encode(&buf)
+		if err != nil {
+			t.Error(err)
+		}
+		outData := buf.Bytes()
+		if !bytes.Equal(data, outData) {
+			t.Error("written stpp box differs from read")
+		}
+	})
+	t.Run("decode completely missing auxiliary mime types", func(t *testing.T) {
+		hexData := ("0000002b737470700000000000000001" +
+			"687474703a2f2f7777772e77332e6f72" +
+			"672f6e732f74746d6c0000")
+		hexData = strings.Replace(hexData, " ", "", -1)
+		data, err := hex.DecodeString(hexData)
+		if err != nil {
+			t.Error(err)
+		}
+		sr := bits.NewFixedSliceReader(data)
+		box, err := DecodeBoxSR(0, sr)
+		if err != nil {
+			t.Error(err)
+		}
+		stpp, ok := box.(*StppBox)
+		if !ok {
+			t.Error("not an stpp box")
+		}
+		if int(stpp.Size()) != len(data) {
+			t.Errorf("stpp size %d not same as %d", stpp.Size(), len(data))
+		}
+	})
 }


### PR DESCRIPTION
Handle the case where there is not even an terminal zero bytes for optional utf8lists in stpp box.