### PR TITLE
fix: more careful mfro decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+
+### Added
+
+- New TryDecodeMfro function
+
+### Fixed
+
+- More robust check for mfro at the end of file
 
 ## [0.43.0] - 2024-04-04
 

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -346,14 +346,8 @@ func (f *File) findAndReadMfra(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("could not seek %d bytes from end: %w", mfroSize, err)
 	}
-	b, err := DecodeBox(uint64(pos), rs) // mfro
+	mfro, err := TryDecodeMfro(uint64(pos), rs) // mfro
 	if err != nil {
-		// Not an mfro box here, just reset and return
-		_, err = rs.Seek(0, io.SeekStart)
-		return err
-	}
-	mfro, ok := b.(*MfroBox)
-	if !ok {
 		// Not an mfro box here, just reset and return
 		_, err = rs.Seek(0, io.SeekStart)
 		return err
@@ -363,7 +357,7 @@ func (f *File) findAndReadMfra(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("could not seek %d bytes from end: %w", mfraSize, err)
 	}
-	b, err = DecodeBox(uint64(pos), rs) // mfra
+	b, err := DecodeBox(uint64(pos), rs) // mfra
 	if err != nil {
 		return fmt.Errorf("could not decode mfra box: %w", err)
 	}

--- a/mp4/mfro.go
+++ b/mp4/mfro.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/Eyevinn/mp4ff/bits"
@@ -12,6 +13,23 @@ type MfroBox struct {
 	Version    byte
 	Flags      uint32
 	ParentSize uint32
+}
+
+// TryDecodeMfro only decode an MfroBox and return it.
+// If it is not an MfroBox, it returns nil and an error.
+func TryDecodeMfro(startPos uint64, r io.Reader) (*MfroBox, error) {
+	hdr, err := DecodeHeader(r)
+	if err != nil {
+		return nil, err
+	}
+	if hdr.Name != "mfro" {
+		return nil, fmt.Errorf("not an mfro box")
+	}
+	box, err := DecodeMfro(hdr, startPos, r)
+	if err != nil {
+		return nil, err
+	}
+	return box.(*MfroBox), nil
 }
 
 // DecodeMfro - box-specific decode


### PR DESCRIPTION
The check for mfro box at end of file is now more robust by checking the header for the corresponding "mfro" type.
Added a new function TrypDecodeMfro().