### PR TITLE
chore: prepare v0.53.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,33 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- cenc encryption with an 8-byte input IV is now CMAF-conformant
-  (ISO/IEC 23000-19 Sec. 8.2.3.1): `InitProtect` sets
-  `tenc.DefaultPerSampleIVSize` to 8, `EncryptFragment` writes 8-byte
-  per-sample IVs to `senc` and increments the IV by one per sample
-  (ISO/IEC 23001-7 Sec. 9.2), and the returned chaining IV is 8 bytes.
-  A 16-byte input IV keeps the previous 16-byte behavior
-- `EncryptFragment` omits the `senc`, `saiz`, and `saio` boxes when a
-  fragment has no sample auxiliary information (full-sample encryption
-  with a constant IV, e.g. cbcs audio), as CMAF Sec. 8.2.2.1 recommends
-- `SaizBox.AddSampleInfo` now returns an error (sample-info sizes above
-  255 do not fit the 8-bit `sample_info_size`) instead of panicking on
-  inconsistent sizes, collapses uniform sizes into
-  `default_sample_info_size`, and switches to per-sample sizes when a
-  differing size arrives
-
-### Fixed
-
-- `DecryptFragment` no longer fails on fragments without a `senc` box
-  when the track uses full-sample encryption with a constant IV
-- `SencBox` keeps its subsample entries aligned with the sample index, so
-  a fragment mixing samples with and without subsamples encodes a zero
-  subsample count instead of panicking, and `saiz` sizes match the
-  `senc` layout
-- `GetAVCProtectRanges` and `GetHEVCProtectRanges` return an all-clear
-  subsample entry for a degenerate sample instead of an empty list
+## [0.53.0] - 2026-07-07
 
 ### Added
 
@@ -104,6 +78,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimum Go version bumped from 1.17 to 1.19. Fuzz tests require native
   fuzzing (`testing.F`, Go 1.18), and Go 1.19 fixes fuzz-corpus CRLF handling
   so the seed corpus loads on Windows CI
+- cenc encryption with an 8-byte input IV is now CMAF-conformant
+  (ISO/IEC 23000-19 Sec. 8.2.3.1): `InitProtect` sets
+  `tenc.DefaultPerSampleIVSize` to 8, `EncryptFragment` writes 8-byte
+  per-sample IVs to `senc` and increments the IV by one per sample
+  (ISO/IEC 23001-7 Sec. 9.2), and the returned chaining IV is 8 bytes.
+  A 16-byte input IV keeps the previous 16-byte behavior
+- `EncryptFragment` omits the `senc`, `saiz`, and `saio` boxes when a
+  fragment has no sample auxiliary information (full-sample encryption
+  with a constant IV, e.g. cbcs audio), as CMAF Sec. 8.2.2.1 recommends
+- `SaizBox.AddSampleInfo` now returns an error (sample-info sizes above
+  255 do not fit the 8-bit `sample_info_size`) instead of panicking on
+  inconsistent sizes, collapses uniform sizes into
+  `default_sample_info_size`, and switches to per-sample sizes when a
+  differing size arrives
+
+### Fixed
+
+- `DecryptFragment` no longer fails on fragments without a `senc` box
+  when the track uses full-sample encryption with a constant IV
+- `SencBox` keeps its subsample entries aligned with the sample index, so
+  a fragment mixing samples with and without subsamples encodes a zero
+  subsample count instead of panicking, and `saiz` sizes match the
+  `senc` layout
+- `GetAVCProtectRanges` and `GetHEVCProtectRanges` return an all-clear
+  subsample entry for a degenerate sample instead of an empty list
 
 ## [0.52.0] - 2026-05-12
 
@@ -904,7 +903,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.52.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.53.0...HEAD
+[0.53.0]: https://github.com/Eyevinn/mp4ff/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/Eyevinn/mp4ff/compare/v0.51.0...v0.52.0
 [0.51.0]: https://github.com/Eyevinn/mp4ff/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/Eyevinn/mp4ff/compare/v0.49.0...v0.50.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.52.0"    // May be updated using build flags
-	commitDate    string = "1778587200" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.53.0"    // May be updated using build flags
+	commitDate    string = "1783382400" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func ExampleGetVersion() {
 	fmt.Println(GetVersion())
-	// Output: v0.52.0, date: 2026-05-12
+	// Output: v0.53.0, date: 2026-07-07
 }


### PR DESCRIPTION
Prepares the v0.53.0 release.

## Changes
- **CHANGELOG.md** — moved all `[Unreleased]` entries into a new `## [0.53.0] - 2026-07-07` section (Added / Changed / Fixed), reset `[Unreleased]` to empty, and added the `[0.53.0]` compare link.
- **internal/version.go** — bumped `commitVersion` to `v0.53.0` and `commitDate` to `1783382400` (2026-07-07).
- **internal/version_test.go** — updated expected `ExampleGetVersion` output.

## Highlights of this release
- New `mp4ff-mvhevc` tool for MV-HEVC inspection/muxing.
- Layered HEVC (MV-HEVC/SHVC) support: multilayer VPS extension parsing, `lhvC` config box, `oinf`/`linf`/`lbli` sample groups.
- Dolby Vision HEVC sample entries (`dvh1`/`dvhe`) and `dvcC`/`dvvC`/`dvwC` config boxes.
- HDR metadata boxes `clli`/`mdcv`; Apple spatial-video `vexu` box family.
- Track Group Box (`trgr`) support.
- CMAF-conformant cenc encryption (8-byte IV) plus several encryption fixes.
- Recovery-point SEI parsing for AVC/HEVC.
- Minimum Go version raised from 1.17 to 1.19.

## After merge
Tag `v0.53.0` on the merged commit (no tag was created for this PR to avoid orphaning it on a squash/rebase merge):
\`\`\`
git tag v0.53.0 <merged-sha> && git push origin v0.53.0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)