### PR TITLE
docs: v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.45.0] - 2024-06-06
+
 ### Changed
 
 - minimum Go version 1.16.
@@ -605,7 +609,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.44.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.45.0...HEAD
+[0.45.0]: https://github.com/Eyevinn/mp4ff/compare/v0.44.0...v0.45.0
 [0.44.0]: https://github.com/Eyevinn/mp4ff/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Eyevinn/mp4ff/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/Eyevinn/mp4ff/compare/v0.41.0...v0.42.0

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.44.0"    // May be updated using build flags
-	commitDate    string = "1713532831" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.45.0"    // May be updated using build flags
+	commitDate    string = "1717703931" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Changed

- minimum Go version 1.16.
- ioutil imports replaced by io and os imports
- Info (mp4ff-info) output for esds boxes
- API of descriptors
- Parsing and info output for url boxes

### Fixed

- support for parsing of hierarchical sidx boxes
- handling of partially bad descriptors
- handle url boxes missing mandatory zero-ending byte

### Added

- support for ssix box
- support for leva box
- details of descriptors as Info outout (mp4ff-info)