### PR TITLE
feat: Reconstruct missing sample sizes where possible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Eyevinn/mp4ff
+module github.com/itouakirai/mp4ff
 
 go 1.16
 

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -134,8 +134,17 @@ func (f *Fragment) GetFullSamples(trex *TrexBox) ([]FullSample, error) {
 	}
 	moofStartPos := moof.StartPos
 	var samples []FullSample
-	for _, trun := range traf.Truns {
+	for i, trun := range traf.Truns {
 		totalDur := trun.AddSampleDefaultValues(tfhd, trex)
+		//Try to fix the missing sample size
+		if !trun.HasSampleSize() && len(traf.Truns)-i != 0 {
+			if trun.HasDataOffset() && traf.Truns[i+1].HasDataOffset() {
+				size := (traf.Truns[i+1].DataOffset - trun.DataOffset) / int32(trun.SampleCount())
+				for j := range trun.Samples {
+					trun.Samples[j].Size = uint32(size)
+				}
+			}
+		}
 		// The default is moofStartPos according to Section 8.8.7.1
 		baseOffset := moofStartPos
 		if tfhd.HasBaseDataOffset() {


### PR DESCRIPTION
For some MP4s with missing sample sizes, try to fill in the sample sizes based on the dataoffset of the current and next truns.

Here are a few MP4 examples, all of which have missing sample sizes in the last fragment.

https://aod.itunes.apple.com/itunes-assets/HLSMusic124/v4/d6/b0/47/d6b0479f-3c1f-a26f-beee-656e020fff31/P236335334_A713601853_audio_en_gr1411_m.mp4
https://aod.itunes.apple.com/itunes-assets/HLSMusic124/v4/ef/4a/99/ef4a9932-45cf-7f83-b334-f17be1530f1f/P236335313_A713601856_audio_en_gr1411_m.mp4
https://aod.itunes.apple.com/itunes-assets/HLSMusic114/v4/c8/e8/f8/c8e8f832-0076-10be-27a4-cff75c4a1d36/P236335306_A713602171_audio_en_gr1411_m.mp4
