### PR TITLE
docs: add changelog entries for KID-aware decryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- KID-aware decryption key selection in mp4ff-decrypt via repeated `--key kid:key` flags (PR #490)
+- `DecryptSegmentWithKeys` and `DecryptFragmentWithKeys` functions in mp4 package for
+  multi-key decryption using KID/key maps. Currently only reads KID from tenc box
+  (seig sample group entry overrides are not yet supported)
+
 ## [0.51.0] - 2026-02-20
 
 ### Added


### PR DESCRIPTION
## Summary
- Add changelog entries under [Unreleased] for the KID-aware decryption feature from PR #490
- Documents the new `--key kid:key` flag support in mp4ff-decrypt
- Documents the new `DecryptSegmentWithKeys` and `DecryptFragmentWithKeys` API functions
- Notes the current limitation that KID is only read from the tenc box (seig sample group entry overrides not yet supported)

## Test plan
- [x] Verified changelog formatting follows Keep a Changelog conventions