### PR TITLE
v0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.46.0] - 2024-08-08
+
 ### Fixed
 
 - mvhd, tkhd, and mdhd timestamps were off by one day
@@ -631,7 +635,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.45.1...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.46.0...HEAD
+[0.46.0]: https://github.com/Eyevinn/mp4ff/compare/v0.45.1...v0.46.0
 [0.45.1]: https://github.com/Eyevinn/mp4ff/compare/v0.45.0...v0.45.1
 [0.45.0]: https://github.com/Eyevinn/mp4ff/compare/v0.44.0...v0.45.0
 [0.44.0]: https://github.com/Eyevinn/mp4ff/compare/v0.43.0...v0.44.0

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.45.1"    // May be updated using build flags
-	commitDate    string = "1720779532" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.46"      // May be updated using build flags
+	commitDate    string = "1723143113" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Fixed

- mvhd, tkhd, and mdhd timestamps were off by one day
- allow other sbgp and sgpd types than seig with senc

### Added

- mvhd, tkhd, and mdhd methods to set and get creation and modification times
- Event Message boxes evte, emib, emeb
- GetBtrt method to StsdBox
- Btrt pointer attribute in AudioSampleEnntry
- stpp can be used as value to CreateEmptyTrak