### PR TITLE
feat: handle bad descriptors and provide detailed info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - support for parsing of hierarchical sidx boxes
+- handling of partially bad descriptors
+
+### Changed
+
+- Info (mp4ff-info) output for esds boxes
+- API of descriptors
 
 ### Added
 
 - support for ssix box
 - support for leva box
+- details for descriptors as Info outout
 
 ## [0.44.0] - 2024-04-19
 

--- a/mp4/descriptors_test.go
+++ b/mp4/descriptors_test.go
@@ -3,32 +3,124 @@ package mp4
 import (
 	"bytes"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/bits"
 )
 
+const badSizeDescriptor = `031900010004134015000000000000000001f40005021190060102`
+const missingSLConfig = `031600010004114015000000000000000001d40005021190`
+const partOfEsdsProgIn = `03808080250002000480808017401500000000010d88000003f80580808005128856e500068080800102`
+
 func TestDecodeDescriptor(t *testing.T) {
-	esDesc, err := hex.DecodeString(esdsProgIn[24:])
-	if err != nil {
-		t.Error(err)
+	cases := []struct {
+		desc string
+		data string
+	}{
+		{"badSizeDescriptor", badSizeDescriptor},
+		{"missingSLConfig", missingSLConfig},
+		{"partOfEsdsProgIn", partOfEsdsProgIn},
 	}
-	sr := bits.NewFixedSliceReader(esDesc)
-	desc, err := DecodeESDescriptor(sr, uint32(len(esDesc)))
-	if err != nil {
-		t.Error(err)
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			data, err := hex.DecodeString(c.data)
+			if err != nil {
+				t.Error(err)
+			}
+			sr := bits.NewFixedSliceReader(data)
+			desc, err := DecodeESDescriptor(sr, uint32(len(data)))
+			if err != nil {
+				t.Error(err)
+			}
+			if desc.Tag() != ES_DescrTag {
+				t.Error("tag is not 3")
+			}
+			out := make([]byte, len(data))
+			sw := bits.NewFixedSliceWriterFromSlice(out)
+			err = desc.EncodeSW(sw)
+			if err != nil {
+				t.Error(err)
+			}
+			if !bytes.Equal(sw.Bytes(), data) {
+				t.Errorf("written es descriptor differs from read\n%s\n%s",
+					hex.EncodeToString(sw.Bytes()), hex.EncodeToString(data))
+			}
+		})
 	}
-	if desc.Tag() != ES_DescrTag {
-		t.Error("tag is not 3")
+}
+
+func TestDescriptorInfo(t *testing.T) {
+	cases := []struct {
+		desc       string
+		data       string
+		wantedInfo string
+	}{
+		{"badSizeDescriptor", badSizeDescriptor,
+			`Descriptor "tag=3 ES" size=2+25
+			- EsID: 1
+			- DependsOnEsID: 0
+			- OCResID: 0
+			- FlagsAndPriority: 0
+			- URLString:
+			 Descriptor "tag=4 DecoderConfig" size=2+19
+			  - ObjectType: 64
+			  - StreamType: 21
+			  - BufferSizeDB: 0
+			  - MaxBitrate: 0
+			  - AvgBitrate: 128000
+			   Descriptor "tag=5 DecoderSpecificInfo" size=2+2
+				- DecConfig (2B): 1190
+			  - UnknownData (2B): 0601
+			- Missing SLConfigDescriptor
+			- UnknownData (1B): 02
+			`},
+		{"missingSLConfig", missingSLConfig,
+			`Descriptor "tag=3 ES" size=2+22
+		- EsID: 1
+		- DependsOnEsID: 0
+		- OCResID: 0
+		- FlagsAndPriority: 0
+		- URLString:
+		 Descriptor "tag=4 DecoderConfig" size=2+17
+		  - ObjectType: 64
+		  - StreamType: 21
+		  - BufferSizeDB: 0
+		  - MaxBitrate: 0
+		  - AvgBitrate: 119808
+		   Descriptor "tag=5 DecoderSpecificInfo" size=2+2
+			- DecConfig (2B): 1190
+		- Missing SLConfigDescriptor
+		`},
 	}
-	out := make([]byte, len(esDesc))
-	sw := bits.NewFixedSliceWriterFromSlice(out)
-	err = desc.EncodeSW(sw)
-	if err != nil {
-		t.Error(err)
-	}
-	if !bytes.Equal(sw.Bytes(), esDesc) {
-		t.Errorf("written es descriptor differs from read\n%s\n%s",
-			hex.EncodeToString(sw.Bytes()), hex.EncodeToString(esDesc))
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			data, err := hex.DecodeString(c.data)
+			if err != nil {
+				t.Error(err)
+			}
+			sr := bits.NewFixedSliceReader(data)
+			desc, err := DecodeESDescriptor(sr, uint32(len(data)))
+			if err != nil {
+				t.Error(err)
+			}
+			buf := bytes.Buffer{}
+			err = desc.Info(&buf, "esds:1", "", "  ")
+			if err != nil {
+				t.Error(err)
+			}
+			gotLines := strings.Split(buf.String(), "\n")
+			wantedLines := strings.Split(c.wantedInfo, "\n")
+			if len(gotLines) != len(wantedLines) {
+				t.Errorf("got %d lines, wanted %d", len(gotLines), len(wantedLines))
+			}
+			for i, line := range gotLines {
+				gotTrimmed := strings.TrimSpace(line)
+				wantedTrimmed := strings.TrimSpace(wantedLines[i])
+				if gotTrimmed != wantedTrimmed {
+					t.Errorf("line %d differs\n%s\n%s", i, gotTrimmed, wantedTrimmed)
+				}
+			}
+		})
 	}
 }

--- a/mp4/esds.go
+++ b/mp4/esds.go
@@ -1,7 +1,6 @@
 package mp4
 
 import (
-	"encoding/hex"
 	"fmt"
 	"io"
 
@@ -94,8 +93,9 @@ func (e *EsdsBox) EncodeSW(sw bits.SliceWriter) error {
 // Info - write box-specific information
 func (e *EsdsBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
 	bd := newInfoDumper(w, indent, e, int(e.Version), e.Flags)
-	bd.write(" - maxBitrate: %d", e.DecConfigDescriptor.MaxBitrate)
-	bd.write(" - avgBitrate: %d", e.DecConfigDescriptor.AvgBitrate)
-	bd.write(" - decConfig: %s", hex.EncodeToString(e.DecConfigDescriptor.DecSpecificInfo.DecConfig))
+	err := e.ESDescriptor.Info(bd.w, specificBoxLevels, indent+indentStep, indentStep)
+	if err != nil {
+		return err
+	}
 	return bd.err
 }


### PR DESCRIPTION
As mentioned in #350, some mp4 samples in the wild have erroneous descriptors.

This PR extends the descriptor handling to become more general, but also to handle
and store data corresponding to bad descriptor data at the end of ES descriptor,
and DecoderConfig descriptor. This makes it possible to Decode and Encode such
assets without change of the data.

The Info() interface as used by mp4ff-info has been extended to reveal more information about encoders.
In particular, a higher level for `esds` boxes propagates into descriptors.

This should solve #350 and #348.