### PR TITLE
Improved url box parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - minimum Go version 1.16.
 - ioutil imports replaced by io and os imports
+- Info (mp4ff-info) output for esds boxes
+- API of descriptors
 
 ### Fixed
 
 - support for parsing of hierarchical sidx boxes
 - handling of partially bad descriptors
 
-### Changed
-
-- Info (mp4ff-info) output for esds boxes
-- API of descriptors
-
 ### Added
 
 - support for ssix box
 - support for leva box
-- details for descriptors as Info outout
+- details of descriptors as Info outout (mp4ff-info)
 
 ## [0.44.0] - 2024-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ioutil imports replaced by io and os imports
 - Info (mp4ff-info) output for esds boxes
 - API of descriptors
+- Parsing and info output for url boxes
 
 ### Fixed
 
 - support for parsing of hierarchical sidx boxes
 - handling of partially bad descriptors
+- handle url boxes missing mandatory zero-ending byte
 
 ### Added
 

--- a/bits/fixedslicereader.go
+++ b/bits/fixedslicereader.go
@@ -160,7 +160,7 @@ func (s *FixedSliceReader) ReadFixedLengthString(n int) string {
 }
 
 // ReadZeroTerminatedString - read string until zero byte but at most maxLen
-// Set err and return empty string if no zero byte found
+// Set err and return empty string if no zero byte found.
 func (s *FixedSliceReader) ReadZeroTerminatedString(maxLen int) string {
 	if s.err != nil {
 		return ""
@@ -177,6 +177,29 @@ func (s *FixedSliceReader) ReadZeroTerminatedString(maxLen int) string {
 			str := string(s.slice[startPos:s.pos])
 			s.pos++ // Next position to read
 			return str
+		}
+		s.pos++
+	}
+}
+
+// ReadPossiblyZeroTerminatedString - read string until zero byte but at most maxLen.
+// If maxLen is reached and no zero-byte, return string and ok = false
+func (s *FixedSliceReader) ReadPossiblyZeroTerminatedString(maxLen int) (str string, ok bool) {
+	startPos := s.pos
+	maxPos := startPos + maxLen
+	for {
+		if s.pos == maxPos {
+			return string(s.slice[startPos:s.pos]), true
+		}
+		if s.pos > maxPos {
+			s.err = errors.New("did not find terminating zero")
+			return "", false
+		}
+		c := s.slice[s.pos]
+		if c == 0 {
+			str = string(s.slice[startPos:s.pos])
+			s.pos++ // Next position to read
+			return str, true
 		}
 		s.pos++
 	}

--- a/bits/fixedslicereader_test.go
+++ b/bits/fixedslicereader_test.go
@@ -237,6 +237,7 @@ func TestFixedSliceReader(t *testing.T) {
 }
 
 func verifyAccErrorInt(t *testing.T, sr *bits.FixedSliceReader, val int) {
+	t.Helper()
 	if sr.AccError() == nil {
 		t.Errorf("should have had an accumulated error")
 	}
@@ -246,6 +247,7 @@ func verifyAccErrorInt(t *testing.T, sr *bits.FixedSliceReader, val int) {
 }
 
 func verifyAccErrorString(t *testing.T, sr *bits.FixedSliceReader, val string) {
+	t.Helper()
 	if sr.AccError() == nil {
 		t.Errorf("should have had an accumulated error")
 	}

--- a/bits/slicereader.go
+++ b/bits/slicereader.go
@@ -19,6 +19,7 @@ type SliceReader interface {
 	ReadInt64() int64
 	ReadFixedLengthString(n int) string
 	ReadZeroTerminatedString(maxLen int) string
+	ReadPossiblyZeroTerminatedString(maxLen int) (str string, ok bool)
 	ReadBytes(n int) []byte
 	RemainingBytes() []byte
 	NrRemainingBytes() int

--- a/mp4/descriptors.go
+++ b/mp4/descriptors.go
@@ -213,6 +213,7 @@ func (e *ESDescriptor) Type() string {
 	return TagType(e.Tag())
 }
 
+// Size is size of payload after tag and size field
 func (e *ESDescriptor) Size() uint64 {
 	var size uint64 = 2 + 1
 	streamDependenceFlag := e.FlagsAndPriority >> 7
@@ -238,6 +239,7 @@ func (e *ESDescriptor) Size() uint64 {
 	return size
 }
 
+// SizeSize is size of size field.
 func (e *ESDescriptor) SizeSize() uint64 {
 	return 1 + uint64(e.sizeFieldSizeMinus1) + 1 + e.Size()
 }
@@ -324,6 +326,19 @@ func (e *ESDescriptor) Info(w io.Writer, specificLevels, indent, indentStep stri
 	return bd.err
 }
 
+// DecoderConfigDescriptor is defined in ISO/IEC 14496-1 Section 7.2.6.6.1
+//
+//	class DecoderConfigDescriptor extends BaseDescriptor : bit(8) tag=DecoderConfigDescrTag {
+//	  bit(8) objectTypeIndication;
+//	  bit(6) streamType;
+//	  bit(1) upStream;
+//	  const bit(1) reserved=1;
+//	  bit(24) bufferSizeDB;
+//	  bit(32) maxBitrate;
+//	  bit(32) avgBitrate;
+//	  DecoderSpecificInfo decSpecificInfo[0 .. 1];
+//	  profileLevelIndicationIndexDescriptor profileLevelIndicationIndexDescr [0..255];
+//	}
 type DecoderConfigDescriptor struct {
 	ObjectType          byte
 	StreamType          byte
@@ -333,7 +348,7 @@ type DecoderConfigDescriptor struct {
 	AvgBitrate          uint32
 	DecSpecificInfo     *DecSpecificInfoDescriptor
 	OtherDescriptors    []Descriptor
-	UnknownData         []byte
+	UnknownData         []byte // Data, probably erronous, that we don't understand
 }
 
 func exceedsMaxNrBytes(sizeFieldSizeMinus1 byte, size uint64, maxNrBytes int) bool {
@@ -463,6 +478,10 @@ func (d *DecoderConfigDescriptor) Info(w io.Writer, specificLevels, indent, inde
 	}
 	return bd.err
 }
+
+// DecSpecificInfoDescriptor is a generic DecoderSpecificInfoDescriptor.
+//
+// The meaning of the MPEG-4 audio descriptor is defined in  ISO/IEC 14496-3 Section 1.6.2.1.
 
 type DecSpecificInfoDescriptor struct {
 	sizeFieldSizeMinus1 byte

--- a/mp4/dref_test.go
+++ b/mp4/dref_test.go
@@ -1,10 +1,30 @@
 package mp4
 
 import (
+	"encoding/hex"
 	"testing"
+
+	"github.com/Eyevinn/mp4ff/bits"
 )
+
+const data = `000000326472656600000000000000010000002275726c200000000168747470733a2f2f666c7573736f6e69632e636f6d2f`
 
 func TestDref(t *testing.T) {
 	dref := CreateDref()
 	boxDiffAfterEncodeAndDecode(t, dref)
+}
+
+func TestDrefDecode(t *testing.T) {
+	d, err := hex.DecodeString(data)
+	if err != nil {
+		t.Error(err)
+	}
+	sr := bits.NewFixedSliceReader(d)
+	box, err := DecodeBoxSR(0, sr)
+	if err != nil {
+		t.Error(err)
+	}
+	if box.Type() != "dref" {
+		t.Errorf("Expected 'dref', got %s", box.Type())
+	}
 }

--- a/mp4/testdata/golden_init_cenc_cmfv_dump.txt
+++ b/mp4/testdata/golden_init_cenc_cmfv_dump.txt
@@ -29,8 +29,7 @@
         [vmhd] size=20 version=0 flags=000000
         [dinf] size=36
           [dref] size=28 version=0 flags=000000
-            [url ] size=12
-             - location: ""
+            [url ] size=12 version=0 flags=000001
         [stbl] size=319
           [stsd] size=243 version=0 flags=000000
             [encv] size=227

--- a/mp4/testdata/golden_init_prog_mp4_dump.txt
+++ b/mp4/testdata/golden_init_prog_mp4_dump.txt
@@ -35,8 +35,7 @@
         [vmhd] size=20 version=0 flags=000001
         [dinf] size=36
           [dref] size=28 version=0 flags=000000
-            [url ] size=12
-             - location: ""
+            [url ] size=12 version=0 flags=000001
         [stbl] size=4655
           [stsd] size=183 version=0 flags=000000
             [avc1] size=167

--- a/mp4/testdata/golden_init_video_mp4_dump.txt
+++ b/mp4/testdata/golden_init_video_mp4_dump.txt
@@ -36,8 +36,7 @@
         [vmhd] size=20 version=0 flags=000001
         [dinf] size=36
           [dref] size=28 version=0 flags=000000
-            [url ] size=12
-             - location: ""
+            [url ] size=12 version=0 flags=000001
         [stbl] size=237
           [stsd] size=161 version=0 flags=000000
             [avc3] size=145

--- a/mp4/url_test.go
+++ b/mp4/url_test.go
@@ -1,7 +1,11 @@
 package mp4
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
+
+	"github.com/Eyevinn/mp4ff/bits"
 )
 
 func TestUrl(t *testing.T) {
@@ -13,4 +17,65 @@ func TestUrl(t *testing.T) {
 	}
 
 	boxDiffAfterEncodeAndDecode(t, urlBox)
+}
+
+func TestUrlDecode(t *testing.T) {
+	cases := []struct {
+		desc              string
+		data              string
+		wantedFlags       uint32
+		wantedLocation    string
+		NoLocation        bool
+		NoZeroTermination bool
+	}{
+		{
+			desc:              "self-contained, with location and zero termination",
+			data:              `0000002375726c200000000168747470733a2f2f666c7573736f6e69632e636f6d2f00`,
+			wantedFlags:       0x00001,
+			wantedLocation:    "",
+			NoLocation:        false,
+			NoZeroTermination: false,
+		},
+		{
+			desc:              "self-contained,  with location but no zero termination",
+			data:              `0000002275726c200000000168747470733a2f2f666c7573736f6e69632e636f6d2f`,
+			wantedFlags:       0x00001,
+			wantedLocation:    "",
+			NoLocation:        false,
+			NoZeroTermination: true,
+		},
+		{
+			desc:              "self-contained,  without location",
+			data:              `0000000c75726c2000000001`,
+			wantedFlags:       0x00001,
+			wantedLocation:    "",
+			NoLocation:        false,
+			NoZeroTermination: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			d, err := hex.DecodeString(c.data)
+			if err != nil {
+				t.Error(err)
+			}
+			sr := bits.NewFixedSliceReader(d)
+			box, err := DecodeBoxSR(0, sr)
+			if err != nil {
+				t.Error(err)
+			}
+			if box.Type() != "url " {
+				t.Errorf("Expected 'url ', got %s", box.Type())
+			}
+			urlBox := box.(*URLBox)
+			o := bytes.Buffer{}
+			err = urlBox.Encode(&o)
+			if err != nil {
+				t.Error(err)
+			}
+			if !bytes.Equal(d, o.Bytes()) {
+				t.Errorf("Encode mismatch: got %s, wanted %s", hex.EncodeToString(o.Bytes()), c.data)
+			}
+		})
+	}
 }


### PR DESCRIPTION
The URL box should have a zero-terminated location string, or no data.
This PR supports that the termination zero byte is missing and that there is a URL also when the content
has the flag set to indicate that it is self-contained.

Solves #353.