### PR TITLE
Modify SEIG parsing to handle skip / crypt block byte.

### DIFF
--- a/mp4/samplegroupentries.go
+++ b/mp4/samplegroupentries.go
@@ -60,7 +60,7 @@ func DecodeSeigSampleGroupEntry(name string, length uint32, sr bits.SliceReader)
 	_ = sr.ReadUint8() // Reserved
 	byteTwo := sr.ReadUint8()
 	s.CryptByteBlock = byteTwo >> 4
-	s.SkipByteBlock = byteTwo % 0xf
+	s.SkipByteBlock = byteTwo & 0xf
 	s.IsProtected = sr.ReadUint8()
 	s.PerSampleIVSize = sr.ReadUint8()
 	s.KID = UUID(sr.ReadBytes(16))


### PR DESCRIPTION
Playground showcasing the parsing issue: https://go.dev/play/p/pJ_4OHqLP2R

Modulus operator on the second half of the byte lead to inaccurate values.

Fixes #381.