### PR TITLE
fix: allow additional empty mdat boxes in progressive files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow missing optional DecoderSpecificInfo
+- Avoid mp4.File.Mdat pointing to an empty mdat box
 
 - Nothing yet
 

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -226,6 +226,16 @@ LoopBoxes:
 				if lastBoxType != "moof" {
 					return nil, fmt.Errorf("does not support %v between moof and mdat", lastBoxType)
 				}
+			} else {
+				if f.Mdat != nil {
+					oldPayloadSize := f.Mdat.Size() - f.Mdat.HeaderSize()
+					newMdat := box.(*MdatBox)
+					newPayloadSize := newMdat.Size() - newMdat.HeaderSize()
+					if oldPayloadSize > 0 && newPayloadSize > 0 {
+						return nil, fmt.Errorf("only one non-empty mdat box supported (payload sizes %d and %d)",
+							oldPayloadSize, newPayloadSize)
+					}
+				}
 			}
 		case "moof":
 			moof := box.(*MoofBox)


### PR DESCRIPTION
The mp4.File.Mdat box will no longer point to an empty mdat box if there is a non-empty one.
Multiple non-empty mdat boxes will generate an error.

Resolves #371 