### PR TITLE
fix: derive necessary layers for VPS output layer set 0

### DIFF
--- a/hevc/vps.go
+++ b/hevc/vps.go
@@ -491,8 +491,12 @@ func parseVPSExtension(vps *VPS, ext *VPSExtension, r *bits.EBSPReader) error {
 		}
 
 		if i == 0 {
-			// output_layer_flag[0][0] is inferred to 1; no bits are read for OLS 0.
+			// OLS 0 is layer set 0, which contains only the base layer. No bits are
+			// read for it, but its derived state is still defined (F-12/F-13): the
+			// single base layer is the inferred output layer and is necessary.
 			ext.OutputLayerFlag[0][0] = true
+			ext.NecessaryLayersFlag[0][0] = true
+			ext.NumNecessaryLayers[0] = 1
 			if vps.BaseLayerInternalFlag && vps.MaxLayersMinus1 > 0 {
 				ext.ProfileTierLevelIdx[0][0] = 1
 			}

--- a/hevc/vps_test.go
+++ b/hevc/vps_test.go
@@ -227,6 +227,17 @@ func TestVPSMultiLayerExtension(t *testing.T) {
 	if vps.Extension.NumDirectRefLayers[1] != 1 {
 		t.Errorf("NumDirectRefLayers[1] = %d, want 1", vps.Extension.NumDirectRefLayers[1])
 	}
+	// OLS 0 is the base layer set: its single layer is output and necessary.
+	if vps.Extension.NumNecessaryLayers[0] != 1 {
+		t.Errorf("NumNecessaryLayers[0] = %d, want 1", vps.Extension.NumNecessaryLayers[0])
+	}
+	if !vps.Extension.OutputLayerFlag[0][0] || !vps.Extension.NecessaryLayersFlag[0][0] {
+		t.Error("expected OLS 0 base layer to be output and necessary")
+	}
+	// OLS 1 contains both layers as necessary (stereo, both views output).
+	if vps.Extension.NumNecessaryLayers[1] != 2 {
+		t.Errorf("NumNecessaryLayers[1] = %d, want 2", vps.Extension.NumNecessaryLayers[1])
+	}
 }
 
 func TestVPSSingleLayerNoExtension(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a gap in the (unreleased) HEVC VPS multilayer extension parser: the F-12/F-13 derivation was skipped for **output layer set 0** (the base layer set), leaving `NumNecessaryLayers[0]` and `NecessaryLayersFlag[0]` unset (zero).

OLS 0 always contains exactly the single base layer (layer set 0), which is the inferred output layer and is necessary. The fix sets `NumNecessaryLayers[0] = 1` and `NecessaryLayersFlag[0][0] = true` in the `i == 0` branch. No bits are read for OLS 0, so bitstream parsing is otherwise unchanged (the existing multilayer vector parses identically).

## Why it matters
This surfaced while building the Operating Points Information (`oinf`) sample group from a parsed VPS: OLS 0 must describe a one-layer operating point (the base layer), but with `NumNecessaryLayers[0] == 0` it came out empty. The fix is a prerequisite for correct `oinf` generation.

## Tests
`TestVPSMultiLayerExtension` now also asserts the OLS-0 derivation (`NumNecessaryLayers[0] == 1`, base layer output+necessary) and `NumNecessaryLayers[1] == 2` for the stereo OLS. `go test ./...`, `go vet`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
