### PR TITLE
feat: export TFHD flag constants for external use

### DIFF
--- a/mp4/tfhd.go
+++ b/mp4/tfhd.go
@@ -6,13 +6,13 @@ import (
 	"github.com/Eyevinn/mp4ff/bits"
 )
 
-const baseDataOffsetPresent uint32 = 0x000001
-const sampleDescriptionIndexPresent uint32 = 0x000002
-const defaultSampleDurationPresent uint32 = 0x000008
-const defaultSampleSizePresent uint32 = 0x000010
-const defaultSampleFlagsPresent uint32 = 0x000020
-const durationIsEmpty uint32 = 0x010000
-const defaultBaseIsMoof uint32 = 0x020000
+const TfhdBaseDataOffsetPresentFlag uint32 = 0x000001
+const TfhdSampleDescriptionIndexPresentFlag uint32 = 0x000002
+const TfhdDefaultSampleDurationPresentFlag uint32 = 0x000008
+const TfhdDefaultSampleSizePresentFlag uint32 = 0x000010
+const TfhdDefaultSampleFlagsPresentFlag uint32 = 0x000020
+const TfhdDurationIsEmptyFlag uint32 = 0x010000
+const TfhdDefaultBaseIsMoofFlag uint32 = 0x020000
 
 // TfhdBox - Track Fragment Header Box (tfhd)
 //
@@ -75,7 +75,7 @@ func CreateTfhd(trackID uint32) *TfhdBox {
 	// The only flag set is defaultBaseIsMoof
 	tfhd := &TfhdBox{
 		Version:                0,
-		Flags:                  defaultBaseIsMoof,
+		Flags:                  TfhdDefaultBaseIsMoofFlag,
 		TrackID:                trackID,
 		BaseDataOffset:         0,
 		SampleDescriptionIndex: 1,
@@ -88,37 +88,37 @@ func CreateTfhd(trackID uint32) *TfhdBox {
 
 // HasBaseDataOffset - interpreted flags value
 func (t *TfhdBox) HasBaseDataOffset() bool {
-	return t.Flags&baseDataOffsetPresent != 0
+	return t.Flags&TfhdBaseDataOffsetPresentFlag != 0
 }
 
 // HasSampleDescriptionIndex - interpreted flags value
 func (t *TfhdBox) HasSampleDescriptionIndex() bool {
-	return t.Flags&sampleDescriptionIndexPresent != 0
+	return t.Flags&TfhdSampleDescriptionIndexPresentFlag != 0
 }
 
 // HasDefaultSampleDuration - interpreted flags value
 func (t *TfhdBox) HasDefaultSampleDuration() bool {
-	return t.Flags&defaultSampleDurationPresent != 0
+	return t.Flags&TfhdDefaultSampleDurationPresentFlag != 0
 }
 
 // HasDefaultSampleSize - interpreted flags value
 func (t *TfhdBox) HasDefaultSampleSize() bool {
-	return t.Flags&defaultSampleSizePresent != 0
+	return t.Flags&TfhdDefaultSampleSizePresentFlag != 0
 }
 
 // HasDefaultSampleFlags - interpreted flags value
 func (t *TfhdBox) HasDefaultSampleFlags() bool {
-	return t.Flags&defaultSampleFlagsPresent != 0
+	return t.Flags&TfhdDefaultSampleFlagsPresentFlag != 0
 }
 
 // DurationIsEmpty - interpreted flags value
 func (t *TfhdBox) DurationIsEmpty() bool {
-	return t.Flags&durationIsEmpty != 0
+	return t.Flags&TfhdDurationIsEmptyFlag != 0
 }
 
 // DefaultBaseIfMoof - interpreted flags value
 func (t *TfhdBox) DefaultBaseIfMoof() bool {
-	return t.Flags&defaultBaseIsMoof != 0
+	return t.Flags&TfhdDefaultBaseIsMoofFlag != 0
 }
 
 // Type - returns box type
@@ -190,7 +190,7 @@ func (t *TfhdBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 	bd := newInfoDumper(w, indent, t, int(t.Version), t.Flags)
 	bd.write(" - trackID: %d", t.TrackID)
 
-	if t.Flags&defaultBaseIsMoof != 0 {
+	if t.Flags&TfhdDefaultBaseIsMoofFlag != 0 {
 		bd.write(" - defaultBaseIsMoof: true")
 	}
 

--- a/mp4/traf.go
+++ b/mp4/traf.go
@@ -202,7 +202,7 @@ func (t *TrafBox) OptimizeTfhdTrun() error {
 		}
 		if hasCommonDur {
 			// Set defaultSampleDuration in tfhd and remove from trun
-			tfhd.Flags = tfhd.Flags | defaultSampleDurationPresent
+			tfhd.Flags = tfhd.Flags | TfhdDefaultSampleDurationPresentFlag
 			tfhd.DefaultSampleDuration = commonDur
 			trun.Flags = trun.Flags & ^TrunSampleDurationPresentFlag
 		}
@@ -219,7 +219,7 @@ func (t *TrafBox) OptimizeTfhdTrun() error {
 		}
 		if hasCommonSize {
 			// Set defaultSampleSize in tfhd and remove from trun
-			tfhd.Flags = tfhd.Flags | defaultSampleSizePresent
+			tfhd.Flags = tfhd.Flags | TfhdDefaultSampleSizePresentFlag
 			tfhd.DefaultSampleSize = commonSize
 			trun.Flags = trun.Flags & ^TrunSampleSizePresentFlag
 		}
@@ -241,7 +241,7 @@ func (t *TrafBox) OptimizeTfhdTrun() error {
 			if firstSampleFlags != commonSampleFlags {
 				trun.SetFirstSampleFlags(firstSampleFlags)
 			}
-			tfhd.Flags = tfhd.Flags | defaultSampleFlagsPresent
+			tfhd.Flags = tfhd.Flags | TfhdDefaultSampleFlagsPresentFlag
 			tfhd.DefaultSampleFlags = commonSampleFlags
 			trun.Flags = trun.Flags & ^TrunSampleFlagsPresentFlag
 		}


### PR DESCRIPTION
Hey,

I wanted to use these constants when I noticed they aren't actually exposed. This PR aims to export them in a similar manner like how it was done in trun's case:

https://github.com/Eyevinn/mp4ff/blob/5e414b1f5b54ef5147fe4c039df0b81975b98de2/mp4/trun.go#L22-L27

I wonder if there is a reason for these to be local in the first place.

PS: I hope the CI will let it pass without adding more test coverage as there isn't much to add here for extra testing. :relaxed: 