### PR TITLE
fix:  don't enforce minimal esds size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - mp4.SetUUID() can take base64 string as well as hex-encoded.
 
+### Fixed
+
+- support short ESDS without SLConfig descriptor (issue #393)
+
 ## [0.47.0] - 2024-11-12
 
 ### Changed

--- a/mp4/descriptors.go
+++ b/mp4/descriptors.go
@@ -20,8 +20,6 @@ const (
 	DecoderConfigDescrTag = 4
 	DecSpecificInfoTag    = 5
 	SLConfigDescrTag      = 6
-
-	minimalEsDescrSize = 25
 )
 
 func TagType(tag byte) string {

--- a/mp4/esds.go
+++ b/mp4/esds.go
@@ -42,9 +42,6 @@ func DecodeEsdsSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 		Version: version,
 		Flags:   versionAndFlags & flagsMask,
 	}
-	if hdr.Size < 12+minimalEsDescrSize {
-		return nil, fmt.Errorf("too few bytes in esds box")
-	}
 	descSize := uint32(hdr.Size - 12)
 	var err error
 	e.ESDescriptor, err = DecodeESDescriptor(sr, descSize)

--- a/mp4/esds_test.go
+++ b/mp4/esds_test.go
@@ -13,6 +13,7 @@ const (
 	esdsMp4Box   = `0000002a6573647300000000031c0000000414401500000000010d88000003f80505128856e500060102`
 	esdsEncAudio = `0000003365736473000000000380808022000000048080801440150018000003eb100002710005808080021190068080800102`
 	esdsLongEnd  = `0000002f65736473000000000321000000041140150002440001ea940001ea94050212100680808080808080800102`
+	esdsShort    = `0000002365736473000000000315000000040d6b150001e00002850000027100060102`
 )
 
 func TestEsdsEncodeAndDecode(t *testing.T) {
@@ -42,7 +43,7 @@ func TestEsdsEncodeAndDecode(t *testing.T) {
 	boxDiffAfterEncodeAndDecode(t, esdsIn)
 }
 func TestDecodeEncodeEsds(t *testing.T) {
-	inputs := []string{esdsProgIn, esdsMp4Box, esdsEncAudio, esdsLongEnd}
+	inputs := []string{esdsShort, esdsProgIn, esdsMp4Box, esdsEncAudio, esdsLongEnd}
 	for i, inp := range inputs {
 		data, err := hex.DecodeString(inp)
 		if err != nil {


### PR DESCRIPTION
Handle case when esds box is shorter because (the mandatory) SLConfig descriptor is not present.

Solves #393.