### PR TITLE
chore: remove unsigned macOS homebrew cask publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,15 +79,6 @@ archives:
       - goos: windows
         formats: [zip]
 
-homebrew_casks:
-  - name: mp4ff
-    homepage: https://github.com/Eyevinn/mp4ff
-    description: "Tools for parsing and manipulating MP4/ISOBMFF files"
-    repository:
-      owner: Eyevinn
-      name: homebrew-tap
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
-
 nfpms:
   - package_name: mp4ff
     homepage: https://github.com/Eyevinn/mp4ff


### PR DESCRIPTION
The cask published to Eyevinn/homebrew-tap ships unsigned/unnotarized macOS binaries, which Gatekeeper blocks on install, and its binary stanza doesn't match any file in the release archives. It's also undocumented. homebrew-core is the supported Homebrew install path.