### PR TITLE
feat: parse HEVC multilayer VPS extension and L-HEVC config record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Parsing of the HEVC multilayer/multiview VPS extension (`vps_extension()`,
+  ISO/IEC 23008-2 Annex F.7.3.2.1.1) used by MV-HEVC and SHVC, exposed as an
+  optional `hevc.VPS.Extension` (`*VPSExtension`) with scalability mask,
+  per-layer dimension/dependency info, layer profile-tier-levels, output layer
+  sets and `rep_format()` resolutions, plus `VPS.GetNumLayers`,
+  `IsMultiLayer`, `GetNumViews` and `ScalabilityMaskBits` helpers
+- L-HEVC (`lhvC`) decoder configuration record support in the hevc package:
+  `DecConfRec.DecodeLHEVCDecConfRec`, `EncodeLHEVC`, `EncodeLHEVCSW` and
+  `LHEVCSize` (ISO/IEC 14496-15 Ed. 7 Sec. 9.4.3)
 - `SampleAccessor.ReadMdatData` for bulk reading of the raw mdat payload of a
   fragment in a single read, intended for streaming with lazy mdat decoding
 - HDR metadata boxes `ClliBox` (Content Light Level, `clli`, ISO/IEC 14496-12

--- a/cmd/mp4ff-pslister/testdata/golden_hevc_mp4_verbose.txt
+++ b/cmd/mp4ff-pslister/testdata/golden_hevc_mp4_verbose.txt
@@ -34,7 +34,8 @@ VPS 1 len 24B: 40010c01ffff016000000300900000030000030078959809
   "NumLayerSetsMinus1": 0,
   "TimingInfoPresentFlag": false,
   "TimingInfo": null,
-  "ExtensionFlag": false
+  "ExtensionFlag": false,
+  "Extension": null
 }
 SPS 1 len 45B: 420101016000000300900000030000030078a00502016965959a4932bc05a80808082000000300200000030321
 {

--- a/cmd/mp4ff-pslister/testdata/golden_hevc_vps_sps_pps.txt
+++ b/cmd/mp4ff-pslister/testdata/golden_hevc_vps_sps_pps.txt
@@ -33,7 +33,8 @@ VPS 1 len 24B: 40010c01ffff016000000300900000030000030078959809
   "NumLayerSetsMinus1": 0,
   "TimingInfoPresentFlag": false,
   "TimingInfo": null,
-  "ExtensionFlag": false
+  "ExtensionFlag": false,
+  "Extension": null
 }
 SPS 1 len 45B: 420101016000000300900000030000030078a00502016965959a4932bc05a80808082000000300200000030321
 {

--- a/hevc/hevcdecoderconfigurationrecord.go
+++ b/hevc/hevcdecoderconfigurationrecord.go
@@ -217,3 +217,81 @@ func (h *DecConfRec) GetNalusForType(naluType NaluType) [][]byte {
 func (h *DecConfRec) AddNaluArrays(na []NaluArray) {
 	h.NaluArrays = append(h.NaluArrays, na...)
 }
+
+// DecodeLHEVCDecConfRec decodes an L-HEVC (lhvC) decoder configuration record.
+// The L-HEVC format differs from the standard hvcC record: it omits the
+// profile/tier/level fields and the chroma/bit-depth/frame-rate fields.
+// See ISO/IEC 14496-15 (Ed. 7) Sec. 9.4.3.
+func DecodeLHEVCDecConfRec(data []byte) (DecConfRec, error) {
+	hdcr := DecConfRec{}
+	sr := bits.NewFixedSliceReader(data)
+	hdcr.ConfigurationVersion = sr.ReadUint8()
+	if hdcr.ConfigurationVersion != 1 {
+		return DecConfRec{}, fmt.Errorf("L-HEVC decoder configuration record version %d unknown",
+			hdcr.ConfigurationVersion)
+	}
+	// No profile/tier/level/compatibility/constraint/level fields in lhvC.
+	hdcr.MinSpatialSegmentationIDC = sr.ReadUint16() & 0x0fff
+	hdcr.ParallellismType = sr.ReadUint8() & 0x3
+	// No chroma/bit-depth/frame-rate/constantFrameRate fields; only 2 reserved bits.
+	aByte := sr.ReadUint8()
+	hdcr.NumTemporalLayers = (aByte >> 3) & 0x7
+	hdcr.TemporalIDNested = (aByte >> 2) & 0x1
+	hdcr.LengthSizeMinusOne = aByte & 0x3
+	numArrays := sr.ReadUint8()
+	for j := 0; j < int(numArrays); j++ {
+		array := NaluArray{
+			completeAndType: sr.ReadUint8(),
+			Nalus:           nil,
+		}
+		numNalus := int(sr.ReadUint16())
+		for i := 0; i < numNalus; i++ {
+			naluLength := int(sr.ReadUint16())
+			array.Nalus = append(array.Nalus, sr.ReadBytes(naluLength))
+		}
+		hdcr.NaluArrays = append(hdcr.NaluArrays, array)
+	}
+	return hdcr, sr.AccError()
+}
+
+// LHEVCSize returns the total size in bytes of the L-HEVC (lhvC) config record.
+func (h *DecConfRec) LHEVCSize() uint64 {
+	totalSize := 6 // configVersion(1) + minSpatialSeg(2) + parallelism(1) + flags(1) + numArrays(1)
+	for _, array := range h.NaluArrays {
+		totalSize += 3 // complete+type(1) + numNalus(2)
+		for _, nalu := range array.Nalus {
+			totalSize += 2 // nalUnitLength
+			totalSize += len(nalu)
+		}
+	}
+	return uint64(totalSize)
+}
+
+// EncodeLHEVC writes an L-HEVC (lhvC) decoder configuration record to w.
+func (h *DecConfRec) EncodeLHEVC(w io.Writer) error {
+	sw := bits.NewFixedSliceWriter(int(h.LHEVCSize()))
+	if err := h.EncodeLHEVCSW(sw); err != nil {
+		return err
+	}
+	_, err := w.Write(sw.Bytes())
+	return err
+}
+
+// EncodeLHEVCSW writes an L-HEVC (lhvC) decoder configuration record to sw.
+func (h *DecConfRec) EncodeLHEVCSW(sw bits.SliceWriter) error {
+	sw.WriteUint8(h.ConfigurationVersion)
+	sw.WriteUint16(0xf000 | h.MinSpatialSegmentationIDC)
+	sw.WriteUint8(0xfc | h.ParallellismType)
+	// reserved(2) + numTemporalLayers(3) + temporalIdNested(1) + lengthSizeMinusOne(2)
+	sw.WriteUint8(0xc0 | h.NumTemporalLayers<<3 | h.TemporalIDNested<<2 | h.LengthSizeMinusOne)
+	sw.WriteUint8(byte(len(h.NaluArrays)))
+	for _, array := range h.NaluArrays {
+		sw.WriteUint8(array.completeAndType)
+		sw.WriteUint16(uint16(len(array.Nalus)))
+		for _, nalu := range array.Nalus {
+			sw.WriteUint16(uint16(len(nalu)))
+			sw.WriteBytes(nalu)
+		}
+	}
+	return sw.AccError()
+}

--- a/hevc/hevcdecoderconfigurationrecord_test.go
+++ b/hevc/hevcdecoderconfigurationrecord_test.go
@@ -134,3 +134,71 @@ func TestDecodeConfRec(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestLHEVCDecConfRecRoundTrip(t *testing.T) {
+	// L-HEVC (lhvC) record carries no profile/tier/level or chroma/bit-depth fields,
+	// only the fields below plus NALU arrays. Build one, encode, decode, compare.
+	vps, _ := hex.DecodeString("40010c11ffff016000000300900000030000030078959815bf7820")
+	lhvcSPS, _ := hex.DecodeString("42010101600000030090000003000003007ba003c08010e5ad")
+	in := DecConfRec{
+		ConfigurationVersion:      1,
+		MinSpatialSegmentationIDC: 0,
+		ParallellismType:          0,
+		NumTemporalLayers:         1,
+		TemporalIDNested:          1,
+		LengthSizeMinusOne:        3,
+		NaluArrays: []NaluArray{
+			NewNaluArray(true, NALU_VPS, [][]byte{vps}),
+			NewNaluArray(true, NALU_SPS, [][]byte{lhvcSPS}),
+		},
+	}
+
+	out := bytes.Buffer{}
+	if err := in.EncodeLHEVC(&out); err != nil {
+		t.Fatal(err)
+	}
+	if uint64(out.Len()) != in.LHEVCSize() {
+		t.Errorf("encoded %d bytes, LHEVCSize() reported %d", out.Len(), in.LHEVCSize())
+	}
+
+	got, err := DecodeLHEVCDecConfRec(out.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ConfigurationVersion != in.ConfigurationVersion {
+		t.Errorf("ConfigurationVersion = %d, want %d", got.ConfigurationVersion, in.ConfigurationVersion)
+	}
+	if got.MinSpatialSegmentationIDC != in.MinSpatialSegmentationIDC {
+		t.Errorf("MinSpatialSegmentationIDC = %d, want %d", got.MinSpatialSegmentationIDC, in.MinSpatialSegmentationIDC)
+	}
+	if got.ParallellismType != in.ParallellismType {
+		t.Errorf("ParallellismType = %d, want %d", got.ParallellismType, in.ParallellismType)
+	}
+	if got.NumTemporalLayers != in.NumTemporalLayers {
+		t.Errorf("NumTemporalLayers = %d, want %d", got.NumTemporalLayers, in.NumTemporalLayers)
+	}
+	if got.TemporalIDNested != in.TemporalIDNested {
+		t.Errorf("TemporalIDNested = %d, want %d", got.TemporalIDNested, in.TemporalIDNested)
+	}
+	if got.LengthSizeMinusOne != in.LengthSizeMinusOne {
+		t.Errorf("LengthSizeMinusOne = %d, want %d", got.LengthSizeMinusOne, in.LengthSizeMinusOne)
+	}
+	if len(got.NaluArrays) != len(in.NaluArrays) {
+		t.Fatalf("got %d NALU arrays, want %d", len(got.NaluArrays), len(in.NaluArrays))
+	}
+	for i := range in.NaluArrays {
+		if got.NaluArrays[i].NaluType() != in.NaluArrays[i].NaluType() {
+			t.Errorf("array %d type = %s, want %s", i, got.NaluArrays[i].NaluType(), in.NaluArrays[i].NaluType())
+		}
+		if !bytes.Equal(got.NaluArrays[i].Nalus[0], in.NaluArrays[i].Nalus[0]) {
+			t.Errorf("array %d NALU bytes differ after round-trip", i)
+		}
+	}
+
+	// Versions other than 1 must be rejected.
+	bad := append([]byte{}, out.Bytes()...)
+	bad[0] = 2
+	if _, err := DecodeLHEVCDecConfRec(bad); err == nil {
+		t.Error("expected error for unknown configurationVersion")
+	}
+}

--- a/hevc/vps.go
+++ b/hevc/vps.go
@@ -7,6 +7,11 @@ import (
 	"github.com/Eyevinn/mp4ff/bits"
 )
 
+// maxLayers is the maximum number of layers supported when parsing the
+// multilayer VPS extension. MV-HEVC stereo uses 2 layers; the fixed-size
+// extension arrays are dimensioned for this bound.
+const maxLayers = 8
+
 // VPS is HEVC VPS parameters
 // ISO/IEC 23008-2 (Ed. 5) Sec. 7.3.2.1 page 47 and 7.4.3.1 page 92
 type VPS struct {
@@ -26,6 +31,10 @@ type VPS struct {
 	TimingInfoPresentFlag           bool
 	TimingInfo                      *VPSTimingInfo
 	ExtensionFlag                   bool
+	// Extension holds the multilayer/multiview (MV-HEVC, SHVC) parameters from
+	// vps_extension(). It is non-nil only when ExtensionFlag is set and the
+	// extension was parsed. See ISO/IEC 23008-2 (Ed. 5) Annex F.7.3.2.1.1.
+	Extension *VPSExtension
 }
 
 // VPSTimingInfo contains VPS timing info parameters.
@@ -36,6 +45,108 @@ type VPSTimingInfo struct {
 	NumTicksPocDiffOneMinus1    uint
 	NumHrdParameters            uint
 	HrdParameters               []*HrdParameters
+}
+
+// VPSExtension contains the multilayer/multiview parameters parsed from
+// vps_extension(). See ISO/IEC 23008-2 (Ed. 5) Annex F.7.3.2.1.1.
+type VPSExtension struct {
+	ScalabilityMask      [16]bool
+	NumScalabilityTypes  int
+	LayerIdInNuh         [maxLayers]byte
+	LayerIdInVps         [64]byte // reverse mapping: nuh_layer_id -> vps layer index
+	DimensionId          [maxLayers][16]byte
+	DirectDependencyFlag [maxLayers][maxLayers]bool
+	NumDirectRefLayers   [64]byte
+	IdDirectRefLayers    [64][maxLayers]byte
+
+	NumProfileTierLevel  int
+	ExtProfileTierLevels []ProfileTierLevel // ext_ptl[0], ext_ptl[1], ...
+	NumOutputLayerSets   int
+	OutputLayerFlag      [maxLayers][maxLayers]bool
+	ProfileTierLevelIdx  [maxLayers][maxLayers]byte
+	NumNecessaryLayers   [maxLayers]int
+	NecessaryLayersFlag  [maxLayers][maxLayers]bool
+
+	NumLayersInIdList   [maxLayers]int
+	LayerSetLayerIdList [maxLayers][maxLayers]byte
+
+	NumRepFormats int
+	RepFormats    []RepFormat
+	RepFormatIdx  [maxLayers]byte
+
+	SubLayersVpsMaxMinus1 [maxLayers]byte
+}
+
+// RepFormat holds resolution and format info for a layer (rep_format() in
+// ISO/IEC 23008-2 Annex F.7.3.2.1.2).
+type RepFormat struct {
+	PicWidthLumaSamples  uint16
+	PicHeightLumaSamples uint16
+	ChromaFormatIDC      byte
+	BitDepthLuma         byte
+	BitDepthChroma       byte
+}
+
+// GetNumLayers returns the number of layers signalled by this VPS.
+func (v *VPS) GetNumLayers() int {
+	return int(v.MaxLayersMinus1) + 1
+}
+
+// IsMultiLayer returns true if this VPS describes a multi-layer bitstream.
+func (v *VPS) IsMultiLayer() bool {
+	return v.MaxLayersMinus1 > 0 && v.Extension != nil
+}
+
+// GetNumViews returns the number of unique views in the multi-view configuration.
+func (v *VPS) GetNumViews() int {
+	if v.Extension == nil {
+		return 1
+	}
+	numViews := 1
+	for i := 1; i <= int(v.MaxLayersMinus1); i++ {
+		viewIdx := v.Extension.getViewIndex(i)
+		newView := true
+		for j := 0; j < i; j++ {
+			if v.Extension.getViewIndex(j) == viewIdx {
+				newView = false
+				break
+			}
+		}
+		if newView {
+			numViews++
+		}
+	}
+	return numViews
+}
+
+// ScalabilityMaskBits returns the scalability mask as a 16-bit value, or 0 if
+// there is no VPS extension.
+func (v *VPS) ScalabilityMaskBits() uint16 {
+	if v.Extension == nil {
+		return 0
+	}
+	var mask uint16
+	for i := 0; i < 16; i++ {
+		if v.Extension.ScalabilityMask[i] {
+			mask |= 1 << i
+		}
+	}
+	return mask
+}
+
+// getViewIndex returns the view order index for a layer (VPS index).
+// The view order index is scalability dimension type 1 (view order index).
+func (e *VPSExtension) getViewIndex(layerIdx int) byte {
+	dimIdx := 0
+	for j := 0; j < 16; j++ {
+		if e.ScalabilityMask[j] {
+			if j == 1 { // view_order_index is scalability type 1
+				return e.DimensionId[layerIdx][dimIdx]
+			}
+			dimIdx++
+		}
+	}
+	return 0
 }
 
 // ParseVPSNALUnit parses HEVC VPS NAL unit starting with NAL unit header.
@@ -82,9 +193,22 @@ func ParseVPSNALUnit(data []byte) (*VPS, error) {
 
 	vps.MaxLayerID = byte(r.Read(6))
 	vps.NumLayerSetsMinus1 = r.ReadExpGolomb()
+	// Capture layer set membership for use by the VPS extension (if present).
+	var numLayersInIdList [maxLayers]int
+	var layerSetLayerIdList [maxLayers][maxLayers]byte
+	numLayersInIdList[0] = 1
 	for i := uint(1); i <= vps.NumLayerSetsMinus1; i++ {
+		n := 0
 		for j := byte(0); j <= vps.MaxLayerID; j++ {
-			_ = r.ReadFlag() // layer_id_included_flag[i][j]
+			if r.ReadFlag() { // layer_id_included_flag[i][j]
+				if i < maxLayers && n < maxLayers {
+					layerSetLayerIdList[i][n] = j
+				}
+				n++
+			}
+		}
+		if i < maxLayers {
+			numLayersInIdList[i] = n
 		}
 	}
 
@@ -117,9 +241,377 @@ func ParseVPSNALUnit(data []byte) (*VPS, error) {
 	}
 
 	vps.ExtensionFlag = r.ReadFlag()
-	if r.AccError() != nil {
+	if !vps.ExtensionFlag || r.AccError() != nil {
 		return vps, nil
 	}
 
+	// Byte-align before the extension (vps_extension_alignment_bit_equal_to_one).
+	if nBits := r.NrBitsReadInCurrentByte(); nBits > 0 && nBits < 8 {
+		_ = r.Read(8 - nBits)
+	}
+
+	ext := &VPSExtension{
+		NumLayersInIdList:   numLayersInIdList,
+		LayerSetLayerIdList: layerSetLayerIdList,
+	}
+	vps.Extension = ext
+	if err := parseVPSExtension(vps, ext, r); err != nil {
+		return vps, fmt.Errorf("error parsing VPS extension: %w", err)
+	}
+
 	return vps, nil
+}
+
+// parseVPSExtension parses vps_extension() into ext.
+// ISO/IEC 23008-2 (Ed. 5) Annex F.7.3.2.1.1.
+func parseVPSExtension(vps *VPS, ext *VPSExtension, r *bits.EBSPReader) error {
+	if int(vps.MaxLayersMinus1) >= maxLayers {
+		return fmt.Errorf("VPS extension with %d layers exceeds supported maximum %d",
+			vps.MaxLayersMinus1+1, maxLayers)
+	}
+
+	if vps.MaxLayersMinus1 > 0 && vps.BaseLayerInternalFlag {
+		ext.ExtProfileTierLevels = append(ext.ExtProfileTierLevels,
+			parseProfileTierLevel(r, false, vps.MaxSubLayersMinus1))
+	}
+
+	// Scalability mask
+	splittingFlag := r.ReadFlag()
+	for i := 0; i < 16; i++ {
+		ext.ScalabilityMask[i] = r.ReadFlag()
+		if ext.ScalabilityMask[i] {
+			ext.NumScalabilityTypes++
+		}
+	}
+
+	// Dimension ID bit lengths
+	var dimensionIDLen [16]byte
+	var dimBitOffset [17]byte
+	if ext.NumScalabilityTypes > 0 {
+		nst := ext.NumScalabilityTypes
+		if splittingFlag {
+			nst--
+		}
+		for i := 0; i < nst; i++ {
+			dimensionIDLen[i] = byte(r.Read(3)) + 1
+		}
+		if splittingFlag {
+			numBits := byte(0)
+			for i := 0; i < ext.NumScalabilityTypes-1; i++ {
+				numBits += dimensionIDLen[i]
+				dimBitOffset[i+1] = numBits
+			}
+			dimensionIDLen[ext.NumScalabilityTypes-1] = 6 - numBits
+			dimBitOffset[ext.NumScalabilityTypes] = 6
+		}
+	}
+
+	// Layer ID mapping and dimension IDs
+	nuhLayerIDPresentFlag := r.ReadFlag()
+	for i := byte(1); i <= vps.MaxLayersMinus1; i++ {
+		if nuhLayerIDPresentFlag {
+			ext.LayerIdInNuh[i] = byte(r.Read(6))
+		} else {
+			ext.LayerIdInNuh[i] = i
+		}
+		ext.LayerIdInVps[ext.LayerIdInNuh[i]] = i
+
+		if !splittingFlag {
+			for j := 0; j < ext.NumScalabilityTypes; j++ {
+				ext.DimensionId[i][j] = byte(r.Read(int(dimensionIDLen[j])))
+			}
+		}
+	}
+	if splittingFlag {
+		for i := byte(0); i <= vps.MaxLayersMinus1; i++ {
+			for j := 0; j < ext.NumScalabilityTypes; j++ {
+				if dimBitOffset[j+1] <= 31 {
+					ext.DimensionId[i][j] = (ext.LayerIdInNuh[i] & ((1 << dimBitOffset[j+1]) - 1)) >> dimBitOffset[j]
+				}
+			}
+		}
+	}
+
+	// View ID
+	viewIDLen := r.Read(4)
+	if viewIDLen > 0 {
+		numViews := vps.GetNumViews()
+		for i := 0; i < numViews; i++ {
+			_ = r.Read(int(viewIDLen)) // view_id_val[i]
+		}
+	}
+
+	// Direct dependency flags
+	for i := byte(1); i <= vps.MaxLayersMinus1; i++ {
+		for j := byte(0); j < i; j++ {
+			ext.DirectDependencyFlag[i][j] = r.ReadFlag()
+		}
+	}
+
+	// Build direct reference layer lists
+	for i := byte(0); i <= vps.MaxLayersMinus1; i++ {
+		iNuhLID := ext.LayerIdInNuh[i]
+		d := byte(0)
+		for j := byte(0); j <= vps.MaxLayersMinus1; j++ {
+			jNuhLID := ext.LayerIdInNuh[j]
+			if ext.DirectDependencyFlag[i][j] {
+				ext.IdDirectRefLayers[iNuhLID][d] = jNuhLID
+				d++
+			}
+		}
+		ext.NumDirectRefLayers[iNuhLID] = d
+	}
+
+	// Count independent layers, then additional layer sets
+	numIndependentLayers := 0
+	for i := byte(0); i <= vps.MaxLayersMinus1; i++ {
+		if ext.NumDirectRefLayers[ext.LayerIdInNuh[i]] == 0 {
+			numIndependentLayers++
+		}
+	}
+	numAddLayerSets := 0
+	if numIndependentLayers > 1 {
+		numAddLayerSets = int(r.ReadExpGolomb())
+	}
+	// Additional layer sets require the tree-partition (F-6) and layer-set (F-9)
+	// derivations to read highest_layer_idx_plus1[i][j] with the correct per-tree
+	// width and to populate the added layer sets. They never occur for MV-HEVC
+	// (which has a single independent layer); refuse rather than misparse.
+	if numAddLayerSets > 0 {
+		return fmt.Errorf("VPS extension with %d additional layer sets is not supported", numAddLayerSets)
+	}
+
+	// Sub-layers max
+	if r.ReadFlag() { // vps_sub_layers_max_minus1_present_flag
+		for i := byte(0); i <= vps.MaxLayersMinus1; i++ {
+			ext.SubLayersVpsMaxMinus1[i] = byte(r.Read(3))
+		}
+	} else {
+		for i := byte(0); i <= vps.MaxLayersMinus1; i++ {
+			ext.SubLayersVpsMaxMinus1[i] = vps.MaxSubLayersMinus1
+		}
+	}
+
+	// Max TID reference present
+	if r.ReadFlag() { // max_tid_ref_present_flag
+		for i := byte(0); i < vps.MaxLayersMinus1; i++ {
+			for j := i + 1; j <= vps.MaxLayersMinus1; j++ {
+				if ext.DirectDependencyFlag[j][i] {
+					_ = r.Read(3) // max_tid_il_ref_pics_plus1[i][j]
+				}
+			}
+		}
+	}
+
+	_ = r.ReadFlag() // default_ref_layers_active_flag
+
+	// Profile tier levels for extension layers
+	ext.NumProfileTierLevel = int(r.ReadExpGolomb()) + 1
+	startIdx := 1
+	if vps.BaseLayerInternalFlag {
+		startIdx = 2
+	}
+	for i := startIdx; i < ext.NumProfileTierLevel; i++ {
+		profilePresentFlag := r.ReadFlag()
+		ext.ExtProfileTierLevels = append(ext.ExtProfileTierLevels,
+			parseProfileTierLevel(r, profilePresentFlag, vps.MaxSubLayersMinus1))
+	}
+
+	// Output layer sets
+	numLayerSets := int(vps.NumLayerSetsMinus1) + 1 + numAddLayerSets
+	numAddOlss := 0
+	defaultOutputLayerIDC := 0
+	if numLayerSets > 1 {
+		numAddOlss = int(r.ReadExpGolomb())
+		defaultOutputLayerIDC = int(r.Read(2))
+		if defaultOutputLayerIDC > 2 {
+			defaultOutputLayerIDC = 2
+		}
+	}
+	ext.NumOutputLayerSets = numAddOlss + numLayerSets
+
+	// Transitive dependency closure
+	var dependencyFlag [maxLayers][maxLayers]bool
+	for i := byte(0); i <= vps.MaxLayersMinus1; i++ {
+		for j := byte(0); j <= vps.MaxLayersMinus1; j++ {
+			dependencyFlag[i][j] = ext.DirectDependencyFlag[i][j]
+			for k := byte(0); k < i; k++ {
+				if ext.DirectDependencyFlag[i][k] && dependencyFlag[k][j] {
+					dependencyFlag[i][j] = true
+				}
+			}
+		}
+	}
+
+	// The OLS loop only reads syntax elements for i >= 1; the i == 0 case (the
+	// base layer set) reads nothing. See the for(i=1;...) loop in F.7.3.2.1.1.
+	// NumOutputLayerSets may be far larger than maxLayers (num_add_olss can be up
+	// to 1023), so per-OLS state is computed in locals indexed by the in-set layer
+	// index j and only persisted into ext for the first maxLayers OLSs.
+	for i := 0; i < ext.NumOutputLayerSets; i++ {
+		olsIdxToLsIdx := i
+		if i >= numLayerSets {
+			// layer_set_idx_for_ols_minus1[i] is only signalled when NumLayerSets > 2,
+			// otherwise it is inferred to be 0 (F-11).
+			if numLayerSets > 2 {
+				nbBits := ceilLog2(numLayerSets - 1)
+				olsIdxToLsIdx = int(r.Read(nbBits)) + 1
+			} else {
+				olsIdxToLsIdx = 1
+			}
+		}
+		if olsIdxToLsIdx >= maxLayers {
+			return fmt.Errorf("VPS extension layer set index %d exceeds supported maximum %d",
+				olsIdxToLsIdx, maxLayers)
+		}
+		numLayersInOls := ext.NumLayersInIdList[olsIdxToLsIdx]
+
+		var outputLayerFlag [maxLayers]bool
+
+		// output_layer_flag[i][j] is signalled only for i >= 1 when
+		// i > vps_num_layer_sets_minus1 or defaultOutputLayerIdc == 2.
+		signalled := i >= 1 && (i > int(vps.NumLayerSetsMinus1) || defaultOutputLayerIDC == 2)
+		switch {
+		case signalled:
+			for j := 0; j < numLayersInOls; j++ {
+				flag := r.ReadFlag()
+				if j < maxLayers {
+					outputLayerFlag[j] = flag
+				}
+			}
+		case i <= int(vps.NumLayerSetsMinus1) && (defaultOutputLayerIDC == 0 || defaultOutputLayerIDC == 1):
+			// Derived for default modes 0/1: a layer is output if idc == 0, or it is
+			// the highest layer in the layer set (which is the last entry, since
+			// LayerSetLayerIdList is filled in increasing nuh_layer_id order).
+			for j := 0; j < numLayersInOls && j < maxLayers; j++ {
+				if defaultOutputLayerIDC == 0 || j == numLayersInOls-1 {
+					outputLayerFlag[j] = true
+				}
+			}
+		}
+
+		if i == 0 {
+			// output_layer_flag[0][0] is inferred to 1; no bits are read for OLS 0.
+			ext.OutputLayerFlag[0][0] = true
+			if vps.BaseLayerInternalFlag && vps.MaxLayersMinus1 > 0 {
+				ext.ProfileTierLevelIdx[0][0] = 1
+			}
+			continue
+		}
+
+		// Derive NumOutputLayersInOutputLayerSet and OlsHighestOutputLayerId (F-12).
+		numOutputLayers := 0
+		var highestOutputLayerID byte
+		for j := 0; j < numLayersInOls && j < maxLayers; j++ {
+			if outputLayerFlag[j] {
+				numOutputLayers++
+				highestOutputLayerID = ext.LayerSetLayerIdList[olsIdxToLsIdx][j]
+			}
+		}
+
+		// Derive NecessaryLayerFlag / NumNecessaryLayers (F-13).
+		var necessaryLayerFlag [maxLayers]bool
+		for j := 0; j < numLayersInOls && j < maxLayers; j++ {
+			if outputLayerFlag[j] {
+				necessaryLayerFlag[j] = true
+				curLayerID := ext.LayerSetLayerIdList[olsIdxToLsIdx][j]
+				for k := 0; k < j; k++ {
+					refLayerID := ext.LayerSetLayerIdList[olsIdxToLsIdx][k]
+					if dependencyFlag[ext.LayerIdInVps[curLayerID]][ext.LayerIdInVps[refLayerID]] {
+						necessaryLayerFlag[k] = true
+					}
+				}
+			}
+		}
+
+		// profile_tier_level_idx[i][j] is read only when vps_num_profile_tier_level_minus1 > 0.
+		if ext.NumProfileTierLevel > 1 {
+			nbBits := ceilLog2(ext.NumProfileTierLevel)
+			for j := 0; j < numLayersInOls && j < maxLayers; j++ {
+				if necessaryLayerFlag[j] {
+					val := byte(r.Read(nbBits))
+					if i < maxLayers {
+						ext.ProfileTierLevelIdx[i][j] = val
+					}
+				}
+			}
+		}
+
+		// alt_output_layer_flag[i]
+		if numOutputLayers == 1 && ext.NumDirectRefLayers[highestOutputLayerID] > 0 {
+			_ = r.ReadFlag()
+		}
+
+		// Persist derived per-OLS state for the OLSs that fit in the fixed arrays.
+		if i < maxLayers {
+			numNecessary := 0
+			for j := 0; j < numLayersInOls && j < maxLayers; j++ {
+				ext.OutputLayerFlag[i][j] = outputLayerFlag[j]
+				ext.NecessaryLayersFlag[i][j] = necessaryLayerFlag[j]
+				if necessaryLayerFlag[j] {
+					numNecessary++
+				}
+			}
+			ext.NumNecessaryLayers[i] = numNecessary
+		}
+	}
+
+	// Rep formats
+	ext.NumRepFormats = int(r.ReadExpGolomb()) + 1
+	for i := 0; i < ext.NumRepFormats; i++ {
+		ext.RepFormats = append(ext.RepFormats, parseRepFormat(r))
+	}
+
+	repFormatIDXPresentFlag := false
+	if ext.NumRepFormats > 1 {
+		repFormatIDXPresentFlag = r.ReadFlag()
+	}
+	nbBits := ceilLog2(ext.NumRepFormats)
+	startLayer := byte(1)
+	if !vps.BaseLayerInternalFlag {
+		startLayer = 0
+	}
+	for i := startLayer; i <= vps.MaxLayersMinus1; i++ {
+		if repFormatIDXPresentFlag {
+			ext.RepFormatIdx[i] = byte(r.Read(nbBits))
+		} else if int(i) < ext.NumRepFormats {
+			ext.RepFormatIdx[i] = i
+		} else {
+			ext.RepFormatIdx[i] = byte(ext.NumRepFormats - 1)
+		}
+	}
+
+	return r.AccError()
+}
+
+// parseRepFormat parses rep_format() (ISO/IEC 23008-2 Annex F.7.3.2.1.2).
+func parseRepFormat(r *bits.EBSPReader) RepFormat {
+	rf := RepFormat{}
+	rf.PicWidthLumaSamples = uint16(r.Read(16))
+	rf.PicHeightLumaSamples = uint16(r.Read(16))
+	if r.ReadFlag() { // chroma_and_bit_depth_vps_present_flag
+		rf.ChromaFormatIDC = byte(r.Read(2))
+		if rf.ChromaFormatIDC == 3 {
+			_ = r.ReadFlag() // separate_colour_plane_vps_flag
+		}
+		rf.BitDepthLuma = byte(r.Read(4)) + 8
+		rf.BitDepthChroma = byte(r.Read(4)) + 8
+	}
+	if r.ReadFlag() { // conformance_window_vps_flag
+		_ = r.ReadExpGolomb() // conf_win_vps_left_offset
+		_ = r.ReadExpGolomb() // conf_win_vps_right_offset
+		_ = r.ReadExpGolomb() // conf_win_vps_top_offset
+		_ = r.ReadExpGolomb() // conf_win_vps_bottom_offset
+	}
+	return rf
+}
+
+// ceilLog2 returns Ceil(Log2(x)), i.e. the smallest n >= 0 with (1 << n) >= x.
+// It is used for the variable-length u(v) fields in vps_extension().
+func ceilLog2(x int) int {
+	n := 0
+	for (1 << n) < x {
+		n++
+	}
+	return n
 }

--- a/hevc/vps_test.go
+++ b/hevc/vps_test.go
@@ -174,6 +174,89 @@ func TestVPSParser(t *testing.T) {
 	}
 }
 
+func TestVPSMultiLayerExtension(t *testing.T) {
+	// MV-HEVC VPS with vps_extension() from a reference MV-HEVC mp4 (GPAC output).
+	vpsHex := "40010c11ffff016000000300900000030000030078959815bf7820001828b2e0c040000013f100000300000f11a0f0008714010a566e90"
+	data, err := hex.DecodeString(vpsHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vps, err := ParseVPSNALUnit(data)
+	if err != nil {
+		t.Fatalf("Error parsing VPS: %v", err)
+	}
+	if vps.VpsID != 0 {
+		t.Errorf("VpsID = %d, want 0", vps.VpsID)
+	}
+	if vps.MaxLayersMinus1 != 1 {
+		t.Errorf("MaxLayersMinus1 = %d, want 1", vps.MaxLayersMinus1)
+	}
+	if got := vps.GetNumLayers(); got != 2 {
+		t.Errorf("GetNumLayers() = %d, want 2", got)
+	}
+	if !vps.IsMultiLayer() {
+		t.Error("expected IsMultiLayer() to be true")
+	}
+	if vps.Extension == nil {
+		t.Fatal("expected non-nil VPS extension")
+	}
+	if got := vps.GetNumViews(); got != 2 {
+		t.Errorf("GetNumViews() = %d, want 2", got)
+	}
+	if got := vps.ScalabilityMaskBits(); got != 0x0002 {
+		t.Errorf("ScalabilityMaskBits() = 0x%04x, want 0x0002", got)
+	}
+	if vps.Extension.NumProfileTierLevel < 3 {
+		t.Errorf("NumProfileTierLevel = %d, want >= 3", vps.Extension.NumProfileTierLevel)
+	}
+	if vps.Extension.NumOutputLayerSets != 2 {
+		t.Errorf("NumOutputLayerSets = %d, want 2", vps.Extension.NumOutputLayerSets)
+	}
+	if vps.Extension.NumRepFormats != 1 {
+		t.Fatalf("NumRepFormats = %d, want 1", vps.Extension.NumRepFormats)
+	}
+	rf := vps.Extension.RepFormats[0]
+	if rf.PicWidthLumaSamples != 1920 || rf.PicHeightLumaSamples != 1080 {
+		t.Errorf("RepFormat resolution = %dx%d, want 1920x1080",
+			rf.PicWidthLumaSamples, rf.PicHeightLumaSamples)
+	}
+	// Layer 1 (dependent view) must reference layer 0 (base view).
+	if !vps.Extension.DirectDependencyFlag[1][0] {
+		t.Error("expected layer 1 to directly depend on layer 0")
+	}
+	if vps.Extension.NumDirectRefLayers[1] != 1 {
+		t.Errorf("NumDirectRefLayers[1] = %d, want 1", vps.Extension.NumDirectRefLayers[1])
+	}
+}
+
+func TestVPSSingleLayerNoExtension(t *testing.T) {
+	// Standard single-layer HEVC VPS (no vps_extension()).
+	vpsHex := "40010c01ffff022000000300b0000003000003007b18b024"
+	data, err := hex.DecodeString(vpsHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vps, err := ParseVPSNALUnit(data)
+	if err != nil {
+		t.Fatalf("Error parsing VPS: %v", err)
+	}
+	if vps.MaxLayersMinus1 != 0 {
+		t.Errorf("MaxLayersMinus1 = %d, want 0", vps.MaxLayersMinus1)
+	}
+	if vps.IsMultiLayer() {
+		t.Error("expected IsMultiLayer() to be false for single-layer VPS")
+	}
+	if vps.Extension != nil {
+		t.Error("expected nil VPS extension for single-layer VPS")
+	}
+	if got := vps.GetNumViews(); got != 1 {
+		t.Errorf("GetNumViews() = %d, want 1", got)
+	}
+	if got := vps.ScalabilityMaskBits(); got != 0 {
+		t.Errorf("ScalabilityMaskBits() = 0x%04x, want 0", got)
+	}
+}
+
 func TestVPSParseError(t *testing.T) {
 	// SPS NALU type instead of VPS
 	spsHex := "42010101600000030090000003000003007ba003c080109640"


### PR DESCRIPTION
## Summary

First sub-PR of the MV-HEVC effort: the HEVC-codec-layer groundwork. Adds parsing of the **multilayer/multiview VPS extension** and the **L-HEVC (`lhvC`) decoder configuration record**, which later PRs (MV-HEVC boxes, the `mp4ff-mvhevc` CLI) build on.

### VPS multilayer extension (`hevc/vps.go`)
- Parses `vps_extension()` (ISO/IEC 23008-2 Annex F.7.3.2.1.1), used by MV-HEVC and SHVC.
- The existing `VPS` struct and base parsing are **unchanged** (existing `TestVPSParser` passes as-is). The extension is exposed as an optional `VPS.Extension *VPSExtension` — mirroring the existing `TimingInfo *VPSTimingInfo` pattern, so single-layer streams are unaffected and `mp4ff-pslister` verbose output gains only a `"Extension": null` line.
- `VPSExtension` carries the scalability mask, per-layer `dimension_id`/dependency info, layer profile-tier-levels, output layer sets, and `rep_format()` resolutions.
- Helpers: `VPS.GetNumLayers`, `IsMultiLayer`, `GetNumViews`, `ScalabilityMaskBits`.

### L-HEVC config record (`hevc/hevcdecoderconfigurationrecord.go`)
- `DecConfRec.DecodeLHEVCDecConfRec`, `EncodeLHEVC`, `EncodeLHEVCSW`, `LHEVCSize` (ISO/IEC 14496-15 Ed. 7 §9.4.3 — the `lhvC` format omits the profile/tier/level and chroma/bit-depth/frame-rate fields of `hvcC`).

## Correctness

The output-layer-set parsing follows the normative syntax/semantics exactly (F-11/F-12/F-13):
- only OLS `i >= 1` read syntax elements (OLS 0 reads nothing),
- `profile_tier_level_idx` is gated on `NecessaryLayerFlag` **and** `vps_num_profile_tier_level_minus1 > 0`,
- `alt_output_layer_flag` is read when its derived condition holds,
- per-OLS state is computed in locals, so a large `NumOutputLayerSets` (`num_add_olss` can be up to 1023) cannot index the fixed-size arrays out of range.

VPS extensions with **additional layer sets** (`num_add_layer_sets > 0`) require the F-6/F-9 tree-partition derivations and never occur for MV-HEVC (single independent layer); they are rejected with an error rather than misparsed.

Bit-parsing was verified against ISO/IEC 23008-2 Ed.5 and ISO/IEC 14496-15 Ed.7 (a multi-reviewer adversarial pass against the spec syntax/semantics tables surfaced and fixed several alignment edge cases that the happy-path stereo vector did not exercise).

## Tests
- `TestVPSParser` (existing, single-layer) — unchanged, passes.
- `TestVPSMultiLayerExtension` — real GPAC MV-HEVC stereo VPS: 1920×1080, 2 views, `ScalabilityMaskBits=0x0002`, layer 1 → layer 0 dependency, 3 PTLs, 2 OLS.
- `TestVPSSingleLayerNoExtension` — single-layer VPS yields nil `Extension`.
- `TestLHEVCDecConfRecRoundTrip` — encode/decode round-trip + version-rejection.
- Regenerated the two `mp4ff-pslister` golden files (diff is exactly the added `"Extension": null` line).

`go test ./...`, `go vet`, and `golangci-lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
