### PR TITLE
fix: advance IV between fragments in mp4ff-encrypt cenc (#499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preventing incorrect perSampleIVSize selection
 - `mp4.NewPsshBox` now stores the supplied `data` argument on the returned
   box instead of dropping it (issue #497)
+- IV is now advanced between fragments when encrypting multiple cenc fragments
+  with `mp4ff-encrypt`, avoiding IV/keystream reuse across fragments (issue #499)
 
 ### Changed
 
 - Minimum Go version bumped from 1.16 to 1.17 (ARM64 macOS support)
+- `mp4.EncryptFragment` now returns `(nextIV []byte, err error)` so callers
+  can chain the IV across fragments. Update call sites that previously
+  captured only the error
 
 ## [0.51.0] - 2026-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DecodeSenc` now delegates to `DecodeSencSR` removing duplicated code
 - Heuristic senc parsing validates candidates against saiz sample sizes,
   preventing incorrect perSampleIVSize selection
+- `mp4.NewPsshBox` now stores the supplied `data` argument on the returned
+  box instead of dropping it (issue #497)
 
 ### Changed
 

--- a/cmd/mp4ff-encrypt/main.go
+++ b/cmd/mp4ff-encrypt/main.go
@@ -195,7 +195,7 @@ func encryptFile(ifh io.Reader, ofh io.Writer, initSeg *mp4.InitSegment,
 
 	for _, s := range inFile.Segments {
 		for _, f := range s.Fragments {
-			err = mp4.EncryptFragment(f, key, iv, ipd)
+			iv, err = mp4.EncryptFragment(f, key, iv, ipd)
 			if err != nil {
 				return fmt.Errorf("encrypt fragment: %w", err)
 			}

--- a/examples/stream-encrypt/encryptor.go
+++ b/examples/stream-encrypt/encryptor.go
@@ -59,7 +59,7 @@ func (se *StreamEncryptor) EncryptFragment(frag *mp4.Fragment) error {
 
 	iv := se.deriveIV(se.fragNum)
 
-	err := mp4.EncryptFragment(frag, se.config.Key, iv, se.ipd)
+	_, err := mp4.EncryptFragment(frag, se.config.Key, iv, se.ipd)
 	if err != nil {
 		return fmt.Errorf("encrypt fragment %d: %w", se.fragNum, err)
 	}

--- a/mp4/crypto.go
+++ b/mp4/crypto.go
@@ -448,9 +448,15 @@ func getHEVCProtFunc(hvcC *HvcCBox) (ProtectionRangeFunc, error) {
 
 }
 
-func EncryptFragment(f *Fragment, key, iv []byte, ipd *InitProtectData) error {
+// EncryptFragment encrypts a fragment in place and returns the next IV to use
+// for the following fragment. For cenc, the returned IV is the input IV
+// incremented by the number of encrypted AES blocks in the fragment, so that
+// callers processing multiple fragments with the same key can chain calls and
+// avoid IV reuse. For cbcs the IV is constant and the returned slice is a
+// copy of the input IV.
+func EncryptFragment(f *Fragment, key, iv []byte, ipd *InitProtectData) ([]byte, error) {
 	if ipd == nil {
-		return fmt.Errorf("no protection data")
+		return nil, fmt.Errorf("no protection data")
 	}
 	if len(iv) == 8 {
 		// Convert to 16 bytes
@@ -459,14 +465,14 @@ func EncryptFragment(f *Fragment, key, iv []byte, ipd *InitProtectData) error {
 		copy(iv, iv8)
 	}
 	if len(iv) != 16 {
-		return fmt.Errorf("iv must be 16 bytes")
+		return nil, fmt.Errorf("iv must be 16 bytes")
 	}
 	if len(f.Moof.Trafs) != 1 {
-		return fmt.Errorf("only one traf supported")
+		return nil, fmt.Errorf("only one traf supported")
 	}
 	traf := f.Moof.Traf
 	if len(traf.Truns) != 1 {
-		return fmt.Errorf("only one trun supported")
+		return nil, fmt.Errorf("only one trun supported")
 	}
 	nrSamples := int(f.Moof.Traf.Trun.SampleCount())
 	saiz := NewSaizBox(nrSamples)
@@ -480,25 +486,25 @@ func EncryptFragment(f *Fragment, key, iv []byte, ipd *InitProtectData) error {
 	case "cbcs":
 		senc = NewSencBox(0, nrSamples)
 	default:
-		return fmt.Errorf("unknown scheme %s", ipd.Scheme)
+		return nil, fmt.Errorf("unknown scheme %s", ipd.Scheme)
 	}
 	_ = traf.AddChild(senc)
 	fss, err := f.GetFullSamples(ipd.Trex)
 	if err != nil {
-		return fmt.Errorf("get full samples: %w", err)
+		return nil, fmt.Errorf("get full samples: %w", err)
 	}
 
 	for _, fs := range fss {
 		sample := fs.Data
 		subsamplePatterns, err := ipd.ProtFunc(sample, ipd.Scheme)
 		if err != nil {
-			return fmt.Errorf("get protect ranges: %w", err)
+			return nil, fmt.Errorf("get protect ranges: %w", err)
 		}
 		switch ipd.Scheme {
 		case "cenc":
 			err = CryptSampleCenc(sample, key, iv, subsamplePatterns)
 			if err != nil {
-				return fmt.Errorf("crypt sample cenc: %w", err)
+				return nil, fmt.Errorf("crypt sample cenc: %w", err)
 			}
 			// Store IVs in the senc box and update depending on blocks of encrypted data
 			_ = senc.AddSample(SencSample{IV: iv, SubSamples: subsamplePatterns})
@@ -507,13 +513,13 @@ func EncryptFragment(f *Fragment, key, iv []byte, ipd *InitProtectData) error {
 		case "cbcs":
 			err = EncryptSampleCbcs(sample, key, iv, subsamplePatterns, ipd.Tenc)
 			if err != nil {
-				return fmt.Errorf("crypt sample cbcs: %w", err)
+				return nil, fmt.Errorf("crypt sample cbcs: %w", err)
 			}
 			// iv is constant and not sent t senc
 			_ = senc.AddSample(SencSample{IV: nil, SubSamples: subsamplePatterns})
 			saiz.AddSampleInfo(nil, subsamplePatterns)
 		default:
-			return fmt.Errorf("unknown scheme %s", ipd.Scheme)
+			return nil, fmt.Errorf("unknown scheme %s", ipd.Scheme)
 		}
 	}
 	moof := f.Moof
@@ -535,7 +541,7 @@ func EncryptFragment(f *Fragment, key, iv []byte, ipd *InitProtectData) error {
 		break
 	}
 	saio.Offset[0] = int64(sencDataOffset)
-	return nil
+	return iv, nil
 }
 
 type DecryptInfo struct {

--- a/mp4/crypto_test.go
+++ b/mp4/crypto_test.go
@@ -188,9 +188,10 @@ func TestEncryptDecrypt(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			fragIV := iv
 			for _, s := range seg.Segments {
 				for _, f := range s.Fragments {
-					err := mp4.EncryptFragment(f, key, iv, ipf)
+					fragIV, err = mp4.EncryptFragment(f, key, fragIV, ipf)
 					if err != nil {
 						t.Error(err)
 					}
@@ -246,15 +247,93 @@ func TestEncryptDecrypt(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
+			fragIV = iv
 			for _, s := range decode.Segments {
 				for _, f := range s.Fragments {
-					err := mp4.EncryptFragment(f, key, iv, pd2)
+					fragIV, err = mp4.EncryptFragment(f, key, fragIV, pd2)
 					if err != nil {
 						t.Errorf("Error re-encrypting fragment: %v\n", err)
 					}
 				}
 			}
 		})
+	}
+}
+
+// TestEncryptFragmentIVChaining is a regression test for issue #499.
+// EncryptFragment must return an updated IV so that callers encrypting
+// multiple fragments with the same key advance the IV between fragments
+// and avoid IV/keystream reuse.
+func TestEncryptFragmentIVChaining(t *testing.T) {
+	initFile := "testdata/init.mp4"
+	segFile := "testdata/1.m4s"
+	keyHex := "00112233445566778899aabbccddeeff"
+	ivHex := "7766554433221100"
+	kidHex := "11112222333344445555666677778888"
+	key, _ := hex.DecodeString(keyHex)
+	iv, _ := hex.DecodeString(ivHex)
+	kidUUID, _ := mp4.NewUUIDFromString(kidHex)
+
+	ifh, err := os.Open(initFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initSeg, err := mp4.DecodeFile(ifh)
+	ifh.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipd, err := mp4.InitProtect(initSeg.Init, key, iv, "cenc", kidUUID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawSeg, err := os.ReadFile(segFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loadFragment := func() *mp4.Fragment {
+		seg, err := mp4.DecodeFile(bytes.NewBuffer(rawSeg))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(seg.Segments) == 0 || len(seg.Segments[0].Fragments) == 0 {
+			t.Fatal("expected at least one fragment in segment")
+		}
+		return seg.Segments[0].Fragments[0]
+	}
+
+	fragA := loadFragment()
+	nextIV, err := mp4.EncryptFragment(fragA, key, iv, ipd)
+	if err != nil {
+		t.Fatalf("EncryptFragment fragA: %v", err)
+	}
+	if bytes.Equal(nextIV, iv) {
+		t.Fatalf("expected returned IV to differ from input IV after cenc encryption")
+	}
+
+	fragB := loadFragment()
+	_, err = mp4.EncryptFragment(fragB, key, nextIV, ipd)
+	if err != nil {
+		t.Fatalf("EncryptFragment fragB: %v", err)
+	}
+
+	sencA := fragA.Moof.Traf.Senc
+	sencB := fragB.Moof.Traf.Senc
+	if sencA == nil || sencB == nil {
+		t.Fatal("missing senc box after encryption")
+	}
+	if len(sencA.IVs) == 0 || len(sencB.IVs) == 0 {
+		t.Fatal("expected per-sample IVs in senc for cenc")
+	}
+	if bytes.Equal(sencA.IVs[0], sencB.IVs[0]) {
+		t.Fatalf("first-sample IVs must differ between chained fragments; got %x for both",
+			sencA.IVs[0])
+	}
+	if !bytes.Equal(sencB.IVs[0], nextIV) {
+		t.Fatalf("fragB first-sample IV %x does not match returned next IV %x",
+			sencB.IVs[0], nextIV)
 	}
 }
 
@@ -385,9 +464,10 @@ func TestDecryptSegmentTrackIDMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	fragIV := iv
 	for _, s := range seg.Segments {
 		for _, f := range s.Fragments {
-			err := mp4.EncryptFragment(f, key, iv, ipf)
+			fragIV, err = mp4.EncryptFragment(f, key, fragIV, ipf)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -479,9 +559,10 @@ func TestDecryptSegmentWithKeys(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		fragIV := iv
 		for _, s := range seg.Segments {
 			for _, f := range s.Fragments {
-				err := mp4.EncryptFragment(f, key, iv, ipf)
+				fragIV, err = mp4.EncryptFragment(f, key, fragIV, ipf)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
## Summary

- Fix issue #499: `mp4ff-encrypt` restarted the cenc IV at the same base value for every fragment, causing AES-CTR keystream reuse across fragments. `EncryptFragment` now returns the next IV so callers can chain it; the CLI threads the returned IV into the next fragment.
- Add a regression test (`TestEncryptFragmentIVChaining`) that asserts chained fragments get distinct first-sample IVs and that the returned `nextIV` matches the next fragment's first-sample IV.
- Document the unrelated `NewPsshBox` data-handling fix from #497 in the changelog (separate commit before the cenc fix).

## Notes

- API change: `mp4.EncryptFragment` now returns `(nextIV []byte, err error)`. Callers that previously captured only `err` need to be updated. Existing in-tree callers (CLI, stream-encrypt example, tests) have been adjusted.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] New `TestEncryptFragmentIVChaining` exercises the chained-IV path