### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cmd/mp4ff-encrypt` did not parse command line
 - `SeigSampleGroupEntry` calculated skipBytes incorrectly
 - `cmd/mp4ff-pslister` did not parse annex B HEVC correctly
-- error when decrypting and re-encrypting a segement (issue #378)
+- error when decrypting and re-encrypting a segment (issue #378)
 
 ### Removed
 
@@ -154,7 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - support for ssix box
 - support for leva box
-- details of descriptors as Info outout (mp4ff-info)
+- details of descriptors as Info output (mp4ff-info)
 
 ## [0.44.0] - 2024-04-19
 
@@ -175,7 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More robust check for mfro at the end of file
 - GetTrex() return value
 - Can now write PIFF `uuid` box that has previously been read
-- Does now avoid the second parsing of `senc` box if the file is ot encrypted as seen in moov box.
+- Does now avoid the second parsing of `senc` box if the file is to encrypted as seen in moov box.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Most boxes have their own file named after the box, but in some cases, there may
 that have the same content, and the code file then has a generic name like
 `mp4/visualsampleentry.go`.
 
-There is an interface for boxes: `Box` specificied in `mp4.box.go`,
+There is an interface for boxes: `Box` specified in `mp4.box.go`,
 
 The interfaces define common Box methods including encode (writing),
 but not the decode (parsing) methods which have distinct names for each box type and are
@@ -314,7 +314,7 @@ dispatched from the parsed box name.
 That dispatch based on box name is defined by the tables `mp4.decodersSR` and `mp4.decoders`
 for the functions `mp4.DecodeBoxSR()` and `mp4.DecodeBox()`, respectively.
 The `SR` variant should normally be used for better performance.
-If a box name is unkonwn, it will result in an `UnknownBox` being created.
+If a box name is unknown, it will result in an `UnknownBox` being created.
 
 ### How to implement a new box
 

--- a/bits/ebspreader.go
+++ b/bits/ebspreader.go
@@ -164,7 +164,7 @@ func (r *EBSPReader) ReadSignedGolomb() int {
 	return -int(unsignedGolomb / 2)
 }
 
-// IsSeeker returns tru if underluing reader supports Seek interface.
+// IsSeeker returns true if underluing reader supports Seek interface.
 func (r *EBSPReader) IsSeeker() bool {
 	_, ok := r.rd.(io.ReadSeeker)
 	return ok
@@ -191,7 +191,7 @@ func (r *EBSPReader) MoreRbspData() (bool, error) {
 		}
 		return true, nil
 	}
-	// If all remainging bits are zero, there is no more rbsp data
+	// If all remaining bits are zero, there is no more rbsp data
 	more := false
 	for {
 		b := r.Read(1)

--- a/bits/ebspreader_test.go
+++ b/bits/ebspreader_test.go
@@ -309,7 +309,7 @@ func TestEBSPReader(t *testing.T) {
 			})
 		}
 	})
