### PR TITLE
feat: GetBtrt method for StsdBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - mvhd and tkhd methods to set and get creation and modification times
 - Event Message boxes evte, emib, emeb
+- GetBtrt method to StsdBox
+- Btrt pointer attribute in AudioSampleEnntry
 
 ## [0.45.1] - 2024-07-12
 

--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -18,6 +18,7 @@ type AudioSampleEntryBox struct {
 	Esds               *EsdsBox
 	Dac3               *Dac3Box
 	Dec3               *Dec3Box
+	Btrt               *BtrtBox
 	Sinf               *SinfBox
 	Children           []Box
 }
@@ -60,6 +61,8 @@ func (a *AudioSampleEntryBox) AddChild(child Box) {
 		a.Dac3 = child.(*Dac3Box)
 	case "dec3":
 		a.Dec3 = child.(*Dec3Box)
+	case "btrt":
+		a.Btrt = child.(*BtrtBox)
 	case "sinf":
 		a.Sinf = child.(*SinfBox)
 	}

--- a/mp4/stsd.go
+++ b/mp4/stsd.go
@@ -235,3 +235,22 @@ func (s *StsdBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 	}
 	return err
 }
+
+// GetBtrt returns the first BtrtBox found in StsdBox children.
+func (s *StsdBox) GetBtrt() *BtrtBox {
+	for _, c := range s.Children {
+		switch child := c.(type) {
+		case *VisualSampleEntryBox:
+			return child.Btrt
+		case *AudioSampleEntryBox:
+			return child.Btrt
+		case *WvttBox:
+			return child.Btrt
+		case *StppBox:
+			return child.Btrt
+		case *EvteBox:
+			return child.Btrt
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
All sample descriptors can have a Btrt box with bitrate information. This new method of `stsd` will return such a box if found in its (known children).