### PR TITLE
feat: add BuildOinfFromVPS and BuildLinfFromVPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`oinf`, ISO/IEC 14496-15 Ed. 7 Sec. 9.6.2) and `LinfSampleGroupEntry` for
   the Layer Information sample group (`linf`, Sec. 4.15), used by layered HEVC
   (MV-HEVC/SHVC)
+- `BuildOinfFromVPS` and `BuildLinfFromVPS` to derive the `oinf` and `linf`
+  sample group entries for a layered HEVC track from a parsed multilayer
+  `hevc.VPS`
 - `LbliSampleGroupEntry` for the L-HEVC external base layer sample group
   (`lbli`, LhvcExternalBaseLayerInfo, ISO/IEC 14496-15 Ed. 7 Sec. 9.6.1),
   used by L-HEVC tracks that predict from an external base layer in a

--- a/mp4/mvhevc.go
+++ b/mp4/mvhevc.go
@@ -1,0 +1,174 @@
+package mp4
+
+import (
+	"fmt"
+
+	"github.com/Eyevinn/mp4ff/hevc"
+)
+
+// BuildOinfFromVPS builds an Operating Points Information sample group entry
+// ('oinf', ISO/IEC 14496-15 Sec. 9.6.2) from a parsed layered VPS. It requires
+// the VPS to carry a multilayer extension (vps.Extension != nil), as produced for
+// an MV-HEVC/SHVC bitstream. The derivation follows GPAC's naludmx_set_hevc_oinf.
+func BuildOinfFromVPS(vps *hevc.VPS) (*OinfSampleGroupEntry, error) {
+	if vps == nil || vps.Extension == nil {
+		return nil, fmt.Errorf("oinf requires a multilayer VPS with a parsed extension")
+	}
+	ext := vps.Extension
+	e := &OinfSampleGroupEntry{ScalabilityMask: vps.ScalabilityMaskBits()}
+
+	// Profile tier levels: index 0 is the base layer PTL, the rest are the
+	// extension PTLs parsed from vps_extension().
+	for i := 0; i < ext.NumProfileTierLevel; i++ {
+		ptl := vps.ProfileTierLevel
+		if i > 0 {
+			if i-1 >= len(ext.ExtProfileTierLevels) {
+				break
+			}
+			ptl = ext.ExtProfileTierLevels[i-1]
+		}
+		e.ProfileTierLevels = append(e.ProfileTierLevels, OinfPTL{
+			GeneralProfileSpace:              ptl.GeneralProfileSpace,
+			GeneralTierFlag:                  ptl.GeneralTierFlag,
+			GeneralProfileIDC:                ptl.GeneralProfileIDC,
+			GeneralProfileCompatibilityFlags: ptl.GeneralProfileCompatibilityFlags,
+			GeneralConstraintIndicatorFlags:  ptl.GeneralConstraintIndicatorFlags,
+			GeneralLevelIDC:                  ptl.GeneralLevelIDC,
+		})
+	}
+
+	numDims := popcount16(e.ScalabilityMask)
+
+	// One operating point per output layer set. For MV-HEVC there are no
+	// additional output layer sets, so the OLS index equals its layer-set index;
+	// LayerSetLayerIdList / NecessaryLayersFlag / ProfileTierLevelIdx are all
+	// indexed by that value. Output layer sets that map to a different layer set
+	// (num_add_olss > 0) are not supported here, as that mapping is not retained.
+	numOLS := ext.NumOutputLayerSets
+	if numOLS > len(ext.NumNecessaryLayers) {
+		numOLS = len(ext.NumNecessaryLayers)
+	}
+	for i := 0; i < numOLS; i++ {
+		op := OinfOperatingPoint{OutputLayerSetIdx: uint16(i)}
+		numInSet := ext.NumLayersInIdList[i]
+		if numInSet > len(ext.LayerSetLayerIdList[i]) {
+			numInSet = len(ext.LayerSetLayerIdList[i])
+		}
+		var minW, minH, maxW, maxH uint16
+		var maxChroma, maxBitDepth, maxTid byte
+		// List the necessary layers of the OLS, keyed by their nuh_layer_id.
+		for k := 0; k < numInSet; k++ {
+			if !ext.NecessaryLayersFlag[i][k] {
+				continue
+			}
+			nuhLayerID := ext.LayerSetLayerIdList[i][k]
+			vpsIdx := ext.LayerIdInVps[nuhLayerID]
+			op.Layers = append(op.Layers, OinfOPLayer{
+				PtlIdx:        ext.ProfileTierLevelIdx[i][k],
+				LayerID:       nuhLayerID,
+				IsOutputLayer: ext.OutputLayerFlag[i][k],
+			})
+			if ext.SubLayersVpsMaxMinus1[vpsIdx] > maxTid {
+				maxTid = ext.SubLayersVpsMaxMinus1[vpsIdx]
+			}
+			fmtIdx := ext.RepFormatIdx[vpsIdx]
+			if int(fmtIdx) >= len(ext.RepFormats) {
+				continue
+			}
+			rf := ext.RepFormats[fmtIdx]
+			if minW == 0 || rf.PicWidthLumaSamples < minW {
+				minW = rf.PicWidthLumaSamples
+			}
+			if minH == 0 || rf.PicHeightLumaSamples < minH {
+				minH = rf.PicHeightLumaSamples
+			}
+			if rf.PicWidthLumaSamples > maxW {
+				maxW = rf.PicWidthLumaSamples
+			}
+			if rf.PicHeightLumaSamples > maxH {
+				maxH = rf.PicHeightLumaSamples
+			}
+			if rf.ChromaFormatIDC > maxChroma {
+				maxChroma = rf.ChromaFormatIDC
+			}
+			bd := rf.BitDepthLuma
+			if rf.BitDepthChroma > bd {
+				bd = rf.BitDepthChroma
+			}
+			if bd > maxBitDepth {
+				maxBitDepth = bd
+			}
+		}
+		op.MaxTemporalID = maxTid
+		op.MinPicWidth = minW
+		op.MinPicHeight = minH
+		op.MaxPicWidth = maxW
+		op.MaxPicHeight = maxH
+		op.MaxChromaFormat = maxChroma
+		if maxBitDepth >= 8 {
+			op.MaxBitDepthMinus8 = maxBitDepth - 8
+		}
+		e.OperatingPoints = append(e.OperatingPoints, op)
+	}
+
+	// Dependency layers: one entry per layer with its direct reference layers and
+	// the dimension IDs corresponding to the set scalability_mask bits.
+	for i := 0; i <= int(vps.MaxLayersMinus1) && i < len(ext.LayerIdInNuh); i++ {
+		nuhLID := ext.LayerIdInNuh[i]
+		dep := OinfDependencyLayer{LayerID: nuhLID}
+		for j := byte(0); j < ext.NumDirectRefLayers[nuhLID] && int(j) < len(ext.IdDirectRefLayers[nuhLID]); j++ {
+			dep.DependsOnLayers = append(dep.DependsOnLayers, ext.IdDirectRefLayers[nuhLID][j])
+		}
+		dimIdx := 0
+		for k := 0; k < 16; k++ {
+			if e.ScalabilityMask&(1<<k) != 0 {
+				if dimIdx < len(ext.DimensionId[i]) {
+					dep.DimensionIds = append(dep.DimensionIds, ext.DimensionId[i][dimIdx])
+				}
+				dimIdx++
+			}
+		}
+		for len(dep.DimensionIds) < numDims {
+			dep.DimensionIds = append(dep.DimensionIds, 0)
+		}
+		e.DependencyLayers = append(e.DependencyLayers, dep)
+	}
+
+	return e, nil
+}
+
+// BuildLinfFromVPS builds a Layer Information sample group entry ('linf',
+// ISO/IEC 14496-15 Sec. 4.15) covering all layers of a layered VPS. It requires
+// the VPS to carry a multilayer extension. maxTemporalIDs optionally gives the
+// observed max temporal id per VPS layer index; a missing entry falls back to the
+// VPS-signalled sub_layers_vps_max_minus1 for that layer.
+func BuildLinfFromVPS(vps *hevc.VPS, maxTemporalIDs []byte) (*LinfSampleGroupEntry, error) {
+	if vps == nil || vps.Extension == nil {
+		return nil, fmt.Errorf("linf requires a multilayer VPS with a parsed extension")
+	}
+	ext := vps.Extension
+	e := &LinfSampleGroupEntry{}
+	numLayers := int(vps.MaxLayersMinus1) + 1
+	for i := 0; i < numLayers && i < len(ext.LayerIdInNuh); i++ {
+		maxTid := ext.SubLayersVpsMaxMinus1[i]
+		if i < len(maxTemporalIDs) {
+			maxTid = maxTemporalIDs[i]
+		}
+		e.Layers = append(e.Layers, LinfLayerEntry{
+			LayerID:               ext.LayerIdInNuh[i],
+			MinTemporalID:         0,
+			MaxTemporalID:         maxTid,
+			SubLayerPresenceFlags: subLayerPresenceMask(maxTid),
+		})
+	}
+	return e, nil
+}
+
+// subLayerPresenceMask returns the 7-bit sub_layer_presence_flags value with the
+// bits for temporal ids 0..maxTid set.
+func subLayerPresenceMask(maxTid byte) byte {
+	if maxTid >= 6 {
+		return 0x7f
+	}
+	return byte((1 << (maxTid + 1)) - 1)
+}

