### PR TITLE
feat: add pos in decoder error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Box decoder error messages include start position
+
 ### Fixed
 
-- Overflow in calculatiing sample decode time
+- Overflow in calculating sample decode time
 
 ## [0.45.0] - 2024-06-06
 

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -308,7 +308,7 @@ func DecodeBox(startPos uint64, r io.Reader) (Box, error) {
 		b, err = d(h, startPos, r)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("decode %s: %w", h.Name, err)
+		return nil, fmt.Errorf("decode %s pos %d: %w", h.Name, startPos, err)
 	}
 
 	return b, nil

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -168,7 +168,7 @@ func DecodeBoxSR(startPos uint64, sr bits.SliceReader) (Box, error) {
 		b, err = d(h, startPos, sr)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("decode box %s: %w", h.Name, err)
+		return nil, fmt.Errorf("decode %s pos %d: %w", h.Name, startPos, err)
 	}
 
 	return b, nil


### PR DESCRIPTION
To facilitate trouble-shooting box decode errors now include start position of the box.
Should help a little in #245 and similar cases.