### PR TITLE
feat: add recovery point SEI message parsing for AVC and HEVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Parsing and writing of the recovery point SEI message (type 6) for both AVC
+  (`RecoveryPointAvcSEI`, ISO/IEC 14496-10 D.1.8) and HEVC (`RecoveryPointHevcSEI`,
+  ISO/IEC 23008-2 D.2.8)
+- Exponential Golomb support on the bit-level types used by the sei package:
+  `ReadExpGolomb`/`ReadSignedGolomb` on `bits.Reader` and
+  `WriteExpGolomb`/`WriteSignedGolomb` on `bits.FixedSliceWriter`
+
 ## [0.52.0] - 2026-05-12
 
 ### Added

--- a/bits/fixedslicewriter.go
+++ b/bits/fixedslicewriter.go
@@ -228,6 +228,34 @@ func (sw *FixedSliceWriter) WriteBits(bits uint, n int) {
 	sw.v &= Mask(8)
 }
 
+// WriteExpGolomb writes an unsigned exponential Golomb code ue(v).
+func (sw *FixedSliceWriter) WriteExpGolomb(n uint) {
+	if sw.accError != nil {
+		return
+	}
+	leadingZeroBits := 0
+	v := n + 1
+	for v > 1 {
+		v >>= 1
+		leadingZeroBits++
+	}
+	sw.WriteBits(n+1, 2*leadingZeroBits+1)
+}
+
+// WriteSignedGolomb writes a signed exponential Golomb code se(v).
+func (sw *FixedSliceWriter) WriteSignedGolomb(n int) {
+	if sw.accError != nil {
+		return
+	}
+	var codeNum uint
+	if n <= 0 {
+		codeNum = uint(-2 * n)
+	} else {
+		codeNum = uint(2*n - 1)
+	}
+	sw.WriteExpGolomb(codeNum)
+}
+
 // WriteFlag writes a flag as 1 bit.
 func (sw *FixedSliceWriter) WriteFlag(f bool) {
 	bit := uint(0)

--- a/bits/fixedslicewriter_test.go
+++ b/bits/fixedslicewriter_test.go
@@ -115,3 +115,56 @@ func TestFixedSliceWriter(t *testing.T) {
 		}
 	})
 }
+
+func TestFixedSliceWriterExpGolomb(t *testing.T) {
+	cases := []struct {
+		n    uint
+		bits string
+	}{
+		{0, "1"},
+		{1, "010"},
+		{2, "011"},
+		{3, "00100"},
+		{14, "0001111"},
+		{15, "000010000"},
+		{30, "000011111"},
+	}
+	for _, c := range cases {
+		sw := bits.NewFixedSliceWriter(8)
+		sw.WriteExpGolomb(c.n)
+		// Add a trailing 1-bit and byte-align, then read the value back.
+		sw.WriteFlag(true)
+		sw.FlushBits()
+		r := bits.NewReader(bytes.NewReader(sw.Bytes()))
+		got := r.ReadExpGolomb()
+		if got != c.n {
+			t.Errorf("roundtrip ExpGolomb %d got %d (bits %s)", c.n, got, c.bits)
+		}
+	}
+}
+
+// TestFixedSliceWriterGolombRoundTrip checks that FixedSliceWriter and Reader agree for ue(v) and se(v).
+func TestFixedSliceWriterGolombRoundTrip(t *testing.T) {
+	unsigned := []uint{0, 1, 2, 3, 14, 15, 30, 255, 65535}
+	for _, v := range unsigned {
+		sw := bits.NewFixedSliceWriter(16)
+		sw.WriteExpGolomb(v)
+		sw.WriteFlag(true)
+		sw.FlushBits()
+		r := bits.NewReader(bytes.NewReader(sw.Bytes()))
+		if got := r.ReadExpGolomb(); got != v {
+			t.Errorf("ue(v) roundtrip %d got %d", v, got)
+		}
+	}
+	signed := []int{0, 1, -1, 2, -2, 16383, -16384}
+	for _, v := range signed {
+		sw := bits.NewFixedSliceWriter(16)
+		sw.WriteSignedGolomb(v)
+		sw.WriteFlag(true)
+		sw.FlushBits()
+		r := bits.NewReader(bytes.NewReader(sw.Bytes()))
+		if got := r.ReadSignedGolomb(); got != v {
+			t.Errorf("se(v) roundtrip %d got %d", v, got)
+		}
+	}
+}

