### PR TITLE
chore: prepare v0.54.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-07-13
+
 ### Added
 
 - AV1 bitstream parsing in the `av1` package: OBU splitting (`SplitOBUs`,
@@ -935,7 +937,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.53.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.54.0...HEAD
+[0.54.0]: https://github.com/Eyevinn/mp4ff/compare/v0.53.0...v0.54.0
 [0.53.0]: https://github.com/Eyevinn/mp4ff/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/Eyevinn/mp4ff/compare/v0.51.0...v0.52.0
 [0.51.0]: https://github.com/Eyevinn/mp4ff/compare/v0.50.0...v0.51.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.53.0"    // May be updated using build flags
-	commitDate    string = "1783382400" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.54.0"    // May be updated using build flags
+	commitDate    string = "1783900800" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func ExampleGetVersion() {
 	fmt.Println(GetVersion())
-	// Output: v0.53.0, date: 2026-07-07
+	// Output: v0.54.0, date: 2026-07-13
 }


### PR DESCRIPTION
Prepare the v0.54.0 release: move the Unreleased changelog entries under a dated 0.54.0 section and bump the version in internal/version.go / internal/version_test.go.

Once merged, tag master as v0.54.0 to trigger the GoReleaser release workflow.