### PR TITLE
V0.48.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.24
       - name: Checkout
         uses: actions/checkout@v4
       - run: go test -v -coverprofile=profile.cov ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: ["1.16", "1.22"]
+        go-version: ["1.16", "1.24"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### New
+- Nothing yet
 
-* UUID
-* Mdat
+## [0.48.0] - 2025-03-28
 
 ### Changed
 
 - mp4.NewUUIDFromHex() changed to more general mp4.NewUUIDFromString()
 - cmd/mp4ff-decrypt -key option instead of -k. Takes hex or base64 value
-- cmd/mp4ff-encrypt -key and -kid options now take hex or bae64 values
+- cmd/mp4ff-encrypt -key and -kid options now take hex or base64 values
 - Replaced mp4.AlouBox and mp4.TlouBox with a common mp4.LoudnessBaseBox
 - mp4.Measurement changed to clearer mp4.LoudnessMeasurement
 
@@ -32,14 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exported constants for ColrBox's ColorType
 - mp4.NewFreeBox, mp4.NewSkipBox functions
 - mp4.FreeBox.Payload method
-- New mp4.SencBox methods: SetPerSampleIVSize, PerSampleIVSize, and ReadButNotParsed
-- New function mp4.CreateUnknownBox
-- New functions mp4.NewTfrfBox and mp4.NewTfxdBox
+- mp4.SencBox methods: SetPerSampleIVSize, PerSampleIVSize, and ReadButNotParsed
+- Function mp4.CreateUnknownBox
+- Functions mp4.NewTfrfBox and mp4.NewTfxdBox
+- HEVC (hvc1) encryption
+- AppendProtectRange function is now public
 
 ### Fixed
 
-- support short ESDS without SLConfig descriptor (issue #393)
+- Support short ESDS without SLConfig descriptor (issue #393)
 - HEVC Slice Header CollocatedFromL0Flag should be true by default
+- Update to golangci-lint/v2 and fixed all warnings
 
 ## [0.47.0] - 2024-11-12
 
@@ -698,7 +700,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.47.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.48.0...HEAD
+[0.48.0]: https://github.com/Eyevinn/mp4ff/compare/v0.47.0...v0.48.0
 [0.47.0]: https://github.com/Eyevinn/mp4ff/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/Eyevinn/mp4ff/compare/v0.45.1...v0.46.0
 [0.45.1]: https://github.com/Eyevinn/mp4ff/compare/v0.45.0...v0.45.1

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.47"      // May be updated using build flags
-	commitDate    string = "1731409630" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.48"      // May be updated using build flags
+	commitDate    string = "1743178574" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func ExampleGetVersion() {
 	fmt.Println(GetVersion())
-	// Output: v0.47, date: 2024-11-12
+	// Output: v0.48, date: 2025-03-28
 }


### PR DESCRIPTION
### Changed

- mp4.NewUUIDFromHex() changed to more general mp4.NewUUIDFromString()
- cmd/mp4ff-decrypt -key option instead of -k. Takes hex or base64 value
- cmd/mp4ff-encrypt -key and -kid options now take hex or base64 values
- Replaced mp4.AlouBox and mp4.TlouBox with a common mp4.LoudnessBaseBox
- mp4.Measurement changed to clearer mp4.LoudnessMeasurement

### Added

- mp4.SetUUID() can take base64 string as well as hex-encoded.
- Support for weird dac3 box with initial 4 zero bytes (Issue #395)
- Lots of fuzzying tests and changes to avoid panic on bad input data
- Support for SMPTE-2086 Mastering Display Metadata Box (SmDm)
- Support for Content Light Level Box (CoLL)
- Better test coverage for VisualSampleEntryBox
- IsVideoNaluType functions in both avc and hevc packages
- Exported constants for ColrBox's ColorType
- mp4.NewFreeBox, mp4.NewSkipBox functions
- mp4.FreeBox.Payload method
- mp4.SencBox methods: SetPerSampleIVSize, PerSampleIVSize, and ReadButNotParsed
- Function mp4.CreateUnknownBox
- Functions mp4.NewTfrfBox and mp4.NewTfxdBox
- HEVC (hvc1) encryption
- AppendProtectRange function is now public

### Fixed

- Support short ESDS without SLConfig descriptor (issue #393)
- HEVC Slice Header CollocatedFromL0Flag should be true by default
- Update to golangci-lint/v2 and fixed all warnings