--- a/bits/reader.go
+++ b/bits/reader.go
@@ -75,6 +75,45 @@ func (r *Reader) ReadFlag() bool {
 	return bit == 1
 }
 
+// ReadExpGolomb reads one unsigned exponential Golomb code ue(v). Returns 0 if error now or previously.
+func (r *Reader) ReadExpGolomb() uint {
+	if r.err != nil {
+		return 0
+	}
+	leadingZeroBits := 0
+	for {
+		b := r.Read(1)
+		if r.err != nil {
+			return 0
+		}
+		if b == 1 {
+			break
+		}
+		leadingZeroBits++
+	}
+	res := uint(1<<leadingZeroBits) - 1
+	endBits := r.Read(leadingZeroBits)
+	if r.err != nil {
+		return 0
+	}
+	return res + endBits
+}
+
+// ReadSignedGolomb reads one signed exponential Golomb code se(v). Returns 0 if error now or previously.
+func (r *Reader) ReadSignedGolomb() int {
+	if r.err != nil {
+		return 0
+	}
+	unsignedGolomb := r.ReadExpGolomb()
+	if r.err != nil {
+		return 0
+	}
+	if unsignedGolomb%2 == 1 {
+		return int((unsignedGolomb + 1) / 2)
+	}
+	return -int(unsignedGolomb / 2)
+}
+
 // ReadRemainingBytes reads remaining bytes if byte-aligned. Returns nil if error now or previously.
 func (r *Reader) ReadRemainingBytes() []byte {
 	if r.err != nil {

--- a/bits/reader_test.go
+++ b/bits/reader_test.go
@@ -296,3 +296,57 @@ func TestByteAlign(t *testing.T) {
 		}
 	})
 }
+
+func TestReaderExpGolomb(t *testing.T) {
+	cases := []struct {
+		input  byte
+		wanted uint
+	}{
+		{0b10000000, 0},
+		{0b01000000, 1},
+		{0b01100000, 2},
+		{0b00010000, 7},
+		{0b00010010, 8},
+		{0b00011110, 14},
+	}
+	for _, c := range cases {
+		r := bits.NewReader(bytes.NewReader([]byte{c.input}))
+		got := r.ReadExpGolomb()
+		if r.AccError() != nil {
+			t.Errorf("unexpected error: %v", r.AccError())
+		}
+		if got != c.wanted {
+			t.Errorf("ReadExpGolomb(%08b)=%d, want %d", c.input, got, c.wanted)
+		}
+	}
+	// Reading beyond available data sets an accumulated error.
+	r := bits.NewReader(bytes.NewReader([]byte{0x00}))
+	_ = r.ReadExpGolomb()
+	if r.AccError() == nil {
+		t.Error("expected accumulated error when reading past end")
+	}
+}
+
+func TestReaderSignedGolomb(t *testing.T) {
+	cases := []struct {
+		input  byte
+		wanted int
+	}{
+		{0b10000000, 0},
+		{0b01000000, 1},
+		{0b01100000, -1},
+		{0b00010000, 4},
+		{0b00010010, -4},
+		{0b00011110, -7},
+	}
+	for _, c := range cases {
+		r := bits.NewReader(bytes.NewReader([]byte{c.input}))
+		got := r.ReadSignedGolomb()
+		if r.AccError() != nil {
+			t.Errorf("unexpected error: %v", r.AccError())
+		}
+		if got != c.wanted {
+			t.Errorf("ReadSignedGolomb(%08b)=%d, want %d", c.input, got, c.wanted)
+		}
+	}
+}

--- a/sei/sei.go
+++ b/sei/sei.go
@@ -482,6 +482,8 @@ func DecodeSEIMessage(sd *SEIData, codec Codec) (SEIMessage, error) {
 			return DecodeUserDataRegisteredSEI(sd)
 		case SEIUserDataUnregisteredType:
 			return DecodeUserDataUnregisteredSEI(sd)
+		case SEIRecoveryPointType:
+			return DecodeRecoveryPointAvcSEI(sd)
 		default:
 			return DecodeGeneralSEI(sd), nil
 		}