-	t.Run("read traling RBSP bits", func(t *testing.T) {
+	t.Run("read trailing RBSP bits", func(t *testing.T) {
 		input := []byte{0b10000000}
 		brd := bytes.NewReader(input)
 		r := bits.NewEBSPReader(brd)
@@ -327,7 +327,7 @@ func TestEBSPReader(t *testing.T) {
 		brd := bytes.NewReader(input)
 		r := bits.NewEBSPReader(brd)
 		r.SetError(io.ErrUnexpectedEOF)
-		// Read shold never result in panic
+		// Read should never result in panic
 		// Error should be preservedd
 		_ = r.Read(100)
 		if r.AccError() != io.ErrUnexpectedEOF {

--- a/bits/fixedslicewriter.go
+++ b/bits/fixedslicewriter.go
@@ -56,7 +56,7 @@ func (sw *FixedSliceWriter) Bytes() []byte {
 	return sw.buf[:sw.off]
 }
 
-// AccError - return accumulated erro
+// AccError - return accumulated error
 func (sw *FixedSliceWriter) AccError() error {
 	return sw.accError
 }

--- a/examples/combine-segs/doc.go
+++ b/examples/combine-segs/doc.go
@@ -12,7 +12,7 @@ Note that they should start at 1 according to the file format specification.
 
 In principle, the `trex` box data from the init segment may be needed when
 generating media segments since that may contain default values. In practice,
-for this specific case of just transfering tracks, it should work without
+for this specific case of just transferring tracks, it should work without
 propagating the `trex` data.
 
 The data is written to the combined `mdat` box track by track, so that there

--- a/examples/segmenter/segmenter.go
+++ b/examples/segmenter/segmenter.go
@@ -39,7 +39,7 @@ func NewSegmenter(inFile *mp4.File) (*Segmenter, error) {
 		case "soun":
 			track.trackType = "audio"
 		default:
-			return nil, fmt.Errorf("hdlr typpe %q not supported", hdlrType)
+			return nil, fmt.Errorf("hdlr type %q not supported", hdlrType)
 		}
 		track.lang = trak.Mdia.Mdhd.GetLanguage()
 		if trak.Mdia.Elng != nil {

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -11,7 +11,7 @@ import (
 const (
 	// boxHeaderSize - standard size + name header
 	boxHeaderSize = 8
-	largeSizeLen  = 8          // Length of largesize exension
+	largeSizeLen  = 8          // Length of largesize extension
 	flagsMask     = 0x00ffffff // Flags for masks from full header
 )
 

--- a/mp4/crypto_test.go
+++ b/mp4/crypto_test.go
@@ -161,7 +161,7 @@ func TestEncryptDecrypt(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// Write init segment with encyption info
+			// Write init segment with encryption info
 			encInitBuf := bytes.Buffer{}
 			err = init.Encode(&encInitBuf)
 			if err != nil {

--- a/mp4/descriptors.go
+++ b/mp4/descriptors.go
@@ -44,7 +44,7 @@ func TagType(tag byte) string {
 type Descriptor interface {
 	// Tag - descriptor tag. Fixed for each descriptor type
 	Tag() byte
-	// Type is string describing Tag, making descriptor fullfill boxLike interface
+	// Type is string describing Tag, making descriptor fulfill boxLike interface
 	Type() string
 	// Size - size of descriptor, excluding tag byte and size field
 	Size() uint64
@@ -102,7 +102,7 @@ type ESDescriptor struct {
 	DecConfigDescriptor *DecoderConfigDescriptor
 	SLConfigDescriptor  *SLConfigDescriptor
 	OtherDescriptors    []Descriptor
-	UnknownData         []byte // Data, probably erronous, that we don't understand
+	UnknownData         []byte // Data, probably erroneous, that we don't understand
 }
 
 func DecodeDescriptor(sr bits.SliceReader, maxNrBytes int) (Descriptor, error) {
@@ -348,7 +348,7 @@ type DecoderConfigDescriptor struct {
 	AvgBitrate          uint32
 	DecSpecificInfo     *DecSpecificInfoDescriptor
 	OtherDescriptors    []Descriptor
-	UnknownData         []byte // Data, probably erronous, that we don't understand
+	UnknownData         []byte // Data, probably erroneous, that we don't understand
 }
 
 func exceedsMaxNrBytes(sizeFieldSizeMinus1 byte, size uint64, maxNrBytes int) bool {
@@ -678,7 +678,7 @@ func (d *RawDescriptor) Info(w io.Writer, specificLevels, indent, indentStep str
 	return bd.err
 }
 
-// CreateESDescriptor creats an ESDescriptor with a DecoderConfigDescriptor for audio.
+// CreateESDescriptor creates an ESDescriptor with a DecoderConfigDescriptor for audio.
 func CreateESDescriptor(decConfig []byte) ESDescriptor {
 	e := ESDescriptor{
 		EsID: 0x01,

--- a/mp4/doc.go
+++ b/mp4/doc.go
@@ -155,7 +155,7 @@ dispatched from the parsed box name.
 That dispatch based on box name is defined by the tables "mp4.decodersSR" and "mp4.decoders"
 for the functions "mp4.DecodeBoxSR" and "mp4.DecodeBox", respectively.
 The "SR" variant that uses [bits/SliceReader] should normally be used for better performance.
-If a box name is unkonwn, it will result in an [mp4.UnknownBox] being created.
+If a box name is unknown, it will result in an [mp4.UnknownBox] being created.
 
 # How to implement a new box
 

--- a/mp4/elng.go
+++ b/mp4/elng.go
@@ -9,9 +9,9 @@ import (
 
 // ElngBox - Extended Language Box
 // Defined in ISO/IEC 14496-12 Section 8.4.6
-// It should be a full box, but was erronously implemented
+// It should be a full box, but was erroneously implemented
 // as a normal box. For backwards compatibility, the
-// erronous box without full header can still be decoded.
+// erroneous box without full header can still be decoded.
 // The method MissingFullBoxBytes() returns true if that is the case.
 type ElngBox struct {
 	missingFullBox bool
@@ -20,7 +20,7 @@ type ElngBox struct {
 	Language       string
 }
 
-// MissingFullBoxBytes indicates that the box is errornously not including the 4 full box header bytes
+// MissingFullBoxBytes indicates that the box is erroneously not including the 4 full box header bytes
 func (b *ElngBox) MissingFullBoxBytes() bool {
 	return b.missingFullBox
 }

--- a/mp4/elng_test.go
+++ b/mp4/elng_test.go
@@ -13,7 +13,7 @@ func TestDecodeElng(t *testing.T) {
 	boxDiffAfterEncodeAndDecode(t, elng)
 }
 
-// TestElngWithoutFullBox tests erronous case where full box headers are not present.
+// TestElngWithoutFullBox tests erroneous case where full box headers are not present.
 func TestElngWithoutFullBox(t *testing.T) {
 	data := []byte("\x00\x00\x00\x0belngdk\x00")
 	bufIn := bytes.NewBuffer(data)

--- a/mp4/infodumper.go
+++ b/mp4/infodumper.go
@@ -61,7 +61,7 @@ func newInfoDumper(w io.Writer, indent string, b boxLike, version int, flags uin
 	return &bd
 }
 
-// write - write formated objecds if level <= bd.level
+// write - write formatted objecds if level <= bd.level
 func (b *infoDumper) write(format string, p ...interface{}) {
 	if b.err != nil {
 		return

--- a/mp4/initsegment_test.go
+++ b/mp4/initsegment_test.go
@@ -52,7 +52,7 @@ func TestInitSegmentParsing(t *testing.T) {
 	wanted := byte(31)
 	got := avcC.AVCLevelIndication
 	if got != wanted {
-		t.Errorf("Got level %d insted of %d", got, wanted)
+		t.Errorf("Got level %d instead of %d", got, wanted)
 	}
 
 }
@@ -74,7 +74,7 @@ func TestMoovParsingWithBtrt(t *testing.T) {
 	wanted := byte(31)
 	got := avcC.AVCLevelIndication
 	if got != wanted {
-		t.Errorf("Got level %d insted of %d", got, wanted)
+		t.Errorf("Got level %d instead of %d", got, wanted)
 	}
 
 	btrt := avcx.Btrt

--- a/mp4/pssh.go
+++ b/mp4/pssh.go
@@ -40,7 +40,7 @@ func ProtectionSystemName(systemID UUID) string {
 }
 
 // PsshBox - Protection System Specific Header Box
-// Defined in ISO/IEC 23001-7 Secion 8.1
+// Defined in ISO/IEC 23001-7 Section 8.1
 type PsshBox struct {
 	Version  byte
 	Flags    uint32

--- a/mp4/saiz.go
+++ b/mp4/saiz.go
@@ -64,7 +64,7 @@ func NewSaizBox(capacity int) *SaizBox {
 }
 
 // AddSampleInfo adds a sampleinfo info based on parameters provided.
-// If no length field, don't update the sample field (typicall audio cbcs)
+// If no length field, don't update the sample field (typically audio cbcs)
 func (b *SaizBox) AddSampleInfo(iv []byte, subsamplePatterns []SubSamplePattern) {
 	size := len(iv)
 	if len(subsamplePatterns) > 0 {

--- a/mp4/stsc.go
+++ b/mp4/stsc.go
@@ -17,7 +17,7 @@ import (
 //   - sample description id : description (see the sample description box - stsd)
 //     this value is most often the same for all samples, so it is stored as a single value if possible.
 //
-// FirstSampleNr is a helper value for fast lookup. Somthing that is often a bottleneck.
+// FirstSampleNr is a helper value for fast lookup. Something that is often a bottleneck.
 type StscBox struct {
 	Version                   byte
 	Flags                     uint32

--- a/mp4/tenc.go
+++ b/mp4/tenc.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TencBox - Track Encryption Box
-// Defined in ISO/IEC 23001-7 Secion 8.2
+// Defined in ISO/IEC 23001-7 Section 8.2
 type TencBox struct {
 	Version                byte
 	Flags                  uint32

--- a/mp4/traf.go
+++ b/mp4/traf.go
@@ -88,7 +88,7 @@ func (t *TrafBox) ParseReadSenc(defaultIVSize byte, moofStartPos uint64) error {
 		// saio should be present, but we try without it, if it doesn't exist
 		posFromSaio := t.Saio.Offset[0] + int64(moofStartPos)
 		if uint64(posFromSaio) != senc.StartPos+16 {
-			//TODO. Reenable
+			//TODO. Re-enable
 			return fmt.Errorf("offset from saio (%d) relative moof start differs from senc data start %d", posFromSaio, senc.StartPos+16)
 			//fmt.Printf("offset from saio (%d) and moof differs from senc data start %d\n", posFromSaio, senc.StartPos+16)
 

--- a/mp4/vppc_test.go
+++ b/mp4/vppc_test.go
@@ -43,7 +43,7 @@ func TestVppC(t *testing.T) {
 		t.Errorf("Expected error msg: %q", errMsg)
 	}
 
-	// Check that there is an error if the CodecInitSize is not compatible withthe box size.
+	// Check that there is an error if the CodecInitSize is not compatible with the box size.
 	copy(raw, data)
 	raw[19] = 2
 	assertBoxDecodeError(t, raw, 0, "decode vpcC pos 0: incorrect box size")


### PR DESCRIPTION
Found via `codespell -S ./mp4/testdata -L trun,te,truns,nam,toi,vie,testin`