### PR TITLE
v0.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.45.1] - 2024-07-12
+
 ### Added
 
 - Box decoder error messages include start position
@@ -616,7 +620,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.45.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.45.1...HEAD
+[0.45.1]: https://github.com/Eyevinn/mp4ff/compare/v0.45.0...v0.45.1
 [0.45.0]: https://github.com/Eyevinn/mp4ff/compare/v0.44.0...v0.45.0
 [0.44.0]: https://github.com/Eyevinn/mp4ff/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Eyevinn/mp4ff/compare/v0.42.0...v0.43.0

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.45.0"    // May be updated using build flags
-	commitDate    string = "1717703931" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.45.1"    // May be updated using build flags
+	commitDate    string = "1720779532" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Added

- Box decoder error messages include start position

### Fixed

- Overflow in calculating sample decode time
- elng box errononously did not include full box headers