### PR TITLE
fix: use correct field when looking up SPS for avc

### DIFF
--- a/avc/slice.go
+++ b/avc/slice.go
@@ -148,7 +148,7 @@ func ParseSliceHeader(nalu []byte, spsMap map[uint32]*SPS, ppsMap map[uint32]*PP
 	if !ok {
 		return nil, fmt.Errorf("pps ID %d unknown", sh.PicParamID)
 	}
-	spsID := pps.PicParameterSetID
+	spsID := pps.SeqParameterSetID
 	sps, ok := spsMap[uint32(spsID)]
 	if !ok {
 		return nil, fmt.Errorf("sps ID %d unknown", spsID)


### PR DESCRIPTION
## Problem

In `ParseSliceHeader` (avc/slice.go), the [code](https://github.com/Eyevinn/mp4ff/blob/f2e07797c307b8cc7c79071dc95a1f1571b82d69/avc/slice.go#L151C1-L151C32) currently reads:

```go
spsID := pps.PicParameterSetID
sps, ok := spsMap[uint32(spsID)]
if !ok {
    return nil, fmt.Errorf("sps ID %d unknown", spsID)
}
```
However, this appears to be incorrect. According to the H.264 spec (ISO/IEC 14496-10, sections 7.4.2.1 and 7.4.2.2), the `pic_parameter_set_id` in the slice header identifies the PPS, and the `seq_parameter_set_id` inside the PPS identifies the SPS it refers to. 
Therefore, looking up the SPS should be done using `pps.SeqParameterSetID`, not `pps.PicParameterSetID`.


## Fix

replace 
```go
spsID := pps.PicParameterSetID
```
with:
```go
spsID := pps.SeqParameterSetID
```
so that the SPS lookup is done via the correct field.


Thanks for the project!