--- a/mp4/mvhevc_test.go
+++ b/mp4/mvhevc_test.go
@@ -1,0 +1,118 @@
+package mp4_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/hevc"
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+// stereoVPSHex is a real MV-HEVC stereo VPS (GPAC output) with a vps_extension():
+// 2 layers, 2 views, scalability_mask 0x0002, 3 profile-tier-levels, 2 output
+// layer sets, one 1920x1080 rep format, layer 1 depends on layer 0.
+const stereoVPSHex = "40010c11ffff016000000300900000030000030078959815bf7820001828b2e0c040000013f100000300000f11a0f0008714010a566e90"
+
+func parseStereoVPS(t *testing.T) *hevc.VPS {
+	t.Helper()
+	data, err := hex.DecodeString(stereoVPSHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vps, err := hevc.ParseVPSNALUnit(data)
+	if err != nil {
+		t.Fatalf("parse VPS: %v", err)
+	}
+	return vps
+}
+
+func TestBuildOinfFromVPS(t *testing.T) {
+	vps := parseStereoVPS(t)
+	oinf, err := mp4.BuildOinfFromVPS(vps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oinf.ScalabilityMask != 0x0002 {
+		t.Errorf("ScalabilityMask = 0x%04x, want 0x0002", oinf.ScalabilityMask)
+	}
+	if len(oinf.ProfileTierLevels) != 3 {
+		t.Errorf("ProfileTierLevels = %d, want 3", len(oinf.ProfileTierLevels))
+	}
+	if len(oinf.OperatingPoints) != 2 {
+		t.Fatalf("OperatingPoints = %d, want 2", len(oinf.OperatingPoints))
+	}
+	// OLS 0 is the base layer operating point: a single output layer (nuh_layer_id
+	// 0, ptl_idx 1) at full resolution.
+	op0 := oinf.OperatingPoints[0]
+	if len(op0.Layers) != 1 {
+		t.Fatalf("OP[0] layers = %d, want 1", len(op0.Layers))
+	}
+	if op0.Layers[0].LayerID != 0 || op0.Layers[0].PtlIdx != 1 || !op0.Layers[0].IsOutputLayer {
+		t.Errorf("OP[0] layer = %+v, want layerID 0, ptlIdx 1, output", op0.Layers[0])
+	}
+	if op0.MaxPicWidth != 1920 || op0.MaxPicHeight != 1080 {
+		t.Errorf("OP[0] max dims = %dx%d, want 1920x1080", op0.MaxPicWidth, op0.MaxPicHeight)
+	}
+	// OLS 1 contains both layers (nuh_layer_id 0 and 1, ptl_idx 1 and 2).
+	op1 := oinf.OperatingPoints[1]
+	if len(op1.Layers) != 2 {
+		t.Fatalf("OP[1] layers = %d, want 2", len(op1.Layers))
+	}
+	if op1.Layers[0].LayerID != 0 || op1.Layers[1].LayerID != 1 {
+		t.Errorf("OP[1] layer ids = %d,%d, want 0,1", op1.Layers[0].LayerID, op1.Layers[1].LayerID)
+	}
+	if op1.Layers[0].PtlIdx != 1 || op1.Layers[1].PtlIdx != 2 {
+		t.Errorf("OP[1] ptl idx = %d,%d, want 1,2", op1.Layers[0].PtlIdx, op1.Layers[1].PtlIdx)
+	}
+	if op1.MaxPicWidth != 1920 || op1.MaxPicHeight != 1080 {
+		t.Errorf("OP[1] max dims = %dx%d, want 1920x1080", op1.MaxPicWidth, op1.MaxPicHeight)
+	}
+	// Two dependency layers: layer 0 (independent) and layer 1 (depends on 0).
+	if len(oinf.DependencyLayers) != 2 {
+		t.Fatalf("DependencyLayers = %d, want 2", len(oinf.DependencyLayers))
+	}
+	if len(oinf.DependencyLayers[0].DependsOnLayers) != 0 {
+		t.Errorf("layer 0 should be independent, got deps %v", oinf.DependencyLayers[0].DependsOnLayers)
+	}
+	if got := oinf.DependencyLayers[1].DependsOnLayers; len(got) != 1 || got[0] != 0 {
+		t.Errorf("layer 1 deps = %v, want [0]", got)
+	}
+
+	// Round-trip the built entry through an sgpd.
+	sgpd := &mp4.SgpdBox{Version: 2, GroupingType: "oinf", DefaultLength: uint32(oinf.Size()),
+		SampleGroupEntries: []mp4.SampleGroupEntry{oinf}}
+	boxDiffAfterEncodeAndDecode(t, sgpd)
+}
+
+func TestBuildLinfFromVPS(t *testing.T) {
+	vps := parseStereoVPS(t)
+	linf, err := mp4.BuildLinfFromVPS(vps, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(linf.Layers) != 2 {
+		t.Fatalf("Layers = %d, want 2", len(linf.Layers))
+	}
+	if linf.Layers[0].LayerID != 0 || linf.Layers[1].LayerID != 1 {
+		t.Errorf("layer ids = %d,%d, want 0,1", linf.Layers[0].LayerID, linf.Layers[1].LayerID)
+	}
+
+	sgpd := &mp4.SgpdBox{Version: 2, GroupingType: "linf", DefaultLength: uint32(linf.Size()),
+		SampleGroupEntries: []mp4.SampleGroupEntry{linf}}
+	boxDiffAfterEncodeAndDecode(t, sgpd)
+}
+
+func TestBuildFromVPSRequiresExtension(t *testing.T) {
+	// Single-layer VPS has no extension; the builders must return an error.
+	data, _ := hex.DecodeString("40010c01ffff022000000300b0000003000003007b18b024")
+	vps, err := hevc.ParseVPSNALUnit(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mp4.BuildOinfFromVPS(vps); err == nil {
+		t.Error("expected error for single-layer VPS (oinf)")
+	}
+	if _, err := mp4.BuildLinfFromVPS(vps, nil); err == nil {
+		t.Error("expected error for single-layer VPS (linf)")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the functional core that ties a parsed multilayer VPS to the L-HEVC sample groups:

- **`BuildOinfFromVPS(vps) (*OinfSampleGroupEntry, error)`** — derives the Operating Points Information (`oinf`) sample group: the list of profile/tier/levels, one operating point per output layer set (its necessary layers keyed by `nuh_layer_id` with `ptl_idx` and output flag, the min/max picture dimensions / chroma / bit depth aggregated over each layer's `rep_format`, and the per-OP max temporal id), and the per-layer dependency + scalability-dimension info.
- **`BuildLinfFromVPS(vps, maxTemporalIDs) (*LinfSampleGroupEntry, error)`** — derives the Layer Information (`linf`) sample group: one entry per layer with its temporal-id range and sub-layer presence flags.

Both require a multilayer VPS (`vps.Extension != nil`, i.e. a VPS with a parsed `vps_extension()`) and return an error otherwise.

## Spec correctness
The derivations were verified against ISO/IEC 14496-15 §9.6.2 (`oinf`) and §4.15 (`linf`) by an adversarial spec review, which caught three latent issues that a stereo-only test masks (where in-OLS position, `nuh_layer_id`, and VPS layer index all coincide). All are fixed here — the operating-point fields key on the real `nuh_layer_id` / VPS layer index, not the loop position:
- OP `layer_id` = the layer set's `nuh_layer_id` (not the position index).
- OP `max_temporal_id` = max of `sub_layers_vps_max_minus1` over the OP's necessary layers (not the base layer's value).
- rep-format lookup is indexed by the layer's VPS index (not the position).
- the operating point lists exactly the layers with `NecessaryLayerFlag` set.
- `sub_layer_presence_flags` sets bits `[0, max_TemporalId]` (per §4.15, bits outside `[min,max]` are unspecified).

Output layer sets that map to a different layer set (`num_add_olss > 0`) are not supported, as that mapping isn't retained by the parser — this does not occur for MV-HEVC.

## Tests
Parses a real GPAC MV-HEVC stereo VPS and checks the emitted `oinf` (scalability mask `0x0002`, 3 PTLs, both operating points including the base-layer OLS with one layer, `nuh_layer_id`s `0`/`1`, `ptl_idx` `1`/`2`, 1920×1080, and the dependency layers) and `linf` (two layers), round-tripping each through an `SgpdBox`; plus an error case for a single-layer VPS. `go test ./...`, `go vet`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
