### PR TITLE
chore: prepare v0.52.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-05-12
+
 ### Added
 
 - KID-aware decryption key selection in mp4ff-decrypt via repeated `--key kid:key` flags (PR #490)
@@ -804,7 +806,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.51.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.52.0...HEAD
+[0.52.0]: https://github.com/Eyevinn/mp4ff/compare/v0.51.0...v0.52.0
 [0.51.0]: https://github.com/Eyevinn/mp4ff/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/Eyevinn/mp4ff/compare/v0.49.0...v0.50.0
 [0.49.0]: https://github.com/Eyevinn/mp4ff/compare/v0.48.0...v0.49.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.51.0"    // May be updated using build flags
-	commitDate    string = "1771588800" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.52.0"    // May be updated using build flags
+	commitDate    string = "1778587200" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func ExampleGetVersion() {
 	fmt.Println(GetVersion())
-	// Output: v0.51.0, date: 2026-02-20
+	// Output: v0.52.0, date: 2026-05-12
 }


### PR DESCRIPTION
## [0.52.0] - 2026-05-12

### Added

- KID-aware decryption key selection in mp4ff-decrypt via repeated `--key kid:key` flags (PR #490)
- `DecryptSegmentWithKeys` and `DecryptFragmentWithKeys` functions in mp4 package for
  multi-key decryption using KID/key maps. Currently only reads KID from tenc box
  (seig sample group entry overrides are not yet supported)
- `Fragment.ParseSenc()` and `MediaSegment.ParseSenc()` methods to parse senc boxes
  using encryption info from a separate init segment
- `SencBox.IsParsedByGuess()` to check if senc was parsed by heuristic
- Support for IAMF (Immersive Audio Model and Formats) `iamf` sample entry and
  `iacb` configuration box, including parsing of IAMF OBU headers for info dumping
- Support for the legacy PIFF protection scheme (`schm.scheme_type = 'piff'`)
  with PIFF TrackEncryption UUID box `8974dbce-7be7-4c51-84f9-7148f9882554`.
  AlgorithmID 1/2 are mapped to cenc/cbcs respectively (issue #496)

### Fixed

- senc parsing when init segment is in a separate file (issue #492).
  The perSampleIVSize is now determined with correct priority:
  1. seig sample group entry, 2. tenc from init segment, 3. heuristic with saiz validation
- `DecodeSenc` now delegates to `DecodeSencSR` removing duplicated code
- Heuristic senc parsing validates candidates against saiz sample sizes,
  preventing incorrect perSampleIVSize selection
- `mp4.NewPsshBox` now stores the supplied `data` argument on the returned
  box instead of dropping it (issue #497)
- IV is now advanced between fragments when encrypting multiple cenc fragments
  with `mp4ff-encrypt`, avoiding IV/keystream reuse across fragments (issue #499)

### Changed

- Minimum Go version bumped from 1.16 to 1.17 (ARM64 macOS support)
- `mp4.EncryptFragment` now returns `(nextIV []byte, err error)` so callers
  can chain the IV across fragments. Update call sites that previously
  captured only the error