### PR TITLE
v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.44.0] - 2024-04-19
+
 ### Added
 
 - New `TryDecodeMfro` function
@@ -583,7 +587,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.43.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.44.0...HEAD
+[0.44.0]: https://github.com/Eyevinn/mp4ff/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Eyevinn/mp4ff/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/Eyevinn/mp4ff/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/Eyevinn/mp4ff/compare/v0.40.2...v0.41.0

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.43.0"    // May be updated using build flags
-	commitDate    string = "1712251234" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.44.0"    // May be updated using build flags
+	commitDate    string = "1713532831" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Added

- New `TryDecodeMfro` function
- New `mp4ff-subslister` tool replacing `mp4ff-wvttlister`. It supports `wvtt` and `stpp`
- `File.UpdateSidx()` to update or add a top level sidx box for a fragmented file
- `mp4.DecStartSegmentOnMoof` flag to make the Decoder interpret every moof as
  a new segment start, unless styp, sidx, or mfra boxes give that information.
- New example `add-sidx` shows how on can add a top-level `sidx` box to a fragmented file.
  It further has the option to remove unused encryption boxes, and to interpret each
  moof box as starting a new segment.
- New method `MoovBox.IsEncrypted()` checks if an encrypted codec is signaled

### Fixed

- More robust check for mfro at the end of file
- GetTrex() return value
- Can now write PIFF `uuid` box that has previously been read
- Does now avoid the second parsing of `senc` box if the file is ot encrypted as seen in moov box.

### Removed

- mp4ff-wvttlister tool removed and replaced by mp4ff-subslister