### PR TITLE
Update min go version to 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: ["1.13", "1.20"]
+        go-version: ["1.16", "1.22"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- minimum Go version 1.16.
+- ioutil imports replaced by io and os imports
+
 ### Fixed
 
 - support for parsing of hierarchical sidx boxes

--- a/avc/slice_test.go
+++ b/avc/slice_test.go
@@ -2,7 +2,7 @@ package avc
 
 import (
 	"encoding/hex"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -30,7 +30,7 @@ func TestParseSliceHeader_BlackFrame(t *testing.T) {
 		SliceBetaOffsetDiv2:    -3,
 		Size:                   7,
 	}
-	data, err := ioutil.ReadFile("testdata/blackframe.264")
+	data, err := os.ReadFile("testdata/blackframe.264")
 	if err != nil {
 		t.Error(err)
 	}
@@ -71,7 +71,7 @@ func TestParseSliceHeader_TwoFrames(t *testing.T) {
 		Size: 5, NumRefIdxActiveOverrideFlag: true, RefPicListModificationL0Flag: true,
 	}
 
-	data, err := ioutil.ReadFile("testdata/two-frames.264")
+	data, err := os.ReadFile("testdata/two-frames.264")
 	if err != nil {
 		t.Error(err)
 	}

--- a/bits/reader.go
+++ b/bits/reader.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 // Reader is a bit reader that stops reading at first error and stores it.
@@ -85,7 +84,7 @@ func (r *Reader) ReadRemainingBytes() []byte {
 		r.err = fmt.Errorf("%d bit instead of byte alignment when reading remaining bytes", r.n)
 		return nil
 	}
-	rest, err := ioutil.ReadAll(r.rd)
+	rest, err := io.ReadAll(r.rd)
 	if err != nil {
 		r.err = err
 		return nil

--- a/bits/writer_benchmark_test.go
+++ b/bits/writer_benchmark_test.go
@@ -1,14 +1,14 @@
 package bits_test
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func BenchmarkWrite(b *testing.B) {
-	writer := bits.NewWriter(ioutil.Discard)
+	writer := bits.NewWriter(io.Discard)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		writer.Write(0xff, 8)
@@ -20,7 +20,7 @@ func BenchmarkWrite(b *testing.B) {
 }
 
 func BenchmarkEbspWrite(b *testing.B) {
-	writer := bits.NewEBSPWriter(ioutil.Discard)
+	writer := bits.NewEBSPWriter(io.Discard)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		writer.Write(0xff, 8)

--- a/cmd/mp4ff-decrypt/decrypt_test.go
+++ b/cmd/mp4ff-decrypt/decrypt_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -68,7 +67,7 @@ func TestDecryptFiles(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		expectedOut, err := ioutil.ReadFile(tc.expectedOutFile)
+		expectedOut, err := os.ReadFile(tc.expectedOutFile)
 		if err != nil {
 			t.Error(err)
 		}
@@ -83,7 +82,7 @@ func TestDecryptFiles(t *testing.T) {
 func BenchmarkDecodeCenc(b *testing.B) {
 	inFile := "../../mp4/testdata/prog_8s_enc_dashinit.mp4"
 	hexKey := "63cb5f7184dd4b689a5c5ff11ee6a328"
-	raw, err := ioutil.ReadFile(inFile)
+	raw, err := os.ReadFile(inFile)
 	if err != nil {
 		b.Error(err)
 	}

--- a/cmd/mp4ff-encrypt/main.go
+++ b/cmd/mp4ff-encrypt/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -99,7 +98,7 @@ func main() {
 
 	var psshData []byte
 	if opts.psshFile != "" {
-		psshData, err = ioutil.ReadFile(opts.psshFile)
+		psshData, err = os.ReadFile(opts.psshFile)
 		if err != nil {
 			log.Fatalf("could not read pssh data from file: %s", err)
 		}

--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -59,7 +58,7 @@ func main() {
 	}
 	// First try to handle Annex B file
 	if *annexB {
-		data, err := ioutil.ReadFile(inFilePath)
+		data, err := os.ReadFile(inFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mp4ff-pslister/main.go
+++ b/cmd/mp4ff-pslister/main.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -178,7 +177,7 @@ func run(inFile, vpsHex, spsHex, ppsHex, codec string, version, verbose bool) er
 }
 
 func getNalusFromBytestream(f io.Reader) ([][]byte, error) {
-	byteStream, err := ioutil.ReadAll(f)
+	byteStream, err := io.ReadAll(f)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/combine-segs/main.go
+++ b/examples/combine-segs/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/Eyevinn/mp4ff/bits"
@@ -40,7 +39,7 @@ func main() {
 func combineInitSegments(files []string, newTrackIDs []uint32) (*mp4.InitSegment, error) {
 	var combinedInit *mp4.InitSegment
 	for i := 0; i < len(files); i++ {
-		data, err := ioutil.ReadFile(files[i])
+		data, err := os.ReadFile(files[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to read init segment: %w", err)
 		}
@@ -78,7 +77,7 @@ func combineMediaSegments(files []string, newTrackIDs []uint32) (*mp4.MediaSegme
 	var combinedSeg *mp4.MediaSegment
 	var outFrag *mp4.Fragment
 	for i := 0; i < len(files); i++ {
-		data, err := ioutil.ReadFile(files[i])
+		data, err := os.ReadFile(files[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to read media segment: %w", err)
 		}

--- a/examples/multitrack/helpers_test.go
+++ b/examples/multitrack/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -46,7 +45,7 @@ func compareOrUpdateGolden(t *testing.T, genData []byte, path string) (err error
 	}
 
 	// Compare with golden dump file
-	golden, err := ioutil.ReadFile(path)
+	golden, err := os.ReadFile(path)
 	if err != nil {
 		t.Error(err)
 	}

--- a/examples/multitrack/multitrack_test.go
+++ b/examples/multitrack/multitrack_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -87,7 +86,7 @@ func TestGetMultiTrackSamples(t *testing.T) {
 		t.Error(err)
 	}
 
-	inFileRaw, err := ioutil.ReadFile(filePath)
+	inFileRaw, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Eyevinn/mp4ff
 
-go 1.14
+go 1.16
 
-require github.com/go-test/deep v1.0.8
+require github.com/go-test/deep v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
-github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=

--- a/hevc/slice_test.go
+++ b/hevc/slice_test.go
@@ -1,7 +1,7 @@
 package hevc
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/avc"
@@ -82,7 +82,7 @@ func TestParseSliceHeader(t *testing.T) {
 			Size:                     10,
 		},
 	}
-	data, err := ioutil.ReadFile("testdata/blackframe.265")
+	data, err := os.ReadFile("testdata/blackframe.265")
 	if err != nil {
 		t.Error(err)
 	}

--- a/mp4/benchmarks_srw_test.go
+++ b/mp4/benchmarks_srw_test.go
@@ -2,7 +2,7 @@ package mp4
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/bits"
@@ -14,7 +14,7 @@ func TestDecodEncodeFileSRW(t *testing.T) {
 		"prog_8s.mp4",
 	}
 	for _, testFile := range testFiles {
-		raw, err := ioutil.ReadFile("testdata/" + testFile)
+		raw, err := os.ReadFile("testdata/" + testFile)
 		if err != nil {
 			t.Error(err)
 		}
@@ -44,7 +44,7 @@ func BenchmarkDecodeFileSR(b *testing.B) {
 		"prog_8s.mp4",
 	}
 	for _, testFile := range testFiles {
-		raw, _ := ioutil.ReadFile("testdata/" + testFile)
+		raw, _ := os.ReadFile("testdata/" + testFile)
 		b.Run(testFile, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				sr := bits.NewFixedSliceReader(raw)
@@ -60,7 +60,7 @@ func BenchmarkEncodeFileSW(b *testing.B) {
 		"prog_8s.mp4",
 	}
 	for _, testFile := range testFiles {
-		raw, _ := ioutil.ReadFile("testdata/" + testFile)
+		raw, _ := os.ReadFile("testdata/" + testFile)
 		inBuf := bytes.NewBuffer(raw)
 		decFile, _ := DecodeFile(inBuf)
 		rawOut := make([]byte, len(raw))

--- a/mp4/benchmarks_test.go
+++ b/mp4/benchmarks_test.go
@@ -2,7 +2,7 @@ package mp4
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestDecodEncodeFile(t *testing.T) {
 		"prog_8s.mp4",
 	}
 	for _, testFile := range testFiles {
-		raw, err := ioutil.ReadFile("testdata/" + testFile)
+		raw, err := os.ReadFile("testdata/" + testFile)
 		if err != nil {
 			t.Error(err)
 		}
@@ -43,7 +43,7 @@ func BenchmarkDecodeFile(b *testing.B) {
 		"prog_8s.mp4",
 	}
 	for _, testFile := range testFiles {
-		raw, _ := ioutil.ReadFile("testdata/" + testFile)
+		raw, _ := os.ReadFile("testdata/" + testFile)
 		b.Run(testFile, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				buf := bytes.NewBuffer(raw)
@@ -59,7 +59,7 @@ func BenchmarkEncodeFile(b *testing.B) {
 		"prog_8s.mp4",
 	}
 	for _, testFile := range testFiles {
-		raw, _ := ioutil.ReadFile("testdata/" + testFile)
+		raw, _ := os.ReadFile("testdata/" + testFile)
 		inBuf := bytes.NewBuffer(raw)
 		decFile, _ := DecodeFile(inBuf)
 		rawOut := make([]byte, 0, len(raw))

--- a/mp4/boxsr_test.go
+++ b/mp4/boxsr_test.go
@@ -2,7 +2,7 @@ package mp4
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/bits"
@@ -17,7 +17,7 @@ func TestDecodeEncodeSRW(t *testing.T) {
 	}
 	for _, testFile := range testFiles {
 
-		inData, err := ioutil.ReadFile(testFile)
+		inData, err := os.ReadFile(testFile)
 		if err != nil {
 			t.Error(err)
 		}

--- a/mp4/dac3.go
+++ b/mp4/dac3.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/Eyevinn/mp4ff/bits"
@@ -62,7 +61,7 @@ type Dac3Box struct {
 
 // DecodeDac3 - box-specific decode
 func DecodeDac3(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/dec3.go
+++ b/mp4/dec3.go
@@ -3,7 +3,6 @@ package mp4
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/Eyevinn/mp4ff/bits"
@@ -67,7 +66,7 @@ type EC3Sub struct {
 
 // DecodeDec3 - box-specific decode
 func DecodeDec3(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/file_test.go
+++ b/mp4/file_test.go
@@ -2,7 +2,6 @@ package mp4
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -124,7 +123,7 @@ func TestDecodeEncode(t *testing.T) {
 	testFiles := []string{"./testdata/prog_8s.mp4", "./testdata/multi_sidx_segment.m4s"}
 
 	for _, testFile := range testFiles {
-		rawInput, err := ioutil.ReadFile("./testdata/prog_8s.mp4")
+		rawInput, err := os.ReadFile("./testdata/prog_8s.mp4")
 		if err != nil {
 			t.Error(err)
 		}

--- a/mp4/infodumper_test.go
+++ b/mp4/infodumper_test.go
@@ -3,7 +3,7 @@ package mp4
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,7 +29,7 @@ func compareOrUpdateInfo(t *testing.T, b Informer, path string) error {
 	}
 
 	// Compare with golden dump file
-	golden, err := ioutil.ReadFile(path)
+	golden, err := os.ReadFile(path)
 	if err != nil {
 		t.Error(err)
 	}

--- a/mp4/initsegment_test.go
+++ b/mp4/initsegment_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -88,7 +87,7 @@ func TestMoovParsingWithBtrt(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	initFileBytes, err := ioutil.ReadFile(initFile)
+	initFileBytes, err := os.ReadFile(initFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -121,7 +120,7 @@ func TestMoovWithCenc(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	initFileBytes, err := ioutil.ReadFile(initFile)
+	initFileBytes, err := os.ReadFile(initFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -196,7 +195,7 @@ func TestGenerateInitSegment(t *testing.T) {
 		return
 	}
 
-	golden, err := ioutil.ReadFile(goldenAssetPath)
+	golden, err := os.ReadFile(goldenAssetPath)
 	if err != nil {
 		t.Error(err)
 	}

--- a/mp4/mediasegment_test.go
+++ b/mp4/mediasegment_test.go
@@ -3,7 +3,6 @@ package mp4
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestMediaSegmentFragmentation(t *testing.T) {
 		t.Error(err)
 	}
 
-	inSeg, err := ioutil.ReadFile(inFile)
+	inSeg, err := os.ReadFile(inFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +91,7 @@ func TestMediaSegmentFragmentation(t *testing.T) {
 			t.Error(err)
 		}
 	} else {
-		goldenFrag, err := ioutil.ReadFile(goldenFragPath)
+		goldenFrag, err := os.ReadFile(goldenFragPath)
 		if err != nil {
 			t.Error(err)
 		}
@@ -125,7 +124,7 @@ func TestDecodeEncodeNoOptimize(t *testing.T) {
 
 	inFile := "testdata/1.m4s"
 
-	data, err := ioutil.ReadFile(inFile)
+	data, err := os.ReadFile(inFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +173,7 @@ func TestMoofEncrypted(t *testing.T) {
 		t.Error(err)
 	}
 
-	inSeg, err := ioutil.ReadFile(inFile)
+	inSeg, err := os.ReadFile(inFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +196,7 @@ func TestMoofEncrypted(t *testing.T) {
 }
 
 func TestDecodeEncodeCencFragmentedFile(t *testing.T) {
-	inData, err := ioutil.ReadFile("testdata/prog_8s_enc_dashinit.mp4")
+	inData, err := os.ReadFile("testdata/prog_8s_enc_dashinit.mp4")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Github actions no longer support testing with Go version 1.13

Update minimum version used in Github actions testing to 1.16.
Also removed the calls to the obsolete ioutil package