### PR TITLE
fix: ensure mime box is large enough to read

### DIFF
--- a/mp4/mime.go
+++ b/mp4/mime.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/Eyevinn/mp4ff/bits"
@@ -30,6 +31,9 @@ func DecodeMimeSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 	b := MimeBox{
 		Version: byte(versionAndFlags >> 24),
 		Flags:   versionAndFlags & flagsMask,
+	}
+	if hdr.payloadLen() < 5 {
+		return nil, fmt.Errorf("mime: box payload size %d less than 5", hdr.payloadLen())
 	}
 	rest := sr.ReadBytes(hdr.payloadLen() - 4)
 	if rest[len(rest)-1] == 0 { // zero-termination

--- a/mp4/testdata/fuzz/FuzzDecodeBox/77cf6e30648805ea
+++ b/mp4/testdata/fuzz/FuzzDecodeBox/77cf6e30648805ea
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\x00\x00\x00\fmime0000")


### PR DESCRIPTION
Fix the panic found by fuzzing:

```
--- FAIL: FuzzDecodeBox (478.19s)
    --- FAIL: FuzzDecodeBox (0.00s)
        testing.go:1591: panic: runtime error: index out of range [-1]
            goroutine 4015806 [running]:
            runtime/debug.Stack()
            	/opt/homebrew/Cellar/go/1.23.1/libexec/src/runtime/debug/stack.go:26 +0xc4
            testing.tRunner.func1()
            	/opt/homebrew/Cellar/go/1.23.1/libexec/src/testing/testing.go:1591 +0x21c
            panic({0x1030bc1a0?, 0x1400a1521f8?})
            	/opt/homebrew/Cellar/go/1.23.1/libexec/src/runtime/panic.go:785 +0x124
            github.com/Eyevinn/mp4ff/mp4.DecodeMimeSR({{0x1400a68e9e0?, 0x1400a6a3f20?}, 0x1400a68e9e0?, 0x8?}, 0x14009e8c658?, {0x1030df818, 0x1400a68cd40})
            	/Users/eric/src/mp4ff/mp4/mime.go:35 +0x214
            github.com/Eyevinn/mp4ff/mp4.DecodeMime({{0x1400a68e9e0?, 0x140001207b0?}, 0x1400a68e9e0?, 0x4?}, 0x0, {0x1030d8da0?, 0x1400a6a3f20?})
            	/Users/eric/src/mp4ff/mp4/mime.go:24 +0x184
            github.com/Eyevinn/mp4ff/mp4.DecodeBox(0x0, {0x1030d8da0, 0x1400a6a3f20})
            	/Users/eric/src/mp4ff/mp4/box.go:315 +0x178
            github.com/Eyevinn/mp4ff/mp4.FuzzDecodeBox.func1(0x1400a6c29c0, {0x1400a112d80, 0xc, 0x10})
            	/Users/eric/src/mp4ff/mp4/fuzz_test.go:65 +0x14c
```