### PR TITLE
Added skip bytes support to AVCDecoderConfigurationRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - mp4.SetUUID() can take base64 string as well as hex-encoded.
-- Support for weird dac3 box with initial 4 zero bytes (Issue #395)
+- Support for weird dac3 box with initial 4 zero bytes (#395)
 - Lots of fuzzying tests and changes to avoid panic on bad input data
 - Support for SMPTE-2086 Mastering Display Metadata Box (SmDm)
 - Support for Content Light Level Box (CoLL)
@@ -38,12 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Functions mp4.NewTfrfBox and mp4.NewTfxdBox
 - HEVC (hvc1) encryption
 - AppendProtectRange function is now public
+- Tfhd bit masks are now public (#423)
+- Skip bytes support for AVCDecoderConfigurationRecord (#420)
 
 ### Fixed
 
 - Support short ESDS without SLConfig descriptor (issue #393)
 - HEVC Slice Header CollocatedFromL0Flag should be true by default
 - Update to golangci-lint/v2 and fixed all warnings
+- Remove more boxes when decrypting files (pr #424)
 
 ## [0.47.0] - 2024-11-12
 

--- a/avc/avcdecoderconfig_test.go
+++ b/avc/avcdecoderconfig_test.go
@@ -49,6 +49,7 @@ func TestAvcDecoderConfigRecord(t *testing.T) {
 }
 
 func TestAvcDecoderConfigRecordWithExtraBytes(t *testing.T) {
+	//nolint: lll
 	byteData, _ := hex.DecodeString("014d4029ffe10026674d40299e5281e022fde028404040500000030010000003032e04000ea6000057e43f13e0a001000468ef752000")
 	spsBytes, _ := hex.DecodeString("674d40299e5281e022fde028404040500000030010000003032e04000ea6000057e43f13e0a0")
 	ppsBytes, _ := hex.DecodeString("68ef7520")
@@ -86,6 +87,7 @@ func TestAvcDecoderConfigRecordWithExtraBytes(t *testing.T) {
 }
 
 func TestAvcDecoderConfigRecordWithExtraBytesProfileHigh(t *testing.T) {
+	//nolint: lll
 	byteData, _ := hex.DecodeString("01640029ffe1002667640029ac3ca5014016ec050808080a00000300020000030065c0c000b71a00022551f89f0501000468ef752500")
 	spsBytes, _ := hex.DecodeString("67640029ac3ca5014016ec050808080a00000300020000030065c0c000b71a00022551f89f05")
 	ppsBytes, _ := hex.DecodeString("68ef7525")

--- a/avc/avcdecoderconfig_test.go
+++ b/avc/avcdecoderconfig_test.go
@@ -48,6 +48,80 @@ func TestAvcDecoderConfigRecord(t *testing.T) {
 	}
 }
 
+func TestAvcDecoderConfigRecordWithExtraBytes(t *testing.T) {
+	byteData, _ := hex.DecodeString("014d4029ffe10026674d40299e5281e022fde028404040500000030010000003032e04000ea6000057e43f13e0a001000468ef752000")
+	spsBytes, _ := hex.DecodeString("674d40299e5281e022fde028404040500000030010000003032e04000ea6000057e43f13e0a0")
+	ppsBytes, _ := hex.DecodeString("68ef7520")
+
+	wanted := DecConfRec{
+		AVCProfileIndication: 77,
+		ProfileCompatibility: 64,
+		AVCLevelIndication:   41,
+		SPSnalus:             [][]byte{spsBytes},
+		PPSnalus:             [][]byte{ppsBytes},
+		ChromaFormat:         0,
+		BitDepthLumaMinus1:   0,
+		BitDepthChromaMinus1: 0,
+		NumSPSExt:            0,
+		NoTrailingInfo:       true,
+		SkipBytes:            1,
+	}
+
+	got, err := DecodeAVCDecConfRec(byteData)
+	if err != nil {
+		t.Error("Error parsing AVCDecoderConfigurationRecord")
+	}
+	if diff := deep.Equal(got, wanted); diff != nil {
+		t.Error(diff)
+	}
+
+	enc := bytes.Buffer{}
+	err = got.Encode(&enc)
+	if err != nil {
+		t.Error("Error encoding AVCDecoderConfigurationRecord")
+	}
+	if !bytes.Equal(enc.Bytes(), byteData) {
+		t.Error("Error encoding AVCDecoderConfigurationRecord")
+	}
+}
+
+func TestAvcDecoderConfigRecordWithExtraBytesProfileHigh(t *testing.T) {
+	byteData, _ := hex.DecodeString("01640029ffe1002667640029ac3ca5014016ec050808080a00000300020000030065c0c000b71a00022551f89f0501000468ef752500")
+	spsBytes, _ := hex.DecodeString("67640029ac3ca5014016ec050808080a00000300020000030065c0c000b71a00022551f89f05")
+	ppsBytes, _ := hex.DecodeString("68ef7525")
+
+	wanted := DecConfRec{
+		AVCProfileIndication: 100,
+		ProfileCompatibility: 0,
+		AVCLevelIndication:   41,
+		SPSnalus:             [][]byte{spsBytes},
+		PPSnalus:             [][]byte{ppsBytes},
+		ChromaFormat:         0,
+		BitDepthLumaMinus1:   0,
+		BitDepthChromaMinus1: 0,
+		NumSPSExt:            0,
+		NoTrailingInfo:       true,
+		SkipBytes:            1,
+	}
+
+	got, err := DecodeAVCDecConfRec(byteData)
+	if err != nil {
+		t.Error("Error parsing AVCDecoderConfigurationRecord")
+	}
+	if diff := deep.Equal(got, wanted); diff != nil {
+		t.Error(diff)
+	}
+
+	enc := bytes.Buffer{}
+	err = got.Encode(&enc)
+	if err != nil {
+		t.Error("Error encoding AVCDecoderConfigurationRecord")
+	}
+	if !bytes.Equal(enc.Bytes(), byteData) {
+		t.Error("Error encoding AVCDecoderConfigurationRecord")
+	}
+}
+
 func TestCreateAVCDecConfRec(t *testing.T) {
 	data, err := os.ReadFile("testdata/blackframe.264")
 	if err != nil {


### PR DESCRIPTION
Replaces #420 with linter fixes and CHANGELOG update