@@ -491,6 +493,8 @@ func DecodeSEIMessage(sd *SEIData, codec Codec) (SEIMessage, error) {
 			return DecodeUserDataRegisteredSEI(sd)
 		case SEIUserDataUnregisteredType:
 			return DecodeUserDataUnregisteredSEI(sd)
+		case SEIRecoveryPointType:
+			return DecodeRecoveryPointHevcSEI(sd)
 		case SEITimeCodeType:
 			return DecodeTimeCodeSEI(sd)
 		case SEIMasteringDisplayColourVolumeType:

--- a/sei/sei6_avc.go
+++ b/sei/sei6_avc.go
@@ -1,0 +1,86 @@
+package sei
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// RecoveryPointAvcSEI carries the data of an AVC SEI 6 RecoveryPoint message.
+// Defined in ISO/IEC 14496-10 Annex D.1.8 (syntax) and D.2.8 (semantics).
+// The corresponding HEVC message in RecoveryPointHevcSEI has a different syntax.
+type RecoveryPointAvcSEI struct {
+	// RecoveryFrameCnt specifies the recovery point of output pictures in output order.
+	RecoveryFrameCnt uint `json:"recovery_frame_cnt"`
+	// ExactMatchFlag indicates whether pictures at and after the recovery point exactly match.
+	ExactMatchFlag bool `json:"exact_match_flag"`
+	// BrokenLinkFlag indicates the presence of a broken link at the recovery point location.
+	BrokenLinkFlag bool `json:"broken_link_flag"`
+	// ChangingSliceGroupIdc is in the range 0 to 2, inclusive.
+	ChangingSliceGroupIdc uint8 `json:"changing_slice_group_idc"`
+}
+
+// DecodeRecoveryPointAvcSEI decodes an AVC SEI 6 RecoveryPoint message.
+func DecodeRecoveryPointAvcSEI(sd *SEIData) (SEIMessage, error) {
+	buf := bytes.NewBuffer(sd.Payload())
+	br := bits.NewReader(buf)
+	rp := RecoveryPointAvcSEI{
+		RecoveryFrameCnt:      br.ReadExpGolomb(),
+		ExactMatchFlag:        br.ReadFlag(),
+		BrokenLinkFlag:        br.ReadFlag(),
+		ChangingSliceGroupIdc: uint8(br.Read(2)),
+	}
+	return &rp, br.AccError()
+}
+
+// Type returns the SEI payload type.
+func (s *RecoveryPointAvcSEI) Type() uint {
+	return SEIRecoveryPointType
+}
+
+// Size is the size in bytes of the raw SEI message rbsp payload.
+func (s *RecoveryPointAvcSEI) Size() uint {
+	nrBits := ueNrBits(s.RecoveryFrameCnt) + 1 + 1 + 2
+	return uint((nrBits + 7) / 8)
+}
+
+// Payload returns the SEI raw rbsp payload.
+func (s *RecoveryPointAvcSEI) Payload() []byte {
+	sw := bits.NewFixedSliceWriter(int(s.Size()))
+	sw.WriteExpGolomb(s.RecoveryFrameCnt)
+	sw.WriteFlag(s.ExactMatchFlag)
+	sw.WriteFlag(s.BrokenLinkFlag)
+	sw.WriteBits(uint(s.ChangingSliceGroupIdc), 2)
+	sw.WriteFlag(true) // Final 1 and then byte align
+	sw.FlushBits()
+	return sw.Bytes()
+}
+
+// String returns a string representation of RecoveryPointAvcSEI.
+func (s *RecoveryPointAvcSEI) String() string {
+	return fmt.Sprintf("%s, size=%d, recoveryFrameCnt=%d, exactMatch=%t, brokenLink=%t, changingSliceGroupIdc=%d",
+		SEIType(s.Type()), s.Size(), s.RecoveryFrameCnt, s.ExactMatchFlag, s.BrokenLinkFlag, s.ChangingSliceGroupIdc)
+}
+
+// ueNrBits returns the number of bits of the unsigned exponential Golomb code ue(v) for value v.
+func ueNrBits(v uint) int {
+	leadingZeroBits := 0
+	x := v + 1
+	for x > 1 {
+		x >>= 1
+		leadingZeroBits++
+	}
+	return 2*leadingZeroBits + 1
+}
+
+// seNrBits returns the number of bits of the signed exponential Golomb code se(v) for value v.
+func seNrBits(v int) int {
+	var codeNum uint
+	if v <= 0 {
+		codeNum = uint(-2 * v)
+	} else {
+		codeNum = uint(2*v - 1)
+	}
+	return ueNrBits(codeNum)
+}

--- a/sei/sei6_avc_test.go
+++ b/sei/sei6_avc_test.go
@@ -1,0 +1,96 @@
+package sei
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestRecoveryPointAvcSEI(t *testing.T) {
+	testCases := []struct {
+		name       string
+		hexPayload string
+		want       RecoveryPointAvcSEI
+		wantString string
+	}{
+		{
+			"frameCnt=0 exact",
+			"c4", // 1 (ue=0) 1 0 00 | 1 (trailing) 00 -> 11000 100 = 0xc4
+			RecoveryPointAvcSEI{
+				RecoveryFrameCnt:      0,
+				ExactMatchFlag:        true,
+				BrokenLinkFlag:        false,
+				ChangingSliceGroupIdc: 0,
+			},
+			"SEIRecoveryPointType (6), size=1, recoveryFrameCnt=0, exactMatch=true, brokenLink=false, changingSliceGroupIdc=0",
+		},
+		{
+			"frameCnt=3 broken idc=2",
+			"2340", // 00100 (ue=3) 0 1 10 | 1 0000000 -> 00100011 01000000
+			RecoveryPointAvcSEI{
+				RecoveryFrameCnt:      3,
+				ExactMatchFlag:        false,
+				BrokenLinkFlag:        true,
+				ChangingSliceGroupIdc: 2,
+			},
+			"SEIRecoveryPointType (6), size=2, recoveryFrameCnt=3, exactMatch=false, brokenLink=true, changingSliceGroupIdc=2",
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d %s", i, tc.name), func(t *testing.T) {
+			pl, err := hex.DecodeString(tc.hexPayload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			seiData := NewSEIData(SEIRecoveryPointType, pl)
+			msg, err := DecodeRecoveryPointAvcSEI(seiData)
+			if err != nil {
+				t.Error(err)
+			}
+			if msg.Type() != SEIRecoveryPointType {
+				t.Errorf("got SEI type %d, wanted %d", msg.Type(), SEIRecoveryPointType)
+			}
+			rp := msg.(*RecoveryPointAvcSEI)
+			if diff := deep.Equal(*rp, tc.want); diff != nil {
+				t.Error(diff)
+			}
+			if msg.String() != tc.wantString {
+				t.Errorf("got %q, wanted %q", msg.String(), tc.wantString)
+			}
+			decPl := msg.Payload()
+			if !bytes.Equal(decPl, pl) {
+				t.Errorf("payload differs: got %s, wanted %s", hex.EncodeToString(decPl), tc.hexPayload)
+			}
+		})
+	}
+}
+
+func TestRecoveryPointAvcSEIRoundTrip(t *testing.T) {
+	cases := []RecoveryPointAvcSEI{
+		{RecoveryFrameCnt: 0, ExactMatchFlag: true, BrokenLinkFlag: false, ChangingSliceGroupIdc: 0},
+		{RecoveryFrameCnt: 1, ExactMatchFlag: false, BrokenLinkFlag: true, ChangingSliceGroupIdc: 1},
+		{RecoveryFrameCnt: 255, ExactMatchFlag: true, BrokenLinkFlag: true, ChangingSliceGroupIdc: 2},
+		{RecoveryFrameCnt: 65535, ExactMatchFlag: false, BrokenLinkFlag: false, ChangingSliceGroupIdc: 0},
+	}
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			in := c
+			pl := in.Payload()
+			if uint(len(pl)) != in.Size() {
+				t.Errorf("Size() %d != len(Payload()) %d", in.Size(), len(pl))
+			}
+			seiData := NewSEIData(SEIRecoveryPointType, pl)
+			msg, err := DecodeRecoveryPointAvcSEI(seiData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := msg.(*RecoveryPointAvcSEI)
+			if diff := deep.Equal(in, *out); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/sei/sei6_hevc.go
+++ b/sei/sei6_hevc.go
@@ -1,0 +1,60 @@
+package sei
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// RecoveryPointHevcSEI carries the data of an HEVC SEI 6 RecoveryPoint message.
+// Defined in ISO/IEC 23008-2 Annex D.2.8 (syntax) and D.3.8 (semantics).
+// The corresponding AVC message in RecoveryPointAvcSEI has a different syntax.
+type RecoveryPointHevcSEI struct {
+	// RecoveryPocCnt specifies the recovery point of decoded pictures in output order.
+	RecoveryPocCnt int `json:"recovery_poc_cnt"`
+	// ExactMatchFlag indicates whether pictures at and after the recovery point exactly match.
+	ExactMatchFlag bool `json:"exact_match_flag"`
+	// BrokenLinkFlag indicates the presence of a broken link at the recovery point location.
+	BrokenLinkFlag bool `json:"broken_link_flag"`
+}
+
+// DecodeRecoveryPointHevcSEI decodes an HEVC SEI 6 RecoveryPoint message.
+func DecodeRecoveryPointHevcSEI(sd *SEIData) (SEIMessage, error) {
+	buf := bytes.NewBuffer(sd.Payload())
+	br := bits.NewReader(buf)
+	rp := RecoveryPointHevcSEI{
+		RecoveryPocCnt: br.ReadSignedGolomb(),
+		ExactMatchFlag: br.ReadFlag(),
+		BrokenLinkFlag: br.ReadFlag(),
+	}
+	return &rp, br.AccError()
+}
+
+// Type returns the SEI payload type.
+func (s *RecoveryPointHevcSEI) Type() uint {
+	return SEIRecoveryPointType
+}
+
+// Size is the size in bytes of the raw SEI message rbsp payload.
+func (s *RecoveryPointHevcSEI) Size() uint {
+	nrBits := seNrBits(s.RecoveryPocCnt) + 1 + 1
+	return uint((nrBits + 7) / 8)
+}
+
+// Payload returns the SEI raw rbsp payload.
+func (s *RecoveryPointHevcSEI) Payload() []byte {
+	sw := bits.NewFixedSliceWriter(int(s.Size()))
+	sw.WriteSignedGolomb(s.RecoveryPocCnt)
+	sw.WriteFlag(s.ExactMatchFlag)
+	sw.WriteFlag(s.BrokenLinkFlag)
+	sw.WriteFlag(true) // Final 1 and then byte align
+	sw.FlushBits()
+	return sw.Bytes()
+}
+
+// String returns a string representation of RecoveryPointHevcSEI.
+func (s *RecoveryPointHevcSEI) String() string {
+	return fmt.Sprintf("%s, size=%d, recoveryPocCnt=%d, exactMatch=%t, brokenLink=%t",
+		SEIType(s.Type()), s.Size(), s.RecoveryPocCnt, s.ExactMatchFlag, s.BrokenLinkFlag)
+}

--- a/sei/sei6_hevc_test.go
+++ b/sei/sei6_hevc_test.go
@@ -1,0 +1,116 @@
+package sei
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestRecoveryPointHevcSEI(t *testing.T) {
+	testCases := []struct {
+		name       string
+		hexPayload string
+		want       RecoveryPointHevcSEI
+		wantString string
+	}{
+		{
+			"pocCnt=0 exact",
+			"d0", // 1 (se=0) 1 0 | 1 (trailing) 0000 -> 1101 0000 = 0xd0
+			RecoveryPointHevcSEI{
+				RecoveryPocCnt: 0,
+				ExactMatchFlag: true,
+				BrokenLinkFlag: false,
+			},
+			"SEIRecoveryPointType (6), size=1, recoveryPocCnt=0, exactMatch=true, brokenLink=false",
+		},
+		{
+			"pocCnt=-1 broken",
+			"6c", // 011 (se=-1) 0 1 | 1 (trailing) 00 -> 01101 100 = 0x6c
+			RecoveryPointHevcSEI{
+				RecoveryPocCnt: -1,
+				ExactMatchFlag: false,
+				BrokenLinkFlag: true,
+			},
+			"SEIRecoveryPointType (6), size=1, recoveryPocCnt=-1, exactMatch=false, brokenLink=true",
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d %s", i, tc.name), func(t *testing.T) {
+			pl, err := hex.DecodeString(tc.hexPayload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			seiData := NewSEIData(SEIRecoveryPointType, pl)
+			msg, err := DecodeRecoveryPointHevcSEI(seiData)
+			if err != nil {
+				t.Error(err)
+			}
+			if msg.Type() != SEIRecoveryPointType {
+				t.Errorf("got SEI type %d, wanted %d", msg.Type(), SEIRecoveryPointType)
+			}
+			rp := msg.(*RecoveryPointHevcSEI)
+			if diff := deep.Equal(*rp, tc.want); diff != nil {
+				t.Error(diff)
+			}
+			if msg.String() != tc.wantString {
+				t.Errorf("got %q, wanted %q", msg.String(), tc.wantString)
+			}
+			decPl := msg.Payload()
+			if !bytes.Equal(decPl, pl) {
+				t.Errorf("payload differs: got %s, wanted %s", hex.EncodeToString(decPl), tc.hexPayload)
+			}
+		})
+	}
+}
+
+func TestRecoveryPointHevcSEIRoundTrip(t *testing.T) {
+	cases := []RecoveryPointHevcSEI{
+		{RecoveryPocCnt: 0, ExactMatchFlag: true, BrokenLinkFlag: false},
+		{RecoveryPocCnt: 1, ExactMatchFlag: false, BrokenLinkFlag: true},
+		{RecoveryPocCnt: -1, ExactMatchFlag: true, BrokenLinkFlag: true},
+		{RecoveryPocCnt: 16383, ExactMatchFlag: false, BrokenLinkFlag: false},
+		{RecoveryPocCnt: -16384, ExactMatchFlag: true, BrokenLinkFlag: false},
+	}
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			in := c
+			pl := in.Payload()
+			if uint(len(pl)) != in.Size() {
+				t.Errorf("Size() %d != len(Payload()) %d", in.Size(), len(pl))
+			}
+			seiData := NewSEIData(SEIRecoveryPointType, pl)
+			msg, err := DecodeRecoveryPointHevcSEI(seiData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := msg.(*RecoveryPointHevcSEI)
+			if diff := deep.Equal(in, *out); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+// TestRecoveryPointViaDecodeSEIMessage checks dispatch through DecodeSEIMessage for both codecs.
+func TestRecoveryPointViaDecodeSEIMessage(t *testing.T) {
+	avcData := NewSEIData(SEIRecoveryPointType, []byte{0xc4})
+	msg, err := DecodeSEIMessage(avcData, AVC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := msg.(*RecoveryPointAvcSEI); !ok {
+		t.Errorf("expected *RecoveryPointAvcSEI, got %T", msg)
+	}
+
+	hevcData := NewSEIData(SEIRecoveryPointType, []byte{0xd0})
+	msg, err = DecodeSEIMessage(hevcData, HEVC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := msg.(*RecoveryPointHevcSEI); !ok {
+		t.Errorf("expected *RecoveryPointHevcSEI, got %T", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Adds parsing and writing of the recovery point SEI message (payload type 6) for both AVC and HEVC. The recovery point message marks a position in the bitstream from which decoding can be reliably resumed (useful for random access / open-GOP handling).

- `RecoveryPointAvcSEI` — AVC syntax per ISO/IEC 14496-10 Annex D.1.8 / D.2.8 (`recovery_frame_cnt` as `ue(v)`, plus `exact_match_flag`, `broken_link_flag`, `changing_slice_group_idc`).
- `RecoveryPointHevcSEI` — HEVC syntax per ISO/IEC 23008-2 Annex D.2.8 / D.3.8 (`recovery_poc_cnt` as `se(v)`, plus `exact_match_flag`, `broken_link_flag`). Note the AVC and HEVC variants have different syntax.
- Both are wired into `DecodeSEIMessage` dispatch for the respective codecs.

### Supporting bit-level additions

The exponential Golomb codec needed for these messages is added to the shared `bits` types:

- `bits.Reader`: `ReadExpGolomb` (`ue(v)`) and `ReadSignedGolomb` (`se(v)`)
- `bits.FixedSliceWriter`: `WriteExpGolomb` (`ue(v)`) and `WriteSignedGolomb` (`se(v)`)

## Test plan

- Added decode, `String()`, and payload round-trip tests for both AVC and HEVC messages, plus dispatch-through-`DecodeSEIMessage` coverage.
- Added Exp-Golomb read/write and round-trip tests on `bits.Reader` and `bits.FixedSliceWriter`.
- `go test ./sei/ ./bits/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)