### PR TITLE
fix: allow missing optional DecoderSpecificInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow missing optional DecoderSpecificInfo
+
 - Nothing yet
 
 ## [0.46.0] - 2024-08-08

--- a/mp4/descriptors_test.go
+++ b/mp4/descriptors_test.go
@@ -12,6 +12,7 @@ import (
 const badSizeDescriptor = `031900010004134015000000000000000001f40005021190060102`
 const missingSLConfig = `031600010004114015000000000000000001d40005021190`
 const partOfEsdsProgIn = `03808080250002000480808017401500000000010d88000003f80580808005128856e500068080800102`
+const missingDecSpecificInfo = `0315000100040d4015000000000000000001d400060102`
 
 func TestDecodeDescriptor(t *testing.T) {
 	cases := []struct {
@@ -21,6 +22,7 @@ func TestDecodeDescriptor(t *testing.T) {
 		{"badSizeDescriptor", badSizeDescriptor},
 		{"missingSLConfig", missingSLConfig},
 		{"partOfEsdsProgIn", partOfEsdsProgIn},
+		{"missingDecSpecificInfo", missingDecSpecificInfo},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
@@ -91,6 +93,22 @@ func TestDescriptorInfo(t *testing.T) {
 		   Descriptor "tag=5 DecoderSpecificInfo" size=2+2
 			- DecConfig (2B): 1190
 		- Missing SLConfigDescriptor
+		`},
+		{"missingDecSpecificInfo", missingDecSpecificInfo,
+			`Descriptor "tag=3 ES" size=2+21
+		- EsID: 1
+		- DependsOnEsID: 0
+		- OCResID: 0
+		- FlagsAndPriority: 0
+		- URLString:
+		 Descriptor "tag=4 DecoderConfig" size=2+13
+		  - ObjectType: 64
+		  - StreamType: 21
+		  - BufferSizeDB: 0
+		  - MaxBitrate: 0
+		  - AvgBitrate: 119808
+		 Descriptor "tag=6 SLConfig" size=2+1
+		  - ConfigValue: 2
 		`},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
The standard allows DecoderSpecificInfo to be absent as pointed out in #372.
This PR fixes this.