### PR TITLE
feat: add ReadMdatData for bulk mdat payload access when streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `SampleAccessor.ReadMdatData` for bulk reading of the raw mdat payload of a
+  fragment in a single read, intended for streaming with lazy mdat decoding
 - HDR metadata boxes `ClliBox` (Content Light Level, `clli`, ISO/IEC 14496-12
   Sec. 12.1.6) and `MdcvBox` (Mastering Display Colour Volume, `mdcv`, ISO/IEC
   14496-12 Sec. 12.1.7), including `VisualSampleEntryBox.Clli` and `.Mdcv`

--- a/mp4/stream.go
+++ b/mp4/stream.go
@@ -137,6 +137,7 @@ type SampleAccessor interface {
 	GetSample(trackID uint32, sampleNr uint32) (*FullSample, error)
 	GetSampleRange(trackID uint32, startSampleNr, endSampleNr uint32) ([]FullSample, error)
 	GetSamples(trackID uint32) ([]FullSample, error)
+	ReadMdatData(dst []byte) (int, error)
 }
 
 // StreamOption configures streaming behavior.
@@ -393,6 +394,22 @@ func (fsa *fragmentSampleAccessor) GetSamples(trackID uint32) ([]FullSample, err
 	}
 
 	return samples, nil
+}
+
+// ReadMdatData reads the raw mdat payload of the fragment into dst in a single read.
+// The caller must provide a dst slice of at least mdat.GetLazyDataSize() bytes.
+// It is intended for bulk access to the media data when using lazy mdat decoding,
+// as an alternative to extracting samples one by one.
+func (fsa *fragmentSampleAccessor) ReadMdatData(dst []byte) (int, error) {
+	mdat := fsa.fragment.Mdat
+	if mdat == nil {
+		return 0, fmt.Errorf("fragment has no mdat box")
+	}
+	start := int64(mdat.PayloadAbsoluteOffset())
+	if _, err := fsa.boxSeekReader.Seek(start, io.SeekStart); err != nil {
+		return 0, fmt.Errorf("seek to mdat payload: %w", err)
+	}
+	return io.ReadFull(fsa.boxSeekReader, dst)
 }
 
 // ProcessFragments reads and processes fragments from the stream until EOF.

--- a/mp4/stream_test.go
+++ b/mp4/stream_test.go
@@ -84,6 +84,66 @@ func TestProcessFragmentsWithCallback(t *testing.T) {
 	t.Logf("Processed %d fragments with %d total samples", fragmentCount, sampleCount)
 }
 
+func TestStreamReadMdatData(t *testing.T) {
+	testFile := "testdata/v300_multiple_segments.mp4"
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Skip("Test file not found, skipping")
+	}
+
+	data, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("Failed to read test file: %v", err)
+	}
+
+	fragmentCount := 0
+	reader := bytes.NewReader(data)
+	sf, err := mp4.InitDecodeStream(reader,
+		mp4.WithFragmentCallback(func(f *mp4.Fragment, sa mp4.SampleAccessor) error {
+			fragmentCount++
+			if f.Mdat == nil {
+				t.Fatal("fragment mdat is nil")
+			}
+
+			// Concatenate the per-sample data for the (single) track.
+			trackID := f.Moof.Trafs[0].Tfhd.TrackID
+			samples, err := sa.GetSamples(trackID)
+			if err != nil {
+				t.Fatalf("GetSamples failed: %v", err)
+			}
+			var concatenated []byte
+			for i := range samples {
+				concatenated = append(concatenated, samples[i].Data...)
+			}
+
+			// Bulk-read the whole mdat payload and compare.
+			size := f.Mdat.GetLazyDataSize()
+			dst := make([]byte, size)
+			n, err := sa.ReadMdatData(dst)
+			if err != nil {
+				t.Fatalf("ReadMdatData failed: %v", err)
+			}
+			if uint64(n) != size {
+				t.Errorf("ReadMdatData read %d bytes, want %d", n, size)
+			}
+			if !bytes.Equal(dst, concatenated) {
+				t.Errorf("ReadMdatData payload (%d bytes) does not match concatenated samples (%d bytes)",
+					len(dst), len(concatenated))
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("DecodeStream failed: %v", err)
+	}
+
+	if err := sf.ProcessFragments(); err != nil {
+		t.Fatalf("ProcessFragments failed: %v", err)
+	}
+	if fragmentCount == 0 {
+		t.Error("No fragments processed")
+	}
+}
+
 func TestStreamFileSlidingWindow(t *testing.T) {
 	testFile := "testdata/v300_multiple_segments.mp4"
 	if _, err := os.Stat(testFile); os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

Adds `ReadMdatData(dst []byte) (int, error)` to the streaming `SampleAccessor`, ported from the [eluv-io/mp4ff `ss/mvhevc`](https://github.com/eluv-io/mp4ff/tree/ss/mvhevc) branch.

When streaming with lazy mdat decoding (`StreamFile` / `ProcessFragments`), the mdat payload is not held in memory — the existing accessors (`GetSample`/`GetSampleRange`/`GetSamples`) extract samples individually via the `BoxSeekReader`. `ReadMdatData` instead reads the **entire raw mdat payload of the current fragment in a single read**, by seeking to the payload offset and doing one `io.ReadFull`. This is useful for repackaging/forwarding fragments where the media bytes are needed verbatim, without per-sample extraction.

The caller sizes `dst` to at least `MdatBox.GetLazyDataSize()`.

## Changes

- New `ReadMdatData(dst []byte) (int, error)` method on the `SampleAccessor` interface, implemented by `fragmentSampleAccessor` (with a nil-mdat guard).
- `TestStreamReadMdatData` verifies a full read of each fragment's mdat and that the bytes equal the concatenation of the per-sample data.
- CHANGELOG entry.

## Note

This adds a method to the exported `SampleAccessor` interface. External code that *implements* `SampleAccessor` (rather than just consuming it from the fragment callback) would need to add the method. The only in-tree implementer is `fragmentSampleAccessor`.

## Testing

- `go test ./...` passes
- `go vet`, `gofmt`, `golangci-lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)