### PR TITLE
fix: make CENC fragment encryption CMAF-conformant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cenc encryption with an 8-byte input IV is now CMAF-conformant
+  (ISO/IEC 23000-19 Sec. 8.2.3.1): `InitProtect` sets
+  `tenc.DefaultPerSampleIVSize` to 8, `EncryptFragment` writes 8-byte
+  per-sample IVs to `senc` and increments the IV by one per sample
+  (ISO/IEC 23001-7 Sec. 9.2), and the returned chaining IV is 8 bytes.
+  A 16-byte input IV keeps the previous 16-byte behavior
+- `EncryptFragment` omits the `senc`, `saiz`, and `saio` boxes when a
+  fragment has no sample auxiliary information (full-sample encryption
+  with a constant IV, e.g. cbcs audio), as CMAF Sec. 8.2.2.1 recommends
+- `SaizBox.AddSampleInfo` now returns an error (sample-info sizes above
+  255 do not fit the 8-bit `sample_info_size`) instead of panicking on
+  inconsistent sizes, collapses uniform sizes into
+  `default_sample_info_size`, and switches to per-sample sizes when a
+  differing size arrives
+
+### Fixed
+
+- `DecryptFragment` no longer fails on fragments without a `senc` box
+  when the track uses full-sample encryption with a constant IV
+- `SencBox` keeps its subsample entries aligned with the sample index, so
+  a fragment mixing samples with and without subsamples encodes a zero
+  subsample count instead of panicking, and `saiz` sizes match the
+  `senc` layout
+- `GetAVCProtectRanges` and `GetHEVCProtectRanges` return an all-clear
+  subsample entry for a degenerate sample instead of an empty list
+
 ### Added
 
 - `TrgrBox` for the Track Group Box (`trgr`, ISO/IEC 14496-12 Sec. 8.3.4) and a

--- a/cmd/mp4ff-encrypt/main.go
+++ b/cmd/mp4ff-encrypt/main.go
@@ -47,7 +47,7 @@ func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
 	fs.StringVar(&opts.initFile, "init", "", "Path to init file with encryption info (scheme, kid, pssh)")
 	fs.StringVar(&opts.kidStr, "kid", "", "key id (32 hex or 24 base64 chars). Required if initFilePath empty")
 	fs.StringVar(&opts.keyStr, "key", "", "Required: key (32 hex or 24 base64 chars)")
-	fs.StringVar(&opts.ivHex, "iv", "", "Required: iv (16 or 32 hex chars)")
+	fs.StringVar(&opts.ivHex, "iv", "", "Required: iv (16 or 32 hex chars; 16 gives CMAF-conformant 8-byte cenc IVs)")
 	fs.StringVar(&opts.scheme, "scheme", "cenc", "cenc or cbcs. Required if initFilePath empty")
 	fs.StringVar(&opts.psshFile, "pssh", "", "file with one or more pssh box(es) in binary format. Will be added at end of moov box")
 	fs.BoolVar(&opts.version, "version", false, "Get mp4ff version")

--- a/mp4/crypto.go
+++ b/mp4/crypto.go
@@ -77,6 +77,12 @@ func GetAVCProtectRanges(spsMap map[uint32]*avc.SPS, ppsMap map[uint32]*avc.PPS,
 	if clearEnd > clearStart {
 		ssps = AppendProtectRange(ssps, clearEnd-clearStart, 0)
 	}
+	if len(ssps) == 0 {
+		// Degenerate sample (e.g. only a NALU length field): mark all
+		// bytes clear so every video sample carries a subsample entry,
+		// keeping senc and saiz consistent within the fragment.
+		ssps = AppendProtectRange(ssps, uint32(length), 0)
+	}
 	return ssps, nil
 }
 
@@ -132,6 +138,12 @@ func GetHEVCProtectRanges(spsMap map[uint32]*hevc.SPS, ppsMap map[uint32]*hevc.P
 	}
 	if clearEnd > clearStart {
 		ssps = AppendProtectRange(ssps, clearEnd-clearStart, 0)
+	}
+	if len(ssps) == 0 {
+		// Degenerate sample (e.g. only a NALU length field): mark all
+		// bytes clear so every video sample carries a subsample entry,
+		// keeping senc and saiz consistent within the fragment.
+		ssps = AppendProtectRange(ssps, uint32(length), 0)
 	}
 	return ssps, nil
 }
@@ -302,8 +314,9 @@ func InitProtect(init *InitSegment, key, iv []byte, scheme string, kid UUID, pss
 		return nil, fmt.Errorf("only one stsd child supported")
 	}
 
+	inputIVSize := len(iv)
 	if len(iv) == 8 {
-		// Convert to 16 bytes
+		// Convert to 16 bytes for use as cbcs constant IV
 		iv8 := iv
 		iv = make([]byte, 16)
 		copy(iv, iv8)
@@ -348,7 +361,20 @@ func InitProtect(init *InitSegment, key, iv []byte, scheme string, kid UUID, pss
 	schi := SchiBox{}
 	switch scheme {
 	case "cenc":
-		ipd.Tenc = &TencBox{Version: 0, DefaultIsProtected: 1, DefaultPerSampleIVSize: 16, DefaultKID: kid}
+		// The per-sample IV size follows the provided iv. CMAF
+		// (ISO/IEC 23000-19 Section 8.2.3.1) requires 8-byte IVs for
+		// the cenc scheme, so an 8-byte iv is the conformant choice;
+		// 16-byte IVs are kept for backwards compatibility.
+		var perSampleIVSize byte
+		switch inputIVSize {
+		case 8:
+			perSampleIVSize = 8
+		case 16:
+			perSampleIVSize = 16
+		default:
+			return nil, fmt.Errorf("cenc iv must be 8 or 16 bytes, got %d", inputIVSize)
+		}
+		ipd.Tenc = &TencBox{Version: 0, DefaultIsProtected: 1, DefaultPerSampleIVSize: perSampleIVSize, DefaultKID: kid}
 		sinf.AddChild(&SchmBox{SchemeType: "cenc", SchemeVersion: 65536})
 	case "cbcs":
 		switch mediaType {
@@ -458,14 +484,24 @@ func EncryptFragment(f *Fragment, key, iv []byte, ipd *InitProtectData) ([]byte,
 	if ipd == nil {
 		return nil, fmt.Errorf("no protection data")
 	}
-	if len(iv) == 8 {
-		// Convert to 16 bytes
-		iv8 := iv
-		iv = make([]byte, 16)
-		copy(iv, iv8)
-	}
-	if len(iv) != 16 {
-		return nil, fmt.Errorf("iv must be 16 bytes")
+	// cenc with 8-byte per-sample IVs (the size CMAF requires): the 8-byte
+	// IV is the high half of the 16-byte CTR counter, the low half starts
+	// at zero for each sample, and the IV increments by one per sample.
+	iv8Mode := ipd.Scheme == "cenc" && ipd.Tenc != nil && ipd.Tenc.DefaultPerSampleIVSize == 8
+	if iv8Mode {
+		if len(iv) != 8 {
+			return nil, fmt.Errorf("cenc with 8-byte per-sample IVs needs an 8-byte iv, got %d bytes", len(iv))
+		}
+	} else {
+		if len(iv) == 8 {
+			// Convert to 16 bytes
+			iv8 := iv
+			iv = make([]byte, 16)
+			copy(iv, iv8)
+		}
+		if len(iv) != 16 {
+			return nil, fmt.Errorf("iv must be 16 bytes")
+		}
 	}
 	if len(f.Moof.Trafs) != 1 {
 		return nil, fmt.Errorf("only one traf supported")
@@ -502,25 +538,52 @@ func EncryptFragment(f *Fragment, key, iv []byte, ipd *InitProtectData) ([]byte,
 		}
 		switch ipd.Scheme {
 		case "cenc":
-			err = CryptSampleCenc(sample, key, iv, subsamplePatterns)
+			ctrIV := iv
+			if iv8Mode {
+				ctrIV = make([]byte, 16)
+				copy(ctrIV, iv)
+			}
+			err = CryptSampleCenc(sample, key, ctrIV, subsamplePatterns)
 			if err != nil {
 				return nil, fmt.Errorf("crypt sample cenc: %w", err)
 			}
-			// Store IVs in the senc box and update depending on blocks of encrypted data
-			_ = senc.AddSample(SencSample{IV: iv, SubSamples: subsamplePatterns})
-			saiz.AddSampleInfo(iv, subsamplePatterns)
-			iv = incrementIV(iv, subsamplePatterns, len(sample))
+			// Store IVs in the senc box and advance the IV for the next sample
+			if err := senc.AddSample(SencSample{IV: iv, SubSamples: subsamplePatterns}); err != nil {
+				return nil, fmt.Errorf("senc add sample: %w", err)
+			}
+			if err := saiz.AddSampleInfo(iv, subsamplePatterns); err != nil {
+				return nil, fmt.Errorf("saiz add sample info: %w", err)
+			}
+			if iv8Mode {
+				nextIV := make([]byte, 8)
+				copy(nextIV, iv)
+				incrementIVInPlace(nextIV, 1)
+				iv = nextIV
+			} else {
+				iv = incrementIV(iv, subsamplePatterns, len(sample))
+			}
 		case "cbcs":
 			err = EncryptSampleCbcs(sample, key, iv, subsamplePatterns, ipd.Tenc)
 			if err != nil {
 				return nil, fmt.Errorf("crypt sample cbcs: %w", err)
 			}
-			// iv is constant and not sent t senc
-			_ = senc.AddSample(SencSample{IV: nil, SubSamples: subsamplePatterns})
-			saiz.AddSampleInfo(nil, subsamplePatterns)
+			// iv is constant and not sent to senc
+			if err := senc.AddSample(SencSample{IV: nil, SubSamples: subsamplePatterns}); err != nil {
+				return nil, fmt.Errorf("senc add sample: %w", err)
+			}
+			if err := saiz.AddSampleInfo(nil, subsamplePatterns); err != nil {
+				return nil, fmt.Errorf("saiz add sample info: %w", err)
+			}
 		default:
 			return nil, fmt.Errorf("unknown scheme %s", ipd.Scheme)
 		}
+	}
+	if len(senc.IVs) == 0 && len(senc.SubSamples) == 0 {
+		// No sample auxiliary information (full-sample encryption with a
+		// constant IV): CMAF (ISO/IEC 23000-19 Section 8.2.2.1) recommends
+		// omitting the senc, saiz, and saio boxes.
+		_ = f.Moof.Traf.RemoveEncryptionBoxes()
+		return iv, nil
 	}
 	moof := f.Moof
 	offset := uint64(8)
@@ -742,19 +805,24 @@ func DecryptFragmentWithKeys(frag *Fragment, di DecryptInfo, key []byte, keysByK
 			if schemeType != "cenc" && schemeType != "cbcs" {
 				return fmt.Errorf("scheme type %s not supported", schemeType)
 			}
+			tenc := ti.Sinf.Schi.Tenc
 			hasSenc, isParsed := traf.ContainsSencBox()
 			if !hasSenc {
-				return fmt.Errorf("no senc box in traf")
+				// A missing senc is fine for full-sample encryption with a
+				// constant IV (no sample auxiliary information); CMAF
+				// (ISO/IEC 23000-19 Section 8.2.2.1) recommends omitting
+				// senc, saiz, and saio in that case.
+				if tenc == nil || tenc.DefaultPerSampleIVSize != 0 || len(tenc.DefaultConstantIV) == 0 {
+					return fmt.Errorf("no senc box in traf")
+				}
 			}
-			if !isParsed {
+			if hasSenc && !isParsed {
 				defaultPerSampleIVSize := ti.Sinf.Schi.Tenc.DefaultPerSampleIVSize
 				err := traf.ParseReadSenc(defaultPerSampleIVSize, moof.StartPos)
 				if err != nil {
 					return fmt.Errorf("parseReadSenc: %w", err)
 				}
 			}
-
-			tenc := ti.Sinf.Schi.Tenc
 			trackKey, err := getTrackKey(ti, key, keysByKID, strictKIDMode)
 			if err != nil {
 				return err
@@ -764,9 +832,10 @@ func DecryptFragmentWithKeys(frag *Fragment, di DecryptInfo, key []byte, keysByK
 				return err
 			}
 			var senc *SencBox
-			if traf.Senc != nil {
+			switch {
+			case traf.Senc != nil:
 				senc = traf.Senc
-			} else {
+			case traf.UUIDSenc != nil:
 				senc = traf.UUIDSenc.Senc
 			}
 
@@ -804,7 +873,7 @@ func decryptSamplesInPlace(schemeType string, samples []FullSample, key []byte, 
 	}
 
 	for i := range samples {
-		if len(senc.IVs) == len(samples) {
+		if senc != nil && len(senc.IVs) == len(samples) {
 			if len(senc.IVs[i]) < 16 {
 				for i := 0; i < 16; i++ {
 					iv[i] = 0
@@ -817,7 +886,7 @@ func decryptSamplesInPlace(schemeType string, samples []FullSample, key []byte, 
 		}
 
 		var subSamplePatterns []SubSamplePattern
-		if len(senc.SubSamples) != 0 {
+		if senc != nil && len(senc.SubSamples) != 0 {
 			subSamplePatterns = senc.SubSamples[i]
 		}
 		switch schemeType {

--- a/mp4/crypto_test.go
+++ b/mp4/crypto_test.go
@@ -2,6 +2,7 @@ package mp4_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -643,4 +644,131 @@ func TestDecryptSegmentWithKeys(t *testing.T) {
 			t.Error("segment not equal after fallback decrypt")
 		}
 	})
+}
+
+// TestEncryptFragmentCenc8ByteIV verifies the CMAF-conformant cenc mode:
+// an 8-byte input IV gives tenc.DefaultPerSampleIVSize = 8, 8-byte
+// per-sample IVs in senc, and an IV that increments by one per sample
+// (ISO/IEC 23001-7 Section 9.2, ISO/IEC 23000-19 Section 8.2.3.1).
+func TestEncryptFragmentCenc8ByteIV(t *testing.T) {
+	key, _ := hex.DecodeString("00112233445566778899aabbccddeeff")
+	iv, _ := hex.DecodeString("7766554433221100")
+	kidUUID, _ := mp4.NewUUIDFromString("11112222333344445555666677778888")
+
+	ifh, err := os.Open("testdata/init.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	initSeg, err := mp4.DecodeFile(ifh)
+	ifh.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipd, err := mp4.InitProtect(initSeg.Init, key, iv, "cenc", kidUUID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ipd.Tenc.DefaultPerSampleIVSize != 8 {
+		t.Errorf("got DefaultPerSampleIVSize %d, expected 8", ipd.Tenc.DefaultPerSampleIVSize)
+	}
+
+	rawSeg, err := os.ReadFile("testdata/1.m4s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seg, err := mp4.DecodeFile(bytes.NewBuffer(rawSeg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	frag := seg.Segments[0].Fragments[0]
+	nextIV, err := mp4.EncryptFragment(frag, key, iv, ipd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	senc := frag.Moof.Traf.Senc
+	if senc == nil || len(senc.IVs) == 0 {
+		t.Fatal("missing senc IVs after encryption")
+	}
+	prev := binary.BigEndian.Uint64(iv)
+	for i, sIV := range senc.IVs {
+		if len(sIV) != 8 {
+			t.Fatalf("sample %d: got %d-byte IV, expected 8", i, len(sIV))
+		}
+		wanted := prev + uint64(i)
+		if got := binary.BigEndian.Uint64(sIV); got != wanted {
+			t.Errorf("sample %d: got IV %#x, expected %#x", i, got, wanted)
+		}
+	}
+	if len(nextIV) != 8 {
+		t.Fatalf("got %d-byte next IV, expected 8", len(nextIV))
+	}
+	wantedNext := prev + uint64(len(senc.IVs))
+	if got := binary.BigEndian.Uint64(nextIV); got != wantedNext {
+		t.Errorf("got next IV %#x, expected %#x", got, wantedNext)
+	}
+}
+
+// TestProtectRangesDegenerateSample verifies that a degenerate video
+// sample (only a NALU length field) still yields one all-clear subsample
+// entry, so that senc and saiz stay consistent within the fragment.
+func TestProtectRangesDegenerateSample(t *testing.T) {
+	sample := []byte{0, 0, 0, 0}
+	for _, tc := range []string{"avc", "hevc"} {
+		var ssps []mp4.SubSamplePattern
+		var err error
+		switch tc {
+		case "avc":
+			ssps, err = mp4.GetAVCProtectRanges(nil, nil, sample, "cenc")
+		case "hevc":
+			ssps, err = mp4.GetHEVCProtectRanges(nil, nil, sample, "cenc")
+		}
+		if err != nil {
+			t.Fatalf("%s: %v", tc, err)
+		}
+		if len(ssps) != 1 || ssps[0].BytesOfClearData != 4 || ssps[0].BytesOfProtectedData != 0 {
+			t.Errorf("%s: got %+v, expected one all-clear range of 4 bytes", tc, ssps)
+		}
+	}
+}
+
+// TestEncryptFragmentNoAuxInfoOmitsBoxes verifies that full-sample
+// encryption with a constant IV (cbcs audio) omits the senc, saiz, and
+// saio boxes, as CMAF (ISO/IEC 23000-19 Section 8.2.2.1) recommends, and
+// that such fragments still decrypt.
+func TestEncryptFragmentNoAuxInfoOmitsBoxes(t *testing.T) {
+	key, _ := hex.DecodeString("00112233445566778899aabbccddeeff")
+	iv, _ := hex.DecodeString("ffeeddccbbaa99887766554433221100")
+	kidUUID, _ := mp4.NewUUIDFromString("11112222333344445555666677778888")
+
+	ifh, err := os.Open("testdata/aac_init.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	initSeg, err := mp4.DecodeFile(ifh)
+	ifh.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipd, err := mp4.InitProtect(initSeg.Init, key, iv, "cbcs", kidUUID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawSeg, err := os.ReadFile("testdata/aac_1.m4s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seg, err := mp4.DecodeFile(bytes.NewBuffer(rawSeg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	frag := seg.Segments[0].Fragments[0]
+	_, err = mp4.EncryptFragment(frag, key, iv, ipd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	traf := frag.Moof.Traf
+	if traf.Senc != nil || traf.Saiz != nil || traf.Saio != nil {
+		t.Errorf("expected senc, saiz, and saio to be omitted, got senc=%v saiz=%v saio=%v",
+			traf.Senc != nil, traf.Saiz != nil, traf.Saio != nil)
+	}
 }

--- a/mp4/saiz.go
+++ b/mp4/saiz.go
@@ -63,26 +63,40 @@ func NewSaizBox(capacity int) *SaizBox {
 	}
 }
 
-// AddSampleInfo adds a sampleinfo info based on parameters provided.
-// If no length field, don't update the sample field (typically audio cbcs)
-func (b *SaizBox) AddSampleInfo(iv []byte, subsamplePatterns []SubSamplePattern) {
+// AddSampleInfo adds the auxiliary information size for one sample.
+// A zero total size (no IV and no subsamples, as for cbcs full-sample
+// encryption with a constant IV) means the sample has no auxiliary
+// information and no entry is recorded. Uniform sizes are stored in
+// DefaultSampleInfoSize; when a differing size arrives, the box switches
+// to per-sample sizes. Within one fragment, either all samples or no
+// samples should carry subsample patterns, matching the box-level
+// senc_use_subsamples flag of the corresponding senc box.
+func (b *SaizBox) AddSampleInfo(iv []byte, subsamplePatterns []SubSamplePattern) error {
 	size := len(iv)
 	if len(subsamplePatterns) > 0 {
 		size += 2 + len(subsamplePatterns)*6
-		b.SampleInfo = append(b.SampleInfo, byte(size))
-	} else if size > 0 {
-		switch b.DefaultSampleInfoSize {
-		case 0:
-			b.DefaultSampleInfoSize = byte(size)
-		default:
-			if byte(size) != b.DefaultSampleInfoSize {
-				panic("inconsistent sample info size")
-			}
+	}
+	if size == 0 {
+		return nil
+	}
+	if size > 255 {
+		return fmt.Errorf("saiz: sample info size %d does not fit in 8 bits", size)
+	}
+	switch {
+	case b.SampleCount == 0:
+		b.DefaultSampleInfoSize = byte(size)
+	case b.DefaultSampleInfoSize != 0 && byte(size) != b.DefaultSampleInfoSize:
+		// Sizes are no longer uniform: switch to per-sample sizes.
+		for i := uint32(0); i < b.SampleCount; i++ {
+			b.SampleInfo = append(b.SampleInfo, b.DefaultSampleInfoSize)
 		}
+		b.DefaultSampleInfoSize = 0
 	}
-	if size > 0 {
-		b.SampleCount++
+	if b.DefaultSampleInfoSize == 0 {
+		b.SampleInfo = append(b.SampleInfo, byte(size))
 	}
+	b.SampleCount++
+	return nil
 }
 
 // Type - return box type

--- a/mp4/saiz_test.go
+++ b/mp4/saiz_test.go
@@ -1,6 +1,7 @@
 package mp4_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/mp4"
@@ -9,4 +10,56 @@ import (
 func TestSaiz(t *testing.T) {
 	saiz := &mp4.SaizBox{DefaultSampleInfoSize: 1}
 	boxDiffAfterEncodeAndDecode(t, saiz)
+}
+
+func TestSaizAddSampleInfo(t *testing.T) {
+	iv8 := make([]byte, 8)
+	subs1 := []mp4.SubSamplePattern{{BytesOfClearData: 10, BytesOfProtectedData: 1000}}
+	subs2 := []mp4.SubSamplePattern{{BytesOfClearData: 10, BytesOfProtectedData: 1000},
+		{BytesOfClearData: 20, BytesOfProtectedData: 2000}}
+
+	t.Run("uniform sizes collapse to default", func(t *testing.T) {
+		saiz := mp4.NewSaizBox(2)
+		assertNoError(t, saiz.AddSampleInfo(iv8, subs1))
+		assertNoError(t, saiz.AddSampleInfo(iv8, subs1))
+		if saiz.DefaultSampleInfoSize != 16 { // 8 + 2 + 6
+			t.Errorf("got default size %d, expected 16", saiz.DefaultSampleInfoSize)
+		}
+		if saiz.SampleCount != 2 || len(saiz.SampleInfo) != 0 {
+			t.Errorf("got sampleCount %d, %d per-sample sizes; expected 2 and 0",
+				saiz.SampleCount, len(saiz.SampleInfo))
+		}
+	})
+
+	t.Run("differing size switches to per-sample sizes", func(t *testing.T) {
+		saiz := mp4.NewSaizBox(3)
+		assertNoError(t, saiz.AddSampleInfo(iv8, subs1))
+		assertNoError(t, saiz.AddSampleInfo(iv8, subs2))
+		assertNoError(t, saiz.AddSampleInfo(iv8, subs1))
+		if saiz.DefaultSampleInfoSize != 0 {
+			t.Errorf("got default size %d, expected 0", saiz.DefaultSampleInfoSize)
+		}
+		wanted := []byte{16, 22, 16}
+		if saiz.SampleCount != 3 || !bytes.Equal(saiz.SampleInfo, wanted) {
+			t.Errorf("got sampleCount %d, sizes %v; expected 3 and %v",
+				saiz.SampleCount, saiz.SampleInfo, wanted)
+		}
+	})
+
+	t.Run("zero size records nothing", func(t *testing.T) {
+		saiz := mp4.NewSaizBox(1)
+		assertNoError(t, saiz.AddSampleInfo(nil, nil))
+		if saiz.SampleCount != 0 || saiz.DefaultSampleInfoSize != 0 || len(saiz.SampleInfo) != 0 {
+			t.Errorf("expected empty saiz, got %+v", saiz)
+		}
+	})
+
+	t.Run("size above 255 is an error", func(t *testing.T) {
+		saiz := mp4.NewSaizBox(1)
+		manySubs := make([]mp4.SubSamplePattern, 43) // 8 + 2 + 43*6 = 268
+		err := saiz.AddSampleInfo(iv8, manySubs)
+		if err == nil {
+			t.Error("expected error for sample info size above 255")
+		}
+	})
 }

--- a/mp4/senc.go
+++ b/mp4/senc.go
@@ -78,8 +78,17 @@ func (s *SencBox) AddSample(sample SencSample) error {
 	}
 
 	if len(sample.SubSamples) > 0 {
+		// Backfill empty entries for any earlier samples without
+		// subsamples so that SubSamples stays aligned with the sample
+		// index. Every sample carries a subsample count on the wire
+		// once the flag is set.
+		for uint32(len(s.SubSamples)) < s.SampleCount {
+			s.SubSamples = append(s.SubSamples, nil)
+		}
 		s.SubSamples = append(s.SubSamples, sample.SubSamples)
 		s.Flags |= UseSubSampleEncryption
+	} else if len(s.SubSamples) > 0 {
+		s.SubSamples = append(s.SubSamples, nil)
 	}
 	s.SampleCount++
 	return nil
@@ -335,7 +344,10 @@ func (s *SencBox) calcSize() uint64 {
 	for i := uint32(0); i < s.SampleCount; i++ {
 		totalSize += perSampleIVSize
 		if s.Flags&UseSubSampleEncryption != 0 {
-			totalSize += 2 + 6*uint64(len(s.SubSamples[i]))
+			totalSize += 2
+			if i < uint32(len(s.SubSamples)) {
+				totalSize += 6 * uint64(len(s.SubSamples[i]))
+			}
 		}
 	}
 	return totalSize
@@ -375,6 +387,13 @@ func (s *SencBox) EncodeSWNoHdr(sw bits.SliceWriter) error {
 		return sw.AccError()
 	}
 	perSampleIVSize := s.GetPerSampleIVSize()
+	if perSampleIVSize > 0 && len(s.IVs) != int(s.SampleCount) {
+		return fmt.Errorf("senc: %d IVs do not match sample count %d", len(s.IVs), s.SampleCount)
+	}
+	if s.Flags&UseSubSampleEncryption != 0 && len(s.SubSamples) != int(s.SampleCount) {
+		return fmt.Errorf("senc: subsample encryption flag set but %d of %d samples have subsample entries",
+			len(s.SubSamples), s.SampleCount)
+	}
 	for i := 0; i < int(s.SampleCount); i++ {
 		if perSampleIVSize > 0 {
 			sw.WriteBytes(s.IVs[i])

--- a/mp4/senc_test.go
+++ b/mp4/senc_test.go
@@ -395,3 +395,61 @@ func TestBadSencData(t *testing.T) {
 		})
 	}
 }
+
+func TestAddSamplesMixedSubSamples(t *testing.T) {
+	// Once any sample has subsamples, the box-level senc_use_subsamples
+	// flag is set and every sample record carries a subsample count on
+	// the wire, including samples without subsamples.
+	senc := mp4.CreateSencBox()
+	assertNoError(t, senc.AddSample(mp4.SencSample{IV: mp4.InitializationVector("01234567")}))
+	assertNoError(t, senc.AddSample(mp4.SencSample{IV: mp4.InitializationVector("01234568"),
+		SubSamples: []mp4.SubSamplePattern{{BytesOfClearData: 10, BytesOfProtectedData: 1000}}}))
+	assertNoError(t, senc.AddSample(mp4.SencSample{IV: mp4.InitializationVector("01234569")}))
+
+	// fullbox header (12) + sampleCount (4) + 3 * (IV (8) + count (2)) + 1 * 6
+	wantedSize := uint64(12 + 4 + 3*(8+2) + 6)
+	if senc.Size() != wantedSize {
+		t.Errorf("got size %d, expected %d", senc.Size(), wantedSize)
+	}
+	var buf bytes.Buffer
+	err := senc.Encode(&buf)
+	assertNoError(t, err)
+	firstEnc := buf.Bytes()
+
+	boxDec, err := mp4.DecodeBox(0, bytes.NewBuffer(firstEnc))
+	assertNoError(t, err)
+	decSenc := boxDec.(*mp4.SencBox)
+	if decSenc.ReadButNotParsed() {
+		assertNoError(t, decSenc.ParseReadBox(8, nil))
+	}
+	if len(decSenc.SubSamples) != 3 {
+		t.Fatalf("got %d subsample entries, expected 3", len(decSenc.SubSamples))
+	}
+	for i, wantedCount := range []int{0, 1, 0} {
+		if len(decSenc.SubSamples[i]) != wantedCount {
+			t.Errorf("sample %d: got %d subsamples, expected %d", i, len(decSenc.SubSamples[i]), wantedCount)
+		}
+	}
+	var buf2 bytes.Buffer
+	assertNoError(t, decSenc.Encode(&buf2))
+	if !bytes.Equal(firstEnc, buf2.Bytes()) {
+		t.Error("re-encoded mixed-subsample senc differs from first encoding")
+	}
+}
+
+func TestSencEncodeInconsistentSubSamples(t *testing.T) {
+	// A directly-constructed box with the subsample flag set but fewer
+	// subsample entries than samples must fail encoding, not panic.
+	senc := mp4.SencBox{
+		Version:     0,
+		Flags:       mp4.UseSubSampleEncryption,
+		SampleCount: 2,
+		SubSamples: [][]mp4.SubSamplePattern{
+			{{BytesOfClearData: 10, BytesOfProtectedData: 1000}},
+		},
+	}
+	sw := bits.NewFixedSliceWriter(int(senc.Size()))
+	if err := senc.EncodeSW(sw); err == nil {
+		t.Error("expected error for subsample flag with missing entries")
+	}
+}


### PR DESCRIPTION
Three related CENC conformance/robustness fixes, found while cross-checking LOCMAF's canonical CMAF reconstruction against ISO/IEC 23001-7:2023 and ISO/IEC 23000-19:2023 (CMAF). Supersedes #517.

- **8-byte cenc IVs** (CMAF 8.2.3.1): an 8-byte input IV now gives `tenc.DefaultPerSampleIVSize=8`, 8-byte per-sample IVs in `senc`, and an IV incremented by one per sample (CENC 9.2). A 16-byte input IV keeps the previous behavior.
- **senc/saiz consistency**: `senc_use_subsamples` is box-level, so once any sample has subsamples, every sample record carries a subsample count. `SencBox` keeps `SubSamples` aligned with the sample index (a fragment mixing samples with and without subsamples encodes count 0 instead of panicking, and an inconsistent hand-built box fails encoding with an error), `saiz` sizes match the `senc` layout, uniform sizes collapse into `default_sample_info_size`, and `AddSampleInfo` returns an error for sizes above 255 instead of panicking (API change). `GetAVCProtectRanges`/`GetHEVCProtectRanges` return an all-clear entry for degenerate samples.
- **No-aux fragments** (CMAF 8.2.2.1 constraint 3): full-sample encryption with a constant IV (cbcs audio) now omits `senc`/`saiz`/`saio` as CMAF recommends, and `DecryptFragment` accepts such fragments — it previously failed with "no senc box in traf" on conformant content from other packagers.