### PR TITLE
fix: ensure ssix box is large enough to read

### DIFF
--- a/mp4/ssix.go
+++ b/mp4/ssix.go
@@ -70,6 +70,9 @@ func DecodeSsixSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 		Version: version,
 		Flags:   versionAndFlags & flagsMask,
 	}
+	if hdr.Size < 16 {
+		return nil, fmt.Errorf("ssix: box is too small")
+	}
 	subSegmentCount := sr.ReadUint32()
 	sizeLeft := hdr.Size - 16
 	if subSegmentCount > uint32(sizeLeft/8) {

--- a/mp4/testdata/fuzz/FuzzDecodeBox/6041c517bf46e9ee
+++ b/mp4/testdata/fuzz/FuzzDecodeBox/6041c517bf46e9ee
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\x00\x00\x00\bssix\x00\x00\x00\x0100,\x00")


### PR DESCRIPTION
Fix the memory usage found from fuzzing:

```
github.com/Eyevinn/mp4ff/mp4.DecodeSsixSR
/Users/eric/src/mp4ff/mp4/ssix.go

  Total:     18.07GB    18.07GB (flat, cum) 99.76%
     73            .          .           	subSegmentCount := sr.ReadUint32() 
     74            .          .           	sizeLeft := hdr.Size - 16 
     75            .          .           	if subSegmentCount > uint32(sizeLeft/8) { 
     76            .          .           		return nil, fmt.Errorf("too many subsegments: %d", subSegmentCount) 
     77            .          .           	} 
     78      18.07GB    18.07GB           	b.SubSegments = make([]SubSegment, subSegmentCount) 
     79            .          .           	for i := 0; i < int(subSegmentCount); i++ { 
     80            .          .           		rangeCount := sr.ReadUint32() 
     81            .          .           		sizeLeft -= 4 
     82            .          .           		if rangeCount > uint32(sizeLeft/4) { 
     83            .          .           			return nil, fmt.Errorf("too many ranges: %d", rangeCount) 
```