### PR TITLE
docs: v0.50.0 preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.50.0] - 2025-09-05
+
 ### Added
 
-- Basic VVC support with vvcC box and VvcDecoderConfigurationRecord
-- Support for parsing VVC NAL unit headers and listing types in mp4ff-nallister
+- Support for VVC with vvcC box and VvcDecoderConfigurationRecord
+- Support for parsing of VVC NALU headers and listing types in mp4ff-nallister
 - Support for AC-4 audio including ac-4 and dac4 boxes
 - Support for Opus and dOps boxes
-- Improved error handling for too short box header
 - Support for MPEG-H sample descriptors including mhaC configuration boxes
 - Support for AVS3 video sample descriptors: avs3 and av3c boxes
+- Improved error handling for too short box header
 
 ### Changed
 
 - Makefile update to setup and run pre-commit with configuration
-- Return type of Sample.PresentationTime is now int64 instead of uint64
+- Return type of Sample.PresentationTime to int64 instead of uint64
   This may happen together with edit lists (seen for VVC video)
 - Corrected SetSyncSampleFlags and SetNonSyncSampleFlags functions
 - Allow for trailing less than 8-bytes in VisualSampleEntry. Solves issue 444
@@ -740,7 +744,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.49.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.50.0...HEAD
+[0.50.0]: https://github.com/Eyevinn/mp4ff/compare/v0.49.0...v0.50.0
 [0.49.0]: https://github.com/Eyevinn/mp4ff/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/Eyevinn/mp4ff/compare/v0.47.0...v0.48.0
 [0.47.0]: https://github.com/Eyevinn/mp4ff/compare/v0.46.0...v0.47.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.49"      // May be updated using build flags
-	commitDate    string = "1750949407" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.50.0"    // May be updated using build flags
+	commitDate    string = "1757070656" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func ExampleGetVersion() {
 	fmt.Println(GetVersion())
-	// Output: v0.49, date: 2025-06-26
+	// Output: v0.50.0, date: 2025-09-05
 }


### PR DESCRIPTION
### Added

- Support for VVC with vvcC box and VvcDecoderConfigurationRecord
- Support for parsing of VVC NALU headers and listing types in mp4ff-nallister
- Support for AC-4 audio including ac-4 and dac4 boxes
- Support for Opus and dOps boxes
- Support for MPEG-H sample descriptors including mhaC configuration boxes
- Support for AVS3 video sample descriptors: avs3 and av3c boxes
- Improved error handling for too short box header

### Changed

- Makefile update to setup and run pre-commit with configuration
- Return type of Sample.PresentationTime to int64 instead of uint64
  This may happen together with edit lists (seen for VVC video)
- Corrected SetSyncSampleFlags and SetNonSyncSampleFlags functions
- Allow for trailing less than 8-bytes in VisualSampleEntry. Solves issue 444
- Allow unspecified `aspect_radio_idc == 0` in avc VUI

### Fixed

- The SliceHeader parser for AVC now uses SPS ID and not PPS ID to look up the SPS