### PR TITLE
fix: allow other sbgp and sgpd types than seig with senc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - mvhd, tkhd, and mdhd timestamps were off by one day
+- allow other sbgp and sgpd types than seig with senc
 
 ### Added
 

--- a/mp4/traf.go
+++ b/mp4/traf.go
@@ -95,11 +95,8 @@ func (t *TrafBox) ParseReadSenc(defaultIVSize byte, moofStartPos uint64) error {
 		}
 	}
 	perSampleIVSize := defaultIVSize
-	if t.Sbgp != nil && t.Sgpd != nil {
-		sbgp, sgpd := t.Sbgp, t.Sgpd
-		if sbgp.GroupingType != "seig" {
-			return fmt.Errorf("sbgp grouping type %s not supported", sbgp.GroupingType)
-		}
+	sbgp, sgpd := t.Sbgp, t.Sgpd
+	if sbgp != nil && sbgp.GroupingType == "seig" && sgpd != nil && sgpd.GroupingType == "seig" {
 		nrSbgpEntries := len(sbgp.SampleCounts)
 		if nrSbgpEntries != 1 {
 			return fmt.Errorf("sbgp entries = %d, only 1 supported for now", nrSbgpEntries)
@@ -108,14 +105,7 @@ func (t *TrafBox) ParseReadSenc(defaultIVSize byte, moofStartPos uint64) error {
 		if sgpdEntryNr != sbgpInsideOffset+1 {
 			return fmt.Errorf("sgpd entry number must be first inside = 65536 + 1")
 		}
-		if sgpd.GroupingType != "seig" {
-			return fmt.Errorf("sgpd grouping type %s not supported", sgpd.GroupingType)
-		}
-
 		sgpdEntry := sgpd.SampleGroupEntries[sgpdEntryNr-sbgpInsideOffset-1]
-		if sgpdEntry.Type() != "seig" {
-			return fmt.Errorf("expected sgpd entry type seig but found %q", sgpdEntry.Type())
-		}
 		seigEntry := sgpdEntry.(*SeigSampleGroupEntry)
 		perSampleIVSize = seigEntry.PerSampleIVSize
 	}


### PR DESCRIPTION
Issue #367 reports a problem with certain sbgp and sgpd types. The issue arises in combination with `senc` where the test for sbgp and sgpd types was too restrictive.

Fixes #367.