### PR TITLE
feat: add lhvC L-HEVC configuration box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `LhvCBox` for the L-HEVC configuration box (`lhvC`, ISO/IEC 14496-15 Ed. 7
+  Sec. 9.5.3.1), carrying the L-HEVC decoder configuration record for the
+  enhancement layers of a layered HEVC (MV-HEVC/SHVC) stream, with a
+  `CreateLhvCFromNalus` constructor and a `VisualSampleEntryBox.LhvC` child
+  reference
 - Parsing of the HEVC multilayer/multiview VPS extension (`vps_extension()`,
   ISO/IEC 23008-2 Annex F.7.3.2.1.1) used by MV-HEVC and SHVC, exposed as an
   optional `hevc.VPS.Extension` (`*VPSExtension`) with scalability mask,

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -82,6 +82,7 @@ func init() {
 		"hint":    DecodeTrefType,
 		"hvc1":    DecodeVisualSampleEntry,
 		"hvcC":    DecodeHvcC,
+		"lhvC":    DecodeLhvC,
 		"iacb":    DecodeIacb,
 		"iamf":    DecodeAudioSampleEntry,
 		"iden":    DecodeIden,

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -73,6 +73,7 @@ func init() {
 		"hint":    DecodeTrefTypeSR,
 		"hvc1":    DecodeVisualSampleEntrySR,
 		"hvcC":    DecodeHvcCSR,
+		"lhvC":    DecodeLhvCSR,
 		"iacb":    DecodeIacbSR,
 		"iamf":    DecodeAudioSampleEntrySR,
 		"iden":    DecodeIdenSR,

--- a/mp4/lhvc.go
+++ b/mp4/lhvc.go
@@ -1,0 +1,100 @@
+package mp4
+
+import (
+	"encoding/hex"
+	"io"
+
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/hevc"
+)
+
+// LhvCBox - LHEVCConfigurationBox (ISO/IEC 14496-15 Ed. 7 Sec. 9.5.3.1)
+// Carries an L-HEVC decoder configuration record for the enhancement layers of
+// a layered HEVC (MV-HEVC/SHVC) stream. It appears alongside an HvcCBox in the
+// visual sample entry. The binary format differs from hvcC: the profile/tier/
+// level and chroma/bit-depth/frame-rate fields are omitted (see hevc Sec. 9.4.3).
+type LhvCBox struct {
+	hevc.DecConfRec
+}
+
+// CreateLhvCFromNalus creates an LhvCBox from enhancement-layer parameter sets.
+func CreateLhvCFromNalus(spsNalus, ppsNalus [][]byte) *LhvCBox {
+	naluArrays := []hevc.NaluArray{
+		hevc.NewNaluArray(true, hevc.NALU_SPS, spsNalus),
+		hevc.NewNaluArray(true, hevc.NALU_PPS, ppsNalus),
+	}
+	dcr := hevc.DecConfRec{
+		ConfigurationVersion: 1,
+		LengthSizeMinusOne:   3,
+		NaluArrays:           naluArrays,
+	}
+	return &LhvCBox{dcr}
+}
+
+// DecodeLhvC - box-specific decode
+func DecodeLhvC(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	data, err := readBoxBody(r, hdr)
+	if err != nil {
+		return nil, err
+	}
+	hdcr, err := hevc.DecodeLHEVCDecConfRec(data)
+	if err != nil {
+		return nil, err
+	}
+	return &LhvCBox{hdcr}, nil
+}
+
+// DecodeLhvCSR - box-specific decode
+func DecodeLhvCSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	hdcr, err := hevc.DecodeLHEVCDecConfRec(sr.ReadBytes(hdr.payloadLen()))
+	if err != nil {
+		return nil, err
+	}
+	return &LhvCBox{hdcr}, nil
+}
+
+// Type - return box type
+func (b *LhvCBox) Type() string {
+	return "lhvC"
+}
+
+// Size - return calculated size
+func (b *LhvCBox) Size() uint64 {
+	return uint64(boxHeaderSize) + b.LHEVCSize()
+}
+
+// Encode - write box to w
+func (b *LhvCBox) Encode(w io.Writer) error {
+	err := EncodeHeader(b, w)
+	if err != nil {
+		return err
+	}
+	return b.EncodeLHEVC(w)
+}
+
+// EncodeSW - write box to sw
+func (b *LhvCBox) EncodeSW(sw bits.SliceWriter) error {
+	err := EncodeHeaderSW(b, sw)
+	if err != nil {
+		return err
+	}
+	return b.EncodeLHEVCSW(sw)
+}
+
+// Info - box-specific Info
+func (b *LhvCBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
+	bd := newInfoDumper(w, indent, b, -1, 0)
+	hdcr := b.DecConfRec
+	bd.write(" - MinSpatialSegmentationIDC: %d", hdcr.MinSpatialSegmentationIDC)
+	bd.write(" - ParallelismType: %d", hdcr.ParallellismType)
+	bd.write(" - NumTemporalLayers: %d", hdcr.NumTemporalLayers)
+	bd.write(" - TemporalIdNested: %d", hdcr.TemporalIDNested)
+	bd.write(" - LengthSizeMinusOne: %d", hdcr.LengthSizeMinusOne)
+	for _, array := range hdcr.NaluArrays {
+		bd.write("   - %s complete: %d", array.NaluType(), array.Complete())
+		for _, nalu := range array.Nalus {
+			bd.write("    %s", hex.EncodeToString(nalu))
+		}
+	}
+	return bd.err
+}

--- a/mp4/lhvc_test.go
+++ b/mp4/lhvc_test.go
@@ -1,0 +1,84 @@
+package mp4_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+func TestLhvC(t *testing.T) {
+	// Enhancement-layer SPS and PPS from a reference MV-HEVC mp4 (GPAC output).
+	spsNalu, err := hex.DecodeString("42090e85924cae6a020202028180")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ppsNalu, err := hex.DecodeString("440948572b062a0140")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lhvC := mp4.CreateLhvCFromNalus([][]byte{spsNalu}, [][]byte{ppsNalu})
+	boxDiffAfterEncodeAndDecode(t, lhvC)
+}
+
+func TestLhvCDecodeFromHex(t *testing.T) {
+	// Full lhvC box bytes from a reference MV-HEVC mp4 (47 bytes including header).
+	boxHex := "0000002f6c68764301f000ffcf02a10001000e42090e85924cae6a020202028180a200010009440948572b062a0140"
+	data, err := hex.DecodeString(boxHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	box, err := mp4.DecodeBox(0, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lhvC, ok := box.(*mp4.LhvCBox)
+	if !ok {
+		t.Fatalf("expected *LhvCBox, got %T", box)
+	}
+	if lhvC.Type() != "lhvC" {
+		t.Errorf("Type() = %q, want lhvC", lhvC.Type())
+	}
+	if lhvC.LengthSizeMinusOne != 3 {
+		t.Errorf("LengthSizeMinusOne = %d, want 3", lhvC.LengthSizeMinusOne)
+	}
+	if lhvC.NumTemporalLayers != 1 {
+		t.Errorf("NumTemporalLayers = %d, want 1", lhvC.NumTemporalLayers)
+	}
+	if len(lhvC.NaluArrays) != 2 {
+		t.Fatalf("NaluArrays len = %d, want 2", len(lhvC.NaluArrays))
+	}
+
+	spsNalus := lhvC.GetNalusForType(hevc.NALU_SPS)
+	if len(spsNalus) != 1 {
+		t.Fatalf("SPS nalus = %d, want 1", len(spsNalus))
+	}
+	if hex.EncodeToString(spsNalus[0]) != "42090e85924cae6a020202028180" {
+		t.Errorf("SPS nalu mismatch: got %s", hex.EncodeToString(spsNalus[0]))
+	}
+
+	boxDiffAfterEncodeAndDecode(t, lhvC)
+}
+
+// TestVisualSampleEntryWithLhvC verifies that an lhvC box decodes as a child of
+// a visual sample entry (alongside hvcC) and is reachable via the LhvC pointer.
+func TestVisualSampleEntryWithLhvC(t *testing.T) {
+	hvc1 := mp4.CreateVisualSampleEntryBox("hvc1", 1920, 1080, nil)
+	spsNalu, _ := hex.DecodeString("42090e85924cae6a020202028180")
+	ppsNalu, _ := hex.DecodeString("440948572b062a0140")
+	hvc1.AddChild(mp4.CreateLhvCFromNalus([][]byte{spsNalu}, [][]byte{ppsNalu}))
+
+	boxDiffAfterEncodeAndDecode(t, hvc1)
+
+	decoded := boxAfterEncodeAndDecode(t, hvc1).(*mp4.VisualSampleEntryBox)
+	if decoded.LhvC == nil {
+		t.Fatal("expected decoded lhvC child reachable via LhvC pointer")
+	}
+	if len(decoded.LhvC.GetNalusForType(hevc.NALU_SPS)) != 1 {
+		t.Error("expected one SPS nalu in decoded lhvC")
+	}
+}

--- a/mp4/visualsampleentry.go
+++ b/mp4/visualsampleentry.go
@@ -20,6 +20,7 @@ type VisualSampleEntryBox struct {
 	CompressorName     string
 	AvcC               *AvcCBox
 	HvcC               *HvcCBox
+	LhvC               *LhvCBox
 	DoViConfig         *DoViConfigurationBox
 	Av1C               *Av1CBox
 	Av3c               *Av3cBox
@@ -71,6 +72,8 @@ func (b *VisualSampleEntryBox) AddChild(child Box) {
 		b.AvcC = box
 	case *HvcCBox:
 		b.HvcC = box
+	case *LhvCBox:
+		b.LhvC = box
 	case *DoViConfigurationBox:
 		b.DoViConfig = box
 	case *Av1CBox:


### PR DESCRIPTION
## Summary

Second sub-PR of the MV-HEVC effort (after #507). Adds the **`lhvC` configuration box** — the file-format wrapper around the L-HEVC decoder configuration record that #507 added to the `hevc` package.

- `LhvCBox` (ISO/IEC 14496-15 Ed. 7 §9.5.3.1) embeds `hevc.DecConfRec` and encodes/decodes it via the L-HEVC record format (no profile/tier/level or chroma/bit-depth fields). It carries the enhancement-layer parameter sets of a layered HEVC (MV-HEVC/SHVC) stream and appears as a child of the visual sample entry, alongside `hvcC`.
- `CreateLhvCFromNalus(spsNalus, ppsNalus)` constructor.
- Registered `lhvC` in the `box.go`/`boxsr.go` decoder tables.
- Added `VisualSampleEntryBox.LhvC *LhvCBox` child reference (+ `AddChild` case).

## Tests
- `TestLhvC` — build from NALUs and round-trip (io + SliceReader paths via `boxDiffAfterEncodeAndDecode`).
- `TestLhvCDecodeFromHex` — decodes a real 47-byte GPAC MV-HEVC `lhvC` payload and checks fields/NALU arrays.
- `TestVisualSampleEntryWithLhvC` — confirms `lhvC` round-trips as a child of an `hvc1` sample entry and is reachable via the `LhvC` pointer.

`go test ./...`, `go vet`, and `golangci-lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
