### PR TITLE
feat: add lbli external base layer sample group entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`oinf`, ISO/IEC 14496-15 Ed. 7 Sec. 9.6.2) and `LinfSampleGroupEntry` for
   the Layer Information sample group (`linf`, Sec. 4.15), used by layered HEVC
   (MV-HEVC/SHVC)
+- `LbliSampleGroupEntry` for the L-HEVC external base layer sample group
+  (`lbli`, LhvcExternalBaseLayerInfo, ISO/IEC 14496-15 Ed. 7 Sec. 9.6.1),
+  used by L-HEVC tracks that predict from an external base layer in a
+  separate track
 - `SampleAccessor.ReadMdatData` for bulk reading of the raw mdat payload of a
   fragment in a single read, intended for streaming with lazy mdat decoding
 - HDR metadata boxes `ClliBox` (Content Light Level, `clli`, ISO/IEC 14496-12

--- a/mp4/sampleGroupEntryLbli.go
+++ b/mp4/sampleGroupEntryLbli.go
@@ -1,0 +1,59 @@
+package mp4
+
+import (
+	"io"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// LbliSampleGroupEntry - External base layer sample group entry ('lbli')
+// (LhvcExternalBaseLayerInfo, ISO/IEC 14496-15 Ed. 7 Sec. 9.6.1). Used for L-HEVC
+// tracks that predict from an external base layer carried in a separate track
+// (referenced via 'sbas'), i.e. when the active VPS has
+// vps_base_layer_internal_flag == 0 and vps_base_layer_available_flag == 1.
+type LbliSampleGroupEntry struct {
+	BlIrapPicFlag     bool
+	BlIrapNalUnitType byte // 6 bits
+	SampleOffset      int8
+}
+
+// DecodeLbliSampleGroupEntry decodes an lbli sample group entry.
+func DecodeLbliSampleGroupEntry(name string, length uint32, sr bits.SliceReader) (SampleGroupEntry, error) {
+	b := sr.ReadUint8() // reserved(1) + bl_irap_pic_flag(1) + bl_irap_nal_unit_type(6)
+	e := &LbliSampleGroupEntry{
+		BlIrapPicFlag:     (b>>6)&0x01 != 0,
+		BlIrapNalUnitType: b & 0x3f,
+		SampleOffset:      int8(sr.ReadUint8()),
+	}
+	return e, sr.AccError()
+}
+
+// Type - grouping type
+func (e *LbliSampleGroupEntry) Type() string {
+	return "lbli"
+}
+
+// Size - size of the sample group entry payload
+func (e *LbliSampleGroupEntry) Size() uint64 {
+	return 2 // flags(1) + sample_offset(1)
+}
+
+// Encode - encode the sample group entry to a SliceWriter
+func (e *LbliSampleGroupEntry) Encode(sw bits.SliceWriter) {
+	b := byte(0x80) // reserved bit = '1'
+	if e.BlIrapPicFlag {
+		b |= 0x40
+	}
+	b |= e.BlIrapNalUnitType & 0x3f
+	sw.WriteUint8(b)
+	sw.WriteUint8(byte(e.SampleOffset))
+}
+
+// Info - write box-specific information
+func (e *LbliSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
+	bd := newInfoDumper(w, indent, e, -2, 0)
+	bd.write(" - blIrapPicFlag: %t", e.BlIrapPicFlag)
+	bd.write(" - blIrapNalUnitType: %d", e.BlIrapNalUnitType)
+	bd.write(" - sampleOffset: %d", e.SampleOffset)
+	return bd.err
+}

--- a/mp4/sampleGroupEntryLbli_test.go
+++ b/mp4/sampleGroupEntryLbli_test.go
@@ -1,0 +1,33 @@
+package mp4_test
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+func TestLbliSgpd(t *testing.T) {
+	cases := []struct {
+		name string
+		e    *mp4.LbliSampleGroupEntry
+	}{
+		{"irap", &mp4.LbliSampleGroupEntry{BlIrapPicFlag: true, BlIrapNalUnitType: 21, SampleOffset: 0}},
+		{"non-irap", &mp4.LbliSampleGroupEntry{BlIrapPicFlag: false, BlIrapNalUnitType: 0, SampleOffset: 1}},
+		{"negative offset", &mp4.LbliSampleGroupEntry{BlIrapPicFlag: false, BlIrapNalUnitType: 0, SampleOffset: -3}},
+		{"max nal type", &mp4.LbliSampleGroupEntry{BlIrapPicFlag: true, BlIrapNalUnitType: 0x3f, SampleOffset: 127}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.e.Type() != "lbli" {
+				t.Errorf("Type() = %q, want lbli", c.e.Type())
+			}
+			sgpd := &mp4.SgpdBox{
+				Version:            2,
+				GroupingType:       "lbli",
+				DefaultLength:      uint32(c.e.Size()),
+				SampleGroupEntries: []mp4.SampleGroupEntry{c.e},
+			}
+			boxDiffAfterEncodeAndDecode(t, sgpd)
+		})
+	}
+}

--- a/mp4/samplegroupentries.go
+++ b/mp4/samplegroupentries.go
@@ -33,6 +33,7 @@ func init() {
 		"alst": DecodeAlstSampleGroupEntry,
 		"oinf": DecodeOinfSampleGroupEntry,
 		"linf": DecodeLinfSampleGroupEntry,
+		"lbli": DecodeLbliSampleGroupEntry,
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the last L-HEVC sample group from §9.6 — the **external base layer** sample group.

- **`LbliSampleGroupEntry`** — `LhvcExternalBaseLayerInfo` (`lbli`, ISO/IEC 14496-15 Ed. 7 §9.6.1). Signals per-sample inter-layer prediction parameters for L-HEVC tracks whose base layer is carried in a *separate* track (referenced via `'sbas'`), i.e. when the active VPS has `vps_base_layer_internal_flag == 0` and `vps_base_layer_available_flag == 1`.

Payload is 2 bytes: `bl_irap_pic_flag` (1), `bl_irap_nal_unit_type` (6), and a signed `sample_offset` (int8); the leading reserved bit is written as `1` per spec. Registered as a sample group entry decoder.

## Tests
`TestLbliSgpd` round-trips (io + SliceReader, via `SgpdBox`) across IRAP/non-IRAP, a negative `sample_offset` (signedness), and max 6-bit nal_unit_type / max offset.

Bit layout matches §9.6.1.2 exactly. `go test ./...`, `go vet`, `golangci-lint` clean.

Note: not needed for MV-HEVC stereo (which uses an internal base layer); added for completeness of §9.6 L-HEVC sample group coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
