### PR TITLE
V0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.43.0] - 2024-04-04
+
 ### Added
 
 - InitSegment.TweakSingleTrakLive changes an init segment to fit live streaming
@@ -25,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - kind box full-box header
-- stpp support when the optional fields do not even have a zero-termination byte
+- stpp support when the optional fields do not have a zero-termination byte
 - mp4ff-wvttlister now lists all boxes in a sample
 
 ## [0.42.0] - 2024-01-26
@@ -558,7 +562,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.42.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.43.0...HEAD
+[0.43.0]: https://github.com/Eyevinn/mp4ff/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/Eyevinn/mp4ff/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/Eyevinn/mp4ff/compare/v0.40.2...v0.41.0
 [0.40.2]: https://github.com/Eyevinn/mp4ff/compare/v0.40.1...v0.40.2

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -214,9 +214,6 @@ LoopBoxes:
 			return nil, err
 		}
 		boxType, boxSize := box.Type(), box.Size()
-		if err != nil {
-			return nil, err
-		}
 		switch boxType {
 		case "mdat":
 			if f.isFragmented {

--- a/mp4/initsegment_test.go
+++ b/mp4/initsegment_test.go
@@ -18,17 +18,13 @@ const pps1nalu = "685bdf20"
 func parseInitFile(fileName string) (*File, error) {
 	fd, err := os.Open(fileName)
 	if err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	defer fd.Close()
 
 	f, err := DecodeFile(fd)
 	if err != io.EOF && err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	if f.IsFragmented() && f.Init.Ftyp == nil {
 		return nil, fmt.Errorf("No ftyp present")
@@ -175,9 +171,7 @@ func TestGenerateInitSegment(t *testing.T) {
 
 	initRead, err := DecodeFile(&buf)
 	if err != io.EOF && err != nil {
-		if err != nil {
-			t.Error(err)
-		}
+		t.Error(err)
 	}
 	if initRead.Moov.Size() != init.Moov.Size() {
 		t.Errorf("Mismatch generated vs read moov size: %d != %d", init.Moov.Size(), initRead.Moov.Size())

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.42.0"    // May be updated using build flags
-	commitDate    string = "1706273015" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.43.0"    // May be updated using build flags
+	commitDate    string = "1712251234" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Added

- InitSegment.TweakSingleTrakLive changes an init segment to fit live streaming
- Made bits.Mask() function public
- New counter methods added to bits.Reader
- colr box support for nclc and unknown colour_type
- av01, encv, and enca direct pointers in stsd

### Changed

- All readers and writers in bits package now stop working at first error and provides the first error as AccError()
- Renamed bits.AccErrReader, bits.AccErrEBSPReader, bits.AccErrWriter to corresponiding names without AccErr
- Renamed bits.SliceWriterError to bits.ErrSliceWrite
- colr box supports unknown colrType

### Fixed

- kind box full-box header
- stpp support when the optional fields do not have a zero-termination byte
- mp4ff-wvttlister now lists all boxes in a sample