### PR TITLE
Fixes to mp4 parsing

### DIFF
--- a/bits/fixedslicereader.go
+++ b/bits/fixedslicereader.go
@@ -1,6 +1,7 @@
 package bits
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -144,6 +145,22 @@ func (s *FixedSliceReader) ReadInt64() int64 {
 	return int64(res)
 }
 
+// ReadFloat64 - read float64 from slice
+func (s *FixedSliceReader) ReadFloat64() float64 {
+	if s.err != nil {
+		return 0
+	}
+	if s.pos > s.len-8 {
+		s.err = ErrSliceRead
+		return 0
+	}
+	buf := bytes.NewReader(s.slice[s.pos : s.pos+8])
+	var val float64
+	_ = binary.Read(buf, binary.BigEndian, &val)
+	s.pos += 8
+	return val
+}
+
 // ReadFixedLengthString - read string of specified length n.
 // Sets err and returns empty string if full length not available
 func (s *FixedSliceReader) ReadFixedLengthString(n int) string {
@@ -251,7 +268,7 @@ func (s *FixedSliceReader) SkipBytes(n int) {
 		return
 	}
 	if s.pos+n > s.Length() {
-		s.err = fmt.Errorf("attempt to skip bytes to pos %d beyond slice len %d", s.pos+n, s.len)
+		s.err = fmt.Errorf("attempt to skip %d bytes to pos %d beyond slice len %d", n, s.pos+n, s.len)
 		return
 	}
 	s.pos += n

--- a/bits/slicereader.go
+++ b/bits/slicereader.go
@@ -17,6 +17,7 @@ type SliceReader interface {
 	ReadInt32() int32
 	ReadUint64() uint64
 	ReadInt64() int64
+	ReadFloat64() float64
 	ReadFixedLengthString(n int) string
 	ReadZeroTerminatedString(maxLen int) string
 	ReadPossiblyZeroTerminatedString(maxLen int) (str string, ok bool)

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -235,17 +235,7 @@ LoopBoxes:
 				if lastBoxType != "moof" {
 					return nil, fmt.Errorf("does not support %v between moof and mdat", lastBoxType)
 				}
-			} else {
-				if f.Mdat != nil {
-					oldPayloadSize := f.Mdat.Size() - f.Mdat.HeaderSize()
-					newMdat := box.(*MdatBox)
-					newPayloadSize := newMdat.Size() - newMdat.HeaderSize()
-					if oldPayloadSize > 0 && newPayloadSize > 0 {
-						return nil, fmt.Errorf("only one non-empty mdat box supported (payload sizes %d and %d)",
-							oldPayloadSize, newPayloadSize)
-					}
-				}
-			}
+			} 
 		case "moof":
 			moof := box.(*MoofBox)
 			for _, traf := range moof.Trafs {

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -65,6 +65,7 @@ func init() {
 		"ipir":    DecodeTrefTypeSR,
 		"kind":    DecodeKindSR,
 		"leva":    DecodeLevaSR,
+		"lpcm":    DecodeAudioSampleEntrySR,
 		"ludt":    DecodeLudtSR,
 		"mdat":    DecodeMdatSR,
 		"mehd":    DecodeMehdSR,

--- a/mp4/elst.go
+++ b/mp4/elst.go
@@ -66,6 +66,7 @@ func DecodeElstSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 	} else {
 		return nil, fmt.Errorf("unknown version for elst")
 	}
+
 	return b, sr.AccError()
 }
 

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -254,7 +254,15 @@ func (f *File) AddChild(child Box, boxStartPos uint64) {
 		f.Ftyp = box
 	case *MoovBox:
 		f.Moov = box
-		if len(f.Moov.Trak.Mdia.Minf.Stbl.Stts.SampleCount) == 0 {
+		// If moov is otherwise-well-formed but contains no samples, build an init box
+		// based on it
+		if f.Moov.Trak != nil &&
+			f.Moov.Trak.Mdia != nil &&
+			f.Moov.Trak.Mdia.Minf != nil &&
+			f.Moov.Trak.Mdia.Minf.Stbl != nil &&
+			f.Moov.Trak.Mdia.Minf.Stbl.Stts != nil &&
+			len(f.Moov.Trak.Mdia.Minf.Stbl.Stts.SampleCount) == 0 {
+
 			f.isFragmented = true
 			f.Init = NewMP4Init()
 			f.Init.AddChild(f.Ftyp)

--- a/mp4/sgpd.go
+++ b/mp4/sgpd.go
@@ -53,7 +53,8 @@ func DecodeSgpdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 			descriptionLength = sr.ReadUint32()
 			b.DescriptionLengths = append(b.DescriptionLengths, descriptionLength)
 		}
-		if descriptionLength == 0 {
+		if descriptionLength == 0  && i > 0 {
+			// We allow a single zero-length entry as seen in some files with a GroupingType of 'tsas'
 			return nil, fmt.Errorf("sgpd: invalid descriptionLength of 0")
 		}
 		sgEntry, err := decodeSampleGroupEntry(b.GroupingType, descriptionLength, sr)

--- a/mp4/stsd.go
+++ b/mp4/stsd.go
@@ -28,6 +28,8 @@ type StsdBox struct {
 	VpXX *VisualSampleEntryBox
 	// Mp4a is a pointer to a box with name mp4a
 	Mp4a *AudioSampleEntryBox
+	// Lpcm is a pointer to to a box with name lpcm
+	Lpcm *AudioSampleEntryBox
 	// AC3 is a pointer to a box with name ac-3
 	AC3 *AudioSampleEntryBox
 	// EC3 is a pointer to a box with name ec-3
@@ -63,6 +65,8 @@ func (s *StsdBox) AddChild(box Box) {
 		s.VpXX = box.(*VisualSampleEntryBox)
 	case "mp4a":
 		s.Mp4a = box.(*AudioSampleEntryBox)
+	case "lpcm":
+		s.Lpcm = box.(*AudioSampleEntryBox)
 	case "ac-3":
 		s.AC3 = box.(*AudioSampleEntryBox)
 	case "ec-3":


### PR DESCRIPTION
Two fixes (separate commits):
 - Handle trailing four-byte terminator in VisualSampleEntryBox
 - Handle quicktime-style AudioSampleEntryBox variants (and add 'lcpm' handling)