### PR TITLE
chore: bump minimum Go version from 1.17 to 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,9 +9,10 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         platform: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: ["1.17", "1.26"]
+        go-version: ["1.19", "1.26"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ReadExpGolomb`/`ReadSignedGolomb` on `bits.Reader` and
   `WriteExpGolomb`/`WriteSignedGolomb` on `bits.FixedSliceWriter`
 
+### Changed
+
+- Minimum Go version bumped from 1.17 to 1.19. Fuzz tests require native
+  fuzzing (`testing.F`, Go 1.18), and Go 1.19 fixes fuzz-corpus CRLF handling
+  so the seed corpus loads on Windows CI
+
 ## [0.52.0] - 2026-05-12
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Eyevinn/mp4ff
 
-go 1.17
+go 1.19
 
 require github.com/go-test/deep v1.1.0

--- a/mp4/fuzz_test.go
+++ b/mp4/fuzz_test.go
@@ -1,6 +1,3 @@
-//go:build go1.18
-// +build go1.18
-
 package mp4_test
 
 import (


### PR DESCRIPTION
## Why

The repo's fuzz tests (`mp4/fuzz_test.go`, and the ones #516 adds) use native fuzzing (`testing.F`), which was introduced in **Go 1.18** — so they don't build on Go 1.17.

Go **1.19** additionally fixes fuzz-corpus **CRLF handling** ([golang/go#52268](https://github.com/golang/go/issues/52268), [CL 402074](https://go-review.googlesource.com/c/go/+/402074)). Go 1.18's corpus reader rejects a `go test fuzz v1\r` header, so on Windows — where git's `autocrlf` rewrites LF→CRLF on checkout — the seed corpus fails to load with `unmarshal: unknown encoding version`. Setting the floor to 1.19 (rather than 1.18) means the toolchain handles this natively, with no `.gitattributes` workaround needed.

## Changes

- `go.mod`: `go 1.17` → `go 1.19`
- `.github/workflows/go.yml`: CI matrix `["1.17", "1.26"]` → `["1.19", "1.26"]`, and `fail-fast: false` so every platform/version leg reports independently
- Removed the now-redundant `//go:build go1.18` guard on `mp4/fuzz_test.go`
- `CHANGELOG.md`: note the bump under `[Unreleased]`

## Notes

- README has no minimum-Go-version statement, so nothing to update there.
- Supersedes #518, which GitHub auto-closed when this branch was renamed from `chore-bump-min-go-1.18`.
- Unblocks #516, whose fuzz targets need ≥1.18 to build and ≥1.19 to load their corpus on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)