### PR TITLE
fix: check trackID when decrypting segments

### DIFF
--- a/mp4/crypto.go
+++ b/mp4/crypto.go
@@ -624,6 +624,17 @@ func DecryptInit(init *InitSegment) (DecryptInfo, error) {
 // DecryptSegment decrypts a media segment in place
 func DecryptSegment(seg *MediaSegment, di DecryptInfo, key []byte) error {
 	for _, frag := range seg.Fragments {
+		for _, traf := range frag.Moof.Trafs {
+			hasSenc, _ := traf.ContainsSencBox()
+			if hasSenc {
+				ti := di.findTrackInfo(traf.Tfhd.TrackID)
+				if ti.Sinf == nil {
+					return fmt.Errorf("no decrypt info for trackID=%d which has senc box", traf.Tfhd.TrackID)
+				}
+			}
+		}
+	}
+	for _, frag := range seg.Fragments {
 		err := DecryptFragment(frag, di, key)
 		if err != nil {
 			return err

--- a/mp4/file_test.go
+++ b/mp4/file_test.go
@@ -404,7 +404,7 @@ func TestDecodeTrunctedFile(t *testing.T) {
 	if boxTree == nil {
 		t.Fatal("expected boxTree to be returned for truncated file")
 	}
-	if boxTree.Ftyp == nil {
+	if boxTree != nil && boxTree.Ftyp == nil {
 		t.Error("expected styp box to be present in truncated file")
 	}
 }


### PR DESCRIPTION
When decrypting segments, the trackID in the TrackInfo was not compared to the track's trackID. This is now checked, and an error reported if they do not match.

Should make the #474 case clearer (by not decrypting).