### PR TITLE
feat: add oinf and linf sample group entries for layered HEVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - L-HEVC (`lhvC`) decoder configuration record support in the hevc package:
   `DecConfRec.DecodeLHEVCDecConfRec`, `EncodeLHEVC`, `EncodeLHEVCSW` and
   `LHEVCSize` (ISO/IEC 14496-15 Ed. 7 Sec. 9.4.3)
+- `OinfSampleGroupEntry` for the Operating Points Information sample group
+  (`oinf`, ISO/IEC 14496-15 Ed. 7 Sec. 9.6.2) and `LinfSampleGroupEntry` for
+  the Layer Information sample group (`linf`, Sec. 4.15), used by layered HEVC
+  (MV-HEVC/SHVC)
 - `SampleAccessor.ReadMdatData` for bulk reading of the raw mdat payload of a
   fragment in a single read, intended for streaming with lazy mdat decoding
 - HDR metadata boxes `ClliBox` (Content Light Level, `clli`, ISO/IEC 14496-12

--- a/mp4/sampleGroupEntryLinf.go
+++ b/mp4/sampleGroupEntryLinf.go
@@ -1,0 +1,93 @@
+package mp4
+
+import (
+	"io"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// LinfSampleGroupEntry - Layer Information sample group entry ('linf')
+// ISO/IEC 14496-15 Ed. 7 Sec. 4.15 (LayerInfoGroupEntry). For L-HEVC (Sec. 9.6.3)
+// IrapGdrPicsInLayerOnlyFlag and CompletenessFlag are required to be 0, but they
+// are kept as fields here so the box round-trips for any layered codec.
+type LinfSampleGroupEntry struct {
+	Layers []LinfLayerEntry
+}
+
+// LinfLayerEntry describes a single layer in the linf sample group.
+type LinfLayerEntry struct {
+	IrapGdrPicsInLayerOnlyFlag bool
+	CompletenessFlag           bool
+	LayerID                    byte // 6 bits
+	MinTemporalID              byte // 3 bits
+	MaxTemporalID              byte // 3 bits
+	SubLayerPresenceFlags      byte // 7 bits
+}
+
+// DecodeLinfSampleGroupEntry decodes a linf sample group entry.
+func DecodeLinfSampleGroupEntry(name string, length uint32, sr bits.SliceReader) (SampleGroupEntry, error) {
+	e := &LinfSampleGroupEntry{}
+	numLayers := int(sr.ReadUint8() & 0x3f) // 2 reserved bits + 6 bits count
+
+	for i := 0; i < numLayers; i++ {
+		// 3 bytes per layer:
+		//  b1: reserved(2) irap_gdr_pics_in_layer_only_flag(1) completeness_flag(1) layer_id[5:2](4)
+		//  b2: layer_id[1:0](2) min_TemporalId(3) max_TemporalId(3)
+		//  b3: reserved(1) sub_layer_presence_flags(7)
+		b1 := sr.ReadUint8()
+		b2 := sr.ReadUint8()
+		b3 := sr.ReadUint8()
+		l := LinfLayerEntry{
+			IrapGdrPicsInLayerOnlyFlag: (b1>>5)&0x01 != 0,
+			CompletenessFlag:           (b1>>4)&0x01 != 0,
+			LayerID:                    ((b1 & 0x0f) << 2) | ((b2 >> 6) & 0x03),
+			MinTemporalID:              (b2 >> 3) & 0x07,
+			MaxTemporalID:              b2 & 0x07,
+			SubLayerPresenceFlags:      b3 & 0x7f,
+		}
+		e.Layers = append(e.Layers, l)
+	}
+	return e, sr.AccError()
+}
+
+// Type - grouping type
+func (e *LinfSampleGroupEntry) Type() string {
+	return "linf"
+}
+
+// Size - size of the sample group entry payload
+func (e *LinfSampleGroupEntry) Size() uint64 {
+	return uint64(1 + len(e.Layers)*3) // num_layers(1) + 3 bytes per layer
+}
+
+// Encode - encode the sample group entry to a SliceWriter
+func (e *LinfSampleGroupEntry) Encode(sw bits.SliceWriter) {
+	sw.WriteUint8(byte(len(e.Layers)) & 0x3f) // 2 reserved bits + 6 bits count
+
+	for _, l := range e.Layers {
+		var b1 byte
+		if l.IrapGdrPicsInLayerOnlyFlag {
+			b1 |= 0x20
+		}
+		if l.CompletenessFlag {
+			b1 |= 0x10
+		}
+		b1 |= (l.LayerID >> 2) & 0x0f
+		sw.WriteUint8(b1)
+		b2 := ((l.LayerID & 0x03) << 6) | ((l.MinTemporalID & 0x07) << 3) | (l.MaxTemporalID & 0x07)
+		sw.WriteUint8(b2)
+		sw.WriteUint8(l.SubLayerPresenceFlags & 0x7f)
+	}
+}
+
+// Info - write box-specific information
+func (e *LinfSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
+	bd := newInfoDumper(w, indent, e, -2, 0)
+	bd.write(" - numLayers: %d", len(e.Layers))
+	for i, l := range e.Layers {
+		bd.write("   Layer[%d]: layerId=%d minTid=%d maxTid=%d subFlags=0x%02x irapGdrOnly=%t complete=%t",
+			i, l.LayerID, l.MinTemporalID, l.MaxTemporalID, l.SubLayerPresenceFlags,
+			l.IrapGdrPicsInLayerOnlyFlag, l.CompletenessFlag)
+	}
+	return bd.err
+}

--- a/mp4/sampleGroupEntryLinfOinf_test.go
+++ b/mp4/sampleGroupEntryLinfOinf_test.go
@@ -1,0 +1,122 @@
+package mp4_test
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+func TestOinfSgpd(t *testing.T) {
+	oinf := &mp4.OinfSampleGroupEntry{
+		ScalabilityMask: 0x0002,
+		ProfileTierLevels: []mp4.OinfPTL{
+			{GeneralProfileSpace: 0, GeneralTierFlag: false, GeneralProfileIDC: 1, GeneralLevelIDC: 120,
+				GeneralProfileCompatibilityFlags: 0x60000000, GeneralConstraintIndicatorFlags: 0x900000000000},
+			{GeneralProfileSpace: 0, GeneralTierFlag: false, GeneralProfileIDC: 0, GeneralLevelIDC: 120},
+			{GeneralProfileSpace: 0, GeneralTierFlag: false, GeneralProfileIDC: 6, GeneralLevelIDC: 120},
+		},
+		OperatingPoints: []mp4.OinfOperatingPoint{
+			{
+				OutputLayerSetIdx: 0, MaxTemporalID: 0,
+				Layers: []mp4.OinfOPLayer{
+					{PtlIdx: 1, LayerID: 0, IsOutputLayer: true},
+				},
+				MinPicWidth: 1920, MinPicHeight: 1080, MaxPicWidth: 1920, MaxPicHeight: 1080,
+				MaxChromaFormat: 1, MaxBitDepthMinus8: 0,
+			},
+			{
+				OutputLayerSetIdx: 1, MaxTemporalID: 0,
+				Layers: []mp4.OinfOPLayer{
+					{PtlIdx: 1, LayerID: 0, IsOutputLayer: false},
+					{PtlIdx: 2, LayerID: 1, IsOutputLayer: true, IsAlternateOutLayer: false},
+				},
+				MinPicWidth: 1920, MinPicHeight: 1080, MaxPicWidth: 1920, MaxPicHeight: 1080,
+				MaxChromaFormat: 1, MaxBitDepthMinus8: 0,
+			},
+		},
+		DependencyLayers: []mp4.OinfDependencyLayer{
+			{LayerID: 0, DependsOnLayers: nil, DimensionIds: []byte{0}},
+			{LayerID: 1, DependsOnLayers: []byte{0}, DimensionIds: []byte{1}},
+		},
+	}
+
+	sgpd := &mp4.SgpdBox{
+		Version:            2,
+		GroupingType:       "oinf",
+		DefaultLength:      uint32(oinf.Size()),
+		SampleGroupEntries: []mp4.SampleGroupEntry{oinf},
+	}
+	boxDiffAfterEncodeAndDecode(t, sgpd)
+}
+
+// TestOinfSgpdWithRateInfo exercises the optional frame-rate and bit-rate fields,
+// which the basic round-trip vector does not cover.
+func TestOinfSgpdWithRateInfo(t *testing.T) {
+	oinf := &mp4.OinfSampleGroupEntry{
+		ScalabilityMask: 0x0002,
+		ProfileTierLevels: []mp4.OinfPTL{
+			{GeneralProfileSpace: 1, GeneralTierFlag: true, GeneralProfileIDC: 4, GeneralLevelIDC: 153,
+				GeneralProfileCompatibilityFlags: 0x12345678, GeneralConstraintIndicatorFlags: 0xabcdef012345},
+		},
+		OperatingPoints: []mp4.OinfOperatingPoint{
+			{
+				OutputLayerSetIdx: 1, MaxTemporalID: 3,
+				Layers: []mp4.OinfOPLayer{
+					{PtlIdx: 1, LayerID: 1, IsOutputLayer: true, IsAlternateOutLayer: true},
+				},
+				MinPicWidth: 1280, MinPicHeight: 720, MaxPicWidth: 3840, MaxPicHeight: 2160,
+				MaxChromaFormat: 2, MaxBitDepthMinus8: 2,
+				FrameRateInfoFlag: true, AvgFrameRate: 6000, ConstantFrameRate: 1,
+				BitRateInfoFlag: true, MaxBitRate: 20000000, AvgBitRate: 12000000,
+			},
+		},
+		DependencyLayers: []mp4.OinfDependencyLayer{
+			{LayerID: 1, DependsOnLayers: []byte{0}, DimensionIds: []byte{1}},
+		},
+	}
+	sgpd := &mp4.SgpdBox{
+		Version:            2,
+		GroupingType:       "oinf",
+		DefaultLength:      uint32(oinf.Size()),
+		SampleGroupEntries: []mp4.SampleGroupEntry{oinf},
+	}
+	boxDiffAfterEncodeAndDecode(t, sgpd)
+}
+
+func TestLinfSgpd(t *testing.T) {
+	linf := &mp4.LinfSampleGroupEntry{
+		Layers: []mp4.LinfLayerEntry{
+			{LayerID: 0, MinTemporalID: 0, MaxTemporalID: 0, SubLayerPresenceFlags: 0x7f},
+			{LayerID: 1, MinTemporalID: 0, MaxTemporalID: 0, SubLayerPresenceFlags: 0x7f},
+		},
+	}
+
+	sgpd := &mp4.SgpdBox{
+		Version:            2,
+		GroupingType:       "linf",
+		DefaultLength:      uint32(linf.Size()),
+		SampleGroupEntries: []mp4.SampleGroupEntry{linf},
+	}
+	boxDiffAfterEncodeAndDecode(t, sgpd)
+}
+
+// TestLinfSgpdWithFlags verifies that irap_gdr_pics_in_layer_only_flag and
+// completeness_flag round-trip (they are real fields per ISO/IEC 14496-15 Sec. 4.15,
+// non-zero for non-L-HEVC layered codecs).
+func TestLinfSgpdWithFlags(t *testing.T) {
+	linf := &mp4.LinfSampleGroupEntry{
+		Layers: []mp4.LinfLayerEntry{
+			{LayerID: 5, MinTemporalID: 1, MaxTemporalID: 6, SubLayerPresenceFlags: 0x3f,
+				IrapGdrPicsInLayerOnlyFlag: true, CompletenessFlag: true},
+			{LayerID: 33, MinTemporalID: 0, MaxTemporalID: 2, SubLayerPresenceFlags: 0x05,
+				IrapGdrPicsInLayerOnlyFlag: false, CompletenessFlag: true},
+		},
+	}
+	sgpd := &mp4.SgpdBox{
+		Version:            2,
+		GroupingType:       "linf",
+		DefaultLength:      uint32(linf.Size()),
+		SampleGroupEntries: []mp4.SampleGroupEntry{linf},
+	}
+	boxDiffAfterEncodeAndDecode(t, sgpd)
+}

--- a/mp4/sampleGroupEntryOinf.go
+++ b/mp4/sampleGroupEntryOinf.go
@@ -1,0 +1,269 @@
+package mp4
+
+import (
+	"io"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// OinfSampleGroupEntry - Operating Points Information sample group entry ('oinf')
+// ISO/IEC 14496-15 Ed. 7 Sec. 9.6.2 (OperatingPointsInformation/OperatingPointsRecord).
+type OinfSampleGroupEntry struct {
+	ScalabilityMask   uint16
+	ProfileTierLevels []OinfPTL
+	OperatingPoints   []OinfOperatingPoint
+	DependencyLayers  []OinfDependencyLayer
+}
+
+// OinfPTL - profile/tier/level entry referenced by operating-point layers.
+type OinfPTL struct {
+	GeneralProfileSpace              byte
+	GeneralTierFlag                  bool
+	GeneralProfileIDC                byte
+	GeneralProfileCompatibilityFlags uint32
+	GeneralConstraintIndicatorFlags  uint64 // 48 bits
+	GeneralLevelIDC                  byte
+}
+
+// OinfOperatingPoint - operating point description.
+type OinfOperatingPoint struct {
+	OutputLayerSetIdx uint16
+	MaxTemporalID     byte
+	Layers            []OinfOPLayer
+	MinPicWidth       uint16
+	MinPicHeight      uint16
+	MaxPicWidth       uint16
+	MaxPicHeight      uint16
+	MaxChromaFormat   byte // 2 bits
+	MaxBitDepthMinus8 byte // 3 bits
+	FrameRateInfoFlag bool
+	BitRateInfoFlag   bool
+	AvgFrameRate      uint16 // present if FrameRateInfoFlag
+	ConstantFrameRate byte   // 2 bits, present if FrameRateInfoFlag
+	MaxBitRate        uint32 // present if BitRateInfoFlag
+	AvgBitRate        uint32 // present if BitRateInfoFlag
+}
+
+// OinfOPLayer - per-layer info within an operating point.
+type OinfOPLayer struct {
+	PtlIdx              byte
+	LayerID             byte // 6 bits
+	IsOutputLayer       bool
+	IsAlternateOutLayer bool
+}
+
+// OinfDependencyLayer - layer dependency description.
+type OinfDependencyLayer struct {
+	LayerID         byte
+	DependsOnLayers []byte
+	DimensionIds    []byte // one per set bit in ScalabilityMask
+}
+
+// DecodeOinfSampleGroupEntry decodes an oinf sample group entry.
+func DecodeOinfSampleGroupEntry(name string, length uint32, sr bits.SliceReader) (SampleGroupEntry, error) {
+	e := &OinfSampleGroupEntry{}
+	e.ScalabilityMask = sr.ReadUint16()
+	numPTLs := int(sr.ReadUint8() & 0x3f) // 2 reserved bits + 6 bits count
+
+	for i := 0; i < numPTLs; i++ {
+		ptl := OinfPTL{}
+		b := sr.ReadUint8()
+		ptl.GeneralProfileSpace = (b >> 6) & 0x03
+		ptl.GeneralTierFlag = (b>>5)&0x01 != 0
+		ptl.GeneralProfileIDC = b & 0x1f
+		ptl.GeneralProfileCompatibilityFlags = sr.ReadUint32()
+		hi := uint64(sr.ReadUint16()) << 32
+		lo := uint64(sr.ReadUint32())
+		ptl.GeneralConstraintIndicatorFlags = hi | lo
+		ptl.GeneralLevelIDC = sr.ReadUint8()
+		e.ProfileTierLevels = append(e.ProfileTierLevels, ptl)
+	}
+
+	numOPs := int(sr.ReadUint16())
+	for i := 0; i < numOPs; i++ {
+		op := OinfOperatingPoint{}
+		op.OutputLayerSetIdx = sr.ReadUint16()
+		op.MaxTemporalID = sr.ReadUint8()
+		layerCount := int(sr.ReadUint8())
+		for j := 0; j < layerCount; j++ {
+			l := OinfOPLayer{}
+			l.PtlIdx = sr.ReadUint8()
+			b := sr.ReadUint8()
+			l.LayerID = (b >> 2) & 0x3f
+			l.IsOutputLayer = (b>>1)&0x01 != 0
+			l.IsAlternateOutLayer = b&0x01 != 0
+			op.Layers = append(op.Layers, l)
+		}
+		op.MinPicWidth = sr.ReadUint16()
+		op.MinPicHeight = sr.ReadUint16()
+		op.MaxPicWidth = sr.ReadUint16()
+		op.MaxPicHeight = sr.ReadUint16()
+		flagsByte := sr.ReadUint8()
+		op.MaxChromaFormat = (flagsByte >> 6) & 0x03
+		op.MaxBitDepthMinus8 = (flagsByte >> 3) & 0x07
+		op.FrameRateInfoFlag = (flagsByte>>1)&0x01 != 0
+		op.BitRateInfoFlag = flagsByte&0x01 != 0
+		if op.FrameRateInfoFlag {
+			op.AvgFrameRate = sr.ReadUint16()
+			op.ConstantFrameRate = sr.ReadUint8() & 0x03 // 6 reserved bits + 2 bits
+		}
+		if op.BitRateInfoFlag {
+			op.MaxBitRate = sr.ReadUint32()
+			op.AvgBitRate = sr.ReadUint32()
+		}
+		e.OperatingPoints = append(e.OperatingPoints, op)
+	}
+
+	numDeps := int(sr.ReadUint8()) // max_layer_count
+	numDims := popcount16(e.ScalabilityMask)
+	for i := 0; i < numDeps; i++ {
+		dep := OinfDependencyLayer{}
+		dep.LayerID = sr.ReadUint8()
+		numDepsOn := int(sr.ReadUint8())
+		for j := 0; j < numDepsOn; j++ {
+			dep.DependsOnLayers = append(dep.DependsOnLayers, sr.ReadUint8())
+		}
+		for j := 0; j < numDims; j++ {
+			dep.DimensionIds = append(dep.DimensionIds, sr.ReadUint8())
+		}
+		e.DependencyLayers = append(e.DependencyLayers, dep)
+	}
+
+	return e, sr.AccError()
+}
+
+// Type - grouping type
+func (e *OinfSampleGroupEntry) Type() string {
+	return "oinf"
+}
+
+// Size - size of the sample group entry payload
+func (e *OinfSampleGroupEntry) Size() uint64 {
+	size := uint64(3) // scalability_mask(2) + reserved+ptl_count(1)
+	size += uint64(len(e.ProfileTierLevels)) * 12
+	size += 2 // num_operating_points
+	for _, op := range e.OperatingPoints {
+		size += 4 // output_layer_set_idx(2) + max_temporal_id(1) + layer_count(1)
+		size += uint64(len(op.Layers)) * 2
+		size += 9 // minPic/maxPic dimensions(8) + flags(1)
+		if op.FrameRateInfoFlag {
+			size += 3 // avgFrameRate(2) + reserved+constantFrameRate(1)
+		}
+		if op.BitRateInfoFlag {
+			size += 8 // maxBitRate(4) + avgBitRate(4)
+		}
+	}
+	numDims := popcount16(e.ScalabilityMask)
+	size += 1 // max_layer_count
+	for _, dep := range e.DependencyLayers {
+		size += 2 // layer_id(1) + num_direct_ref_layers(1)
+		size += uint64(len(dep.DependsOnLayers))
+		size += uint64(numDims)
+	}
+	return size
+}
+
+// Encode - encode the sample group entry to a SliceWriter
+func (e *OinfSampleGroupEntry) Encode(sw bits.SliceWriter) {
+	sw.WriteUint16(e.ScalabilityMask)
+	sw.WriteUint8(byte(len(e.ProfileTierLevels)) & 0x3f)
+
+	for _, ptl := range e.ProfileTierLevels {
+		b := ptl.GeneralProfileSpace << 6
+		if ptl.GeneralTierFlag {
+			b |= 0x20
+		}
+		b |= ptl.GeneralProfileIDC & 0x1f
+		sw.WriteUint8(b)
+		sw.WriteUint32(ptl.GeneralProfileCompatibilityFlags)
+		sw.WriteUint16(uint16(ptl.GeneralConstraintIndicatorFlags >> 32))
+		sw.WriteUint32(uint32(ptl.GeneralConstraintIndicatorFlags & 0xffffffff))
+		sw.WriteUint8(ptl.GeneralLevelIDC)
+	}
+
+	sw.WriteUint16(uint16(len(e.OperatingPoints)))
+	for _, op := range e.OperatingPoints {
+		sw.WriteUint16(op.OutputLayerSetIdx)
+		sw.WriteUint8(op.MaxTemporalID)
+		sw.WriteUint8(byte(len(op.Layers)))
+		for _, l := range op.Layers {
+			sw.WriteUint8(l.PtlIdx)
+			b := (l.LayerID & 0x3f) << 2
+			if l.IsOutputLayer {
+				b |= 0x02
+			}
+			if l.IsAlternateOutLayer {
+				b |= 0x01
+			}
+			sw.WriteUint8(b)
+		}
+		sw.WriteUint16(op.MinPicWidth)
+		sw.WriteUint16(op.MinPicHeight)
+		sw.WriteUint16(op.MaxPicWidth)
+		sw.WriteUint16(op.MaxPicHeight)
+		flagsByte := (op.MaxChromaFormat & 0x03) << 6
+		flagsByte |= (op.MaxBitDepthMinus8 & 0x07) << 3
+		if op.FrameRateInfoFlag {
+			flagsByte |= 0x02
+		}
+		if op.BitRateInfoFlag {
+			flagsByte |= 0x01
+		}
+		sw.WriteUint8(flagsByte)
+		if op.FrameRateInfoFlag {
+			sw.WriteUint16(op.AvgFrameRate)
+			sw.WriteUint8(op.ConstantFrameRate & 0x03)
+		}
+		if op.BitRateInfoFlag {
+			sw.WriteUint32(op.MaxBitRate)
+			sw.WriteUint32(op.AvgBitRate)
+		}
+	}
+
+	sw.WriteUint8(byte(len(e.DependencyLayers)))
+	for _, dep := range e.DependencyLayers {
+		sw.WriteUint8(dep.LayerID)
+		sw.WriteUint8(byte(len(dep.DependsOnLayers)))
+		for _, id := range dep.DependsOnLayers {
+			sw.WriteUint8(id)
+		}
+		for _, dim := range dep.DimensionIds {
+			sw.WriteUint8(dim)
+		}
+	}
+}
+
+// Info - write box-specific information
+func (e *OinfSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
+	bd := newInfoDumper(w, indent, e, -2, 0)
+	bd.write(" - scalabilityMask: 0x%04x", e.ScalabilityMask)
+	bd.write(" - numProfileTierLevels: %d", len(e.ProfileTierLevels))
+	for i, ptl := range e.ProfileTierLevels {
+		bd.write("   PTL[%d]: space=%d tier=%t profile=%d level=%d",
+			i, ptl.GeneralProfileSpace, ptl.GeneralTierFlag, ptl.GeneralProfileIDC, ptl.GeneralLevelIDC)
+	}
+	bd.write(" - numOperatingPoints: %d", len(e.OperatingPoints))
+	for i, op := range e.OperatingPoints {
+		bd.write("   OP[%d]: olsIdx=%d maxTid=%d layers=%d dims=%dx%d-%dx%d",
+			i, op.OutputLayerSetIdx, op.MaxTemporalID, len(op.Layers),
+			op.MinPicWidth, op.MinPicHeight, op.MaxPicWidth, op.MaxPicHeight)
+		for j, l := range op.Layers {
+			bd.write("     layer[%d]: ptlIdx=%d layerId=%d output=%t", j, l.PtlIdx, l.LayerID, l.IsOutputLayer)
+		}
+	}
+	bd.write(" - numDependencyLayers: %d", len(e.DependencyLayers))
+	for i, dep := range e.DependencyLayers {
+		bd.write("   Dep[%d]: layerId=%d dependsOn=%v dimIds=%v", i, dep.LayerID, dep.DependsOnLayers, dep.DimensionIds)
+	}
+	return bd.err
+}
+
+// popcount16 returns the number of set bits in v.
+func popcount16(v uint16) int {
+	count := 0
+	for v != 0 {
+		count += int(v & 1)
+		v >>= 1
+	}
+	return count
+}

--- a/mp4/samplegroupentries.go
+++ b/mp4/samplegroupentries.go
@@ -31,6 +31,8 @@ func init() {
 		"roll": DecodeRollSampleGroupEntry,
 		"rap ": DecodeRapSampleGroupEntry,
 		"alst": DecodeAlstSampleGroupEntry,
+		"oinf": DecodeOinfSampleGroupEntry,
+		"linf": DecodeLinfSampleGroupEntry,
 	}
 }
 


### PR DESCRIPTION
## Summary

MV-HEVC effort: adds the two layered-HEVC sample group entries. Independent of the open `lhvC` PR (#508) — it only touches the sample-group machinery.

- **`OinfSampleGroupEntry`** — Operating Points Information sample group (`oinf`, ISO/IEC 14496-15 Ed. 7 §9.6.2): scalability mask, the list of profile/tier/levels, operating points (output layer set index, per-layer ptl/output flags, min/max picture dimensions, optional frame-rate and bit-rate info) and layer dependencies with dimension IDs.
- **`LinfSampleGroupEntry`** — Layer Information sample group (`linf`, §4.15): per-layer `layer_id`, min/max `TemporalId`, and `sub_layer_presence_flags`.
- Both registered as sample group entry decoders.

## Spec note
The `linf` per-layer entry in §4.15 includes `irap_gdr_pics_in_layer_only_flag` and `completeness_flag`. I kept these as real fields so the box round-trips for **any** layered codec; for L-HEVC specifically they are required to be 0 (§9.6.3).

## Tests
- `TestOinfSgpd` / `TestLinfSgpd` — round-trip via `SgpdBox` (io + SliceReader paths).
- `TestOinfSgpdWithRateInfo` — exercises the optional frame-rate/bit-rate fields and the alternate-output-layer flag.
- `TestLinfSgpdWithFlags` — verifies `irap_gdr_pics_in_layer_only_flag`/`completeness_flag` and a 6-bit `layer_id` split across two bytes round-trip.

Bit layouts were verified field-by-field against the 14496-15 syntax tables (independent adversarial review found no discrepancies). `go test ./...`, `go vet`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
