### PR TITLE
v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.47.0] - 2024-11-12
+
 ### Changed
 
 - CreatePrftBox now takes flags parameter
@@ -14,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed ReplaceChild method of StsdBox
 - CreateHdlr name for timed metadata
 - extension .m4s is interpreted as MP4 file in mp4ff-pslister
+- moved mp4.GetVersion() to internal.GetVersion()
 
 ### Added
 
@@ -661,7 +666,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.46.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.47.0...HEAD
+[0.47.0]: https://github.com/Eyevinn/mp4ff/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/Eyevinn/mp4ff/compare/v0.45.1...v0.46.0
 [0.45.1]: https://github.com/Eyevinn/mp4ff/compare/v0.45.0...v0.45.1
 [0.45.0]: https://github.com/Eyevinn/mp4ff/compare/v0.44.0...v0.45.0

--- a/cmd/mp4ff-crop/main.go
+++ b/cmd/mp4ff-crop/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/Eyevinn/mp4ff/internal"
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
@@ -62,7 +63,7 @@ func run(args []string, stdout io.Writer) error {
 	}
 
 	if o.version {
-		fmt.Fprintf(stdout, "%s %s\n", appName, mp4.GetVersion())
+		fmt.Fprintf(stdout, "%s %s\n", appName, internal.GetVersion())
 		return nil
 	}
 

--- a/cmd/mp4ff-decrypt/main.go
+++ b/cmd/mp4ff-decrypt/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Eyevinn/mp4ff/internal"
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
@@ -61,7 +62,7 @@ func run(args []string) error {
 	}
 
 	if opts.version {
-		fmt.Printf("%s %s\n", appName, mp4.GetVersion())
+		fmt.Printf("%s %s\n", appName, internal.GetVersion())
 		return nil
 	}
 

--- a/cmd/mp4ff-encrypt/main.go
+++ b/cmd/mp4ff-encrypt/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Eyevinn/mp4ff/internal"
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
@@ -72,7 +73,7 @@ func run(args []string) error {
 	}
 
 	if opts.version {
-		fmt.Printf("%s %s\n", appName, mp4.GetVersion())
+		fmt.Printf("%s %s\n", appName, internal.GetVersion())
 		return nil
 	}
 

--- a/cmd/mp4ff-info/main.go
+++ b/cmd/mp4ff-info/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Eyevinn/mp4ff/internal"
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
@@ -59,7 +60,7 @@ func run(args []string, w io.Writer) error {
 	}
 
 	if opts.version {
-		fmt.Printf("%s %s\n", appName, mp4.GetVersion())
+		fmt.Printf("%s %s\n", appName, internal.GetVersion())
 		return nil
 	}
 

--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Eyevinn/mp4ff/avc"
 	"github.com/Eyevinn/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/internal"
 	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/Eyevinn/mp4ff/sei"
 )
@@ -80,7 +81,7 @@ func run(args []string, stdout io.Writer) error {
 	}
 
 	if o.version {
-		fmt.Fprintf(stdout, "%s %s\n", appName, mp4.GetVersion())
+		fmt.Fprintf(stdout, "%s %s\n", appName, internal.GetVersion())
 		return nil
 	}
 

--- a/cmd/mp4ff-pslister/main.go
+++ b/cmd/mp4ff-pslister/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Eyevinn/mp4ff/avc"
 	"github.com/Eyevinn/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/internal"
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
@@ -75,7 +76,7 @@ func run(args []string, stdout io.Writer) error {
 	}
 
 	if o.version {
-		fmt.Fprintf(stdout, "%s %s\n", appName, mp4.GetVersion())
+		fmt.Fprintf(stdout, "%s %s\n", appName, internal.GetVersion())
 		return nil
 	}
 

--- a/cmd/mp4ff-subslister/main.go
+++ b/cmd/mp4ff-subslister/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Eyevinn/mp4ff/internal"
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
@@ -64,7 +65,7 @@ func run(args []string, stdout io.Writer) error {
 	}
 
 	if o.version {
-		fmt.Fprintf(stdout, "%s %s\n", appName, mp4.GetVersion())
+		fmt.Fprintf(stdout, "%s %s\n", appName, internal.GetVersion())
 		return nil
 	}
 

--- a/examples/add-sidx/main.go
+++ b/examples/add-sidx/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Eyevinn/mp4ff/internal"
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
@@ -67,7 +68,7 @@ func run(args []string, stdout io.Writer) error {
 	}
 
 	if o.version {
-		fmt.Fprintf(stdout, "%s %s\n", appName, mp4.GetVersion())
+		fmt.Fprintf(stdout, "%s %s\n", appName, internal.GetVersion())
 		return nil
 	}
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	commitVersion string = "v0.46"      // May be updated using build flags
+	commitVersion string = "v0.47"      // May be updated using build flags
 	commitDate    string = "1731409630" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,4 +1,4 @@
-package mp4
+package internal
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 
 var (
 	commitVersion string = "v0.46"      // May be updated using build flags
-	commitDate    string = "1723143113" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitDate    string = "1731409630" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func ExampleGetVersion() {
 	fmt.Println(GetVersion())
-	// Output: v0.46, date: 2024-11-12
+	// Output: v0.47, date: 2024-11-12
 }

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -1,8 +1,8 @@
-package mp4
+package internal
 
 import "fmt"
 
 func ExampleGetVersion() {
 	fmt.Println(GetVersion())
-	// Output: v0.46, date: 2024-08-08
+	// Output: v0.46, date: 2024-11-12
 }


### PR DESCRIPTION
### Changed

- CreatePrftBox now takes flags parameter
- PrftBox Info output
- Removed ReplaceChild method of StsdBox
- CreateHdlr name for timed metadata
- extension .m4s is interpreted as MP4 file in mp4ff-pslister
- moved mp4.GetVersion() to internal.GetVersion()

### Added

- NTP64 struct with methods to convert to time.Time
- Constants for PrftBox flags
- Unittest to all programs in [cmd](cmd) and [examples](examples).
- Documentation in doc.go files for all packages

### Fixed

- Allow missing optional DecoderSpecificInfo
- Avoid mp4.File.Mdat pointing to an empty mdat box
- `cmd/mp4ff-encrypt` did not parse command line
- `SeigSampleGroupEntry` calculated skipBytes incorrectly
- `cmd/mp4ff-pslister` did not parse annex B HEVC correctly
- error when decrypting and re-encrypting a segement (issue #378)