### PR TITLE
change: remove too specific functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow missing optional DecoderSpecificInfo
 
-- Nothing yet
+### Removed
+
+- Too specific functions DumpWithSampleData and Fragment.DumpSampleData
 
 ## [0.46.0] - 2024-08-08
 

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -355,7 +355,7 @@ func (f *File) startSegmentIfNeeded(b Box, boxStartPos uint64) {
 func (f *File) findAndReadMfra(r io.Reader) error {
 	rs, ok := r.(io.ReadSeeker)
 	if !ok {
-		return fmt.Errorf("expecting readseeker when decoding file ISM file")
+		return fmt.Errorf("expecting readseeker when decoding ISM file")
 	}
 	mfroSize := int64(16) // This is the fixed size of the mfro box
 	pos, err := rs.Seek(-mfroSize, io.SeekEnd)
@@ -405,45 +405,6 @@ func (f *File) AddSidx(sidx *SidxBox) {
 		f.Sidx = sidx
 	}
 	f.Sidxs = append(f.Sidxs, sidx)
-}
-
-// DumpWithSampleData - print information about file and its children boxes
-func (f *File) DumpWithSampleData(w io.Writer, specificBoxLevels string) error {
-	if f.isFragmented {
-		fmt.Printf("Init segment\n")
-		err := f.Init.Info(w, specificBoxLevels, "", "  ")
-		if err != nil {
-			return err
-		}
-		for i, seg := range f.Segments {
-			fmt.Printf("  mediaSegment %d\n", i)
-			for j, frag := range seg.Fragments {
-				fmt.Printf("  fragment %d\n ", j)
-				w, err := os.OpenFile("tmp.264", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-				if err != nil {
-					return err
-				}
-				err = frag.DumpSampleData(w, f.Init.Moov.Mvex.Trex)
-				if err != nil {
-					w.Close()
-					return err
-				}
-				w.Close()
-			}
-		}
-
-	} else {
-		err := f.Ftyp.Info(w, specificBoxLevels, "", "  ")
-		if err != nil {
-			return err
-		}
-		err = f.Moov.Info(w, specificBoxLevels, "", "  ")
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // Encode - encode a file to a Writer

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -257,28 +257,6 @@ func (f *Fragment) AddSampleToTrack(s Sample, trackID uint32, baseMediaDecodeTim
 	return nil
 }
 
-// DumpSampleData - Get Sample data and print out
-func (f *Fragment) DumpSampleData(w io.Writer, trex *TrexBox) error {
-	samples, err := f.GetFullSamples(trex)
-	if err != nil {
-		return err
-	}
-	for i, s := range samples {
-		if i < 9 {
-			fmt.Printf("%4d %8d %8d %6x %d %d\n", i, s.DecodeTime, s.PresentationTime(),
-				s.Flags, s.Size, len(s.Data))
-		}
-		toAnnexB(s.Data)
-		if w != nil {
-			_, err := w.Write(s.Data)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // Encode - write fragment via writer
 func (f *Fragment) Encode(w io.Writer) error {
 	if f.Moof == nil {

--- a/mp4/sample.go
+++ b/mp4/sample.go
@@ -1,7 +1,5 @@
 package mp4
 
-import "encoding/binary"
-
 // Sample - sample as used in trun box (mdhd timescale)
 type Sample struct {
 	Flags                 uint32 // interpreted as SampleFlags
@@ -40,18 +38,4 @@ func (s *FullSample) PresentationTime() uint64 {
 		p = 0 // Extraordinary case. Clip it to 0.
 	}
 	return uint64(p)
-}
-
-func toAnnexB(videoSample []byte) {
-	length := uint64(len(videoSample))
-	var pos uint64 = 0
-	for pos < length-4 {
-		lenSlice := videoSample[pos : pos+4]
-		nalLen := binary.BigEndian.Uint32(lenSlice)
-		videoSample[pos] = 0
-		videoSample[pos+1] = 0
-		videoSample[pos+2] = 0
-		videoSample[pos+3] = 1
-		pos += uint64(nalLen + 4)
-	}
 }


### PR DESCRIPTION
The two functions DumpWithSampleData and Fragment.DumpSampleData are too specific and should not have been part of the mp4ff repo.

No tests or programs used them.