### PR TITLE
feat: support for weird dac3 reported in Issue #395

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - mp4.SetUUID() can take base64 string as well as hex-encoded.
+- Support for weird dac3 box with initial 4 zero bytes (Issue #395)
 
 ### Fixed
 

--- a/mp4/dac3_test.go
+++ b/mp4/dac3_test.go
@@ -8,8 +8,14 @@ import (
 )
 
 func TestEncodeDedodeAC3(t *testing.T) {
-	dac3 := &Dac3Box{FSCod: 1, BSID: 2, ACMod: 3, LFEOn: 1, BitRateCode: 7}
-	boxDiffAfterEncodeAndDecode(t, dac3)
+	t.Run("normal-dac3", func(t *testing.T) {
+		dac3 := &Dac3Box{FSCod: 1, BSID: 2, ACMod: 3, LFEOn: 1, BitRateCode: 7}
+		boxDiffAfterEncodeAndDecode(t, dac3)
+	})
+	t.Run("weird-dac3", func(t *testing.T) {
+		dac3 := &Dac3Box{FSCod: 1, BSID: 2, ACMod: 3, LFEOn: 1, BitRateCode: 7, InitialZeroes: 4}
+		boxDiffAfterEncodeAndDecode(t, dac3)
+	})
 }
 
 func TestGetChannelInfo(t *testing.T) {


### PR DESCRIPTION
The dac3 box reported in #395 has four zero-valued bytes at the start of the payload.
This is not aligned with the spec, but is now parsed and can be written again.

Solves #395.