### PR TITLE
Add CreateSEINalu for AVC and HEVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `avc.CreateSEINalu` and `hevc.CreateSEINalu` to build a full SEI NAL unit (codec
+  NAL header + EBSP payload) from `sei.SEIMessage` values; the encode-side inverse of
+  `ParseSEINalu`
+
 ### Fixed
 
 - Panic in `hevc.ParseSEINalu` and `avc.ParseSEINalu` on NAL units shorter than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Panic in `hevc.ParseSEINalu` and `avc.ParseSEINalu` on NAL units shorter than
   the codec's NAL unit header (e.g. an empty or single-byte HEVC SEI NALU);
   such input now returns `ErrNotSEINalu`
+- `sei.DecodeUserDataRegisteredSEI` and `sei.ParseCEA608` no longer panic on a
+  short/truncated type-4 (user_data_registered_itu_t_t35) SEI payload; they return
+  an error that propagates through `avc`/`hevc.ParseSEINalu`
 
 ## [0.54.0] - 2026-07-13
 

--- a/avc/sei.go
+++ b/avc/sei.go
@@ -12,6 +12,19 @@ var (
 	ErrNotSEINalu = errors.New("not an SEI NAL unit")
 )
 
+// CreateSEINalu creates an SEI NAL unit (header + EBSP payload) from SEI messages.
+// It is the inverse of ParseSEINalu.
+func CreateSEINalu(msgs []sei.SEIMessage) ([]byte, error) {
+	buf := bytes.Buffer{}
+	// AVC NAL unit header (1 byte): forbidden_zero_bit(1)=0 | nal_ref_idc(2)=0 |
+	// nal_unit_type(5)=NALU_SEI(6). The byte value equals NALU_SEI = 0x06.
+	buf.WriteByte(byte(NALU_SEI))
+	if err := sei.WriteSEIMessages(&buf, msgs); err != nil {
+		return nil, fmt.Errorf("writing SEI messages: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 // ParseSEINalu - parse SEI NAL unit (incl header) and return messages given SPS.
 // Returns sei.ErrRbspTrailingBitsMissing if the NALU is missing the trailing bits.
 func ParseSEINalu(nalu []byte, sps *SPS) ([]sei.SEIMessage, error) {

--- a/avc/sei_test.go
+++ b/avc/sei_test.go
@@ -9,6 +9,20 @@ import (
 	"github.com/Eyevinn/mp4ff/sei"
 )
 
+func TestParseSEINaluTruncatedType4(t *testing.T) {
+	// A NAL unit carrying a type-4 (T.35) SEI whose payload is shorter than the
+	// 8-byte T.35 header must return an error, not panic.
+	nalu, err := avc.CreateSEINalu([]sei.SEIMessage{
+		sei.NewSEIData(sei.SEIUserDataRegisteredITUtT35Type, []byte{0xb5, 0x00, 0x31}),
+	})
+	if err != nil {
+		t.Fatalf("CreateSEINalu failed: %v", err)
+	}
+	if _, err := avc.ParseSEINalu(nalu, nil); err == nil {
+		t.Error("expected error parsing truncated type-4 SEI NAL unit, got nil")
+	}
+}
+
 func TestCreateSEINaluRoundTrip(t *testing.T) {
 	testCases := []struct {
 		desc string

--- a/avc/sei_test.go
+++ b/avc/sei_test.go
@@ -1,12 +1,66 @@
 package avc_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/avc"
 	"github.com/Eyevinn/mp4ff/sei"
 )
+
+func TestCreateSEINaluRoundTrip(t *testing.T) {
+	testCases := []struct {
+		desc string
+		msgs []sei.SEIMessage
+	}{
+		{
+			desc: "single registered ITU-T T.35 message",
+			msgs: []sei.SEIMessage{
+				sei.NewSEIData(sei.SEIUserDataRegisteredITUtT35Type, []byte{0xb5, 0x00, 0x31, 0x11, 0x22, 0x33, 0x44, 0x55}),
+			},
+		},
+		{
+			desc: "single unregistered message",
+			msgs: []sei.SEIMessage{
+				sei.NewSEIData(sei.SEIUserDataUnregisteredType, []byte("0123456789abcdef")),
+			},
+		},
+		{
+			desc: "multiple messages in one NAL unit",
+			msgs: []sei.SEIMessage{
+				sei.NewSEIData(sei.SEIUserDataRegisteredITUtT35Type, []byte{0xb5, 0x00, 0x31, 0x11, 0x22, 0x33, 0x44, 0x55}),
+				sei.NewSEIData(sei.SEIUserDataUnregisteredType, []byte("0123456789abcdef")),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			nalu, err := avc.CreateSEINalu(tc.msgs)
+			if err != nil {
+				t.Fatalf("CreateSEINalu failed: %v", err)
+			}
+			if avc.GetNaluType(nalu[0]) != avc.NALU_SEI {
+				t.Errorf("expected NAL unit type %d, got %d", avc.NALU_SEI, avc.GetNaluType(nalu[0]))
+			}
+			msgs, err := avc.ParseSEINalu(nalu, nil)
+			if err != nil {
+				t.Fatalf("ParseSEINalu failed: %v", err)
+			}
+			if len(msgs) != len(tc.msgs) {
+				t.Fatalf("expected %d messages, got %d", len(tc.msgs), len(msgs))
+			}
+			for i, msg := range msgs {
+				if msg.Type() != tc.msgs[i].Type() {
+					t.Errorf("message %d: expected type %d, got %d", i, tc.msgs[i].Type(), msg.Type())
+				}
+				if !bytes.Equal(msg.Payload(), tc.msgs[i].Payload()) {
+					t.Errorf("message %d: expected payload %x, got %x", i, tc.msgs[i].Payload(), msg.Payload())
+				}
+			}
+		})
+	}
+}
 
 func TestSEIParsing(t *testing.T) {
 	testCases := []struct {

--- a/hevc/sei.go
+++ b/hevc/sei.go
@@ -12,6 +12,21 @@ var (
 	ErrNotSEINalu = errors.New("not an SEI NAL unit")
 )
 
+// CreateSEINalu creates a prefix SEI NAL unit (header + EBSP payload) from SEI messages.
+// It is the inverse of ParseSEINalu.
+func CreateSEINalu(msgs []sei.SEIMessage) ([]byte, error) {
+	buf := bytes.Buffer{}
+	// HEVC NAL unit header (2 bytes):
+	// forbidden_zero_bit(1)=0 | nal_unit_type(6)=NALU_SEI_PREFIX(39) | nuh_layer_id(6)=0 | nuh_temporal_id_plus1(3)=1.
+	// First byte = NALU_SEI_PREFIX << 1 = 0x4e, second byte = 0x01.
+	buf.WriteByte(byte(NALU_SEI_PREFIX) << 1)
+	buf.WriteByte(0x01)
+	if err := sei.WriteSEIMessages(&buf, msgs); err != nil {
+		return nil, fmt.Errorf("writing SEI messages: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 // ParseSEINalu - parse SEI NAL unit (incl header) and return messages given SPS.
 // Returns sei.ErrRbspTrailingBitsMissing if the NALU is missing the trailing bits.
 func ParseSEINalu(nalu []byte, sps *SPS) ([]sei.SEIMessage, error) {

--- a/hevc/sei_test.go
+++ b/hevc/sei_test.go
@@ -1,11 +1,65 @@
 package hevc
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/sei"
 )
+
+func TestCreateSEINaluRoundTrip(t *testing.T) {
+	testCases := []struct {
+		desc string
+		msgs []sei.SEIMessage
+	}{
+		{
+			desc: "single registered ITU-T T.35 message",
+			msgs: []sei.SEIMessage{
+				sei.NewSEIData(sei.SEIUserDataRegisteredITUtT35Type, []byte{0xb5, 0x00, 0x31, 0x11, 0x22, 0x33, 0x44, 0x55}),
+			},
+		},
+		{
+			desc: "single unregistered message",
+			msgs: []sei.SEIMessage{
+				sei.NewSEIData(sei.SEIUserDataUnregisteredType, []byte("0123456789abcdef")),
+			},
+		},
+		{
+			desc: "multiple messages in one NAL unit",
+			msgs: []sei.SEIMessage{
+				sei.NewSEIData(sei.SEIUserDataRegisteredITUtT35Type, []byte{0xb5, 0x00, 0x31, 0x11, 0x22, 0x33, 0x44, 0x55}),
+				sei.NewSEIData(sei.SEIUserDataUnregisteredType, []byte("0123456789abcdef")),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			nalu, err := CreateSEINalu(tc.msgs)
+			if err != nil {
+				t.Fatalf("CreateSEINalu failed: %v", err)
+			}
+			if GetNaluType(nalu[0]) != NALU_SEI_PREFIX {
+				t.Errorf("expected NAL unit type %d, got %d", NALU_SEI_PREFIX, GetNaluType(nalu[0]))
+			}
+			msgs, err := ParseSEINalu(nalu, nil)
+			if err != nil {
+				t.Fatalf("ParseSEINalu failed: %v", err)
+			}
+			if len(msgs) != len(tc.msgs) {
+				t.Fatalf("expected %d messages, got %d", len(tc.msgs), len(msgs))
+			}
+			for i, msg := range msgs {
+				if msg.Type() != tc.msgs[i].Type() {
+					t.Errorf("message %d: expected type %d, got %d", i, tc.msgs[i].Type(), msg.Type())
+				}
+				if !bytes.Equal(msg.Payload(), tc.msgs[i].Payload()) {
+					t.Errorf("message %d: expected payload %x, got %x", i, tc.msgs[i].Payload(), msg.Payload())
+				}
+			}
+		})
+	}
+}
 
 func TestSEIParsing(t *testing.T) {
 	testCases := []struct {

--- a/sei/sei4.go
+++ b/sei/sei4.go
@@ -8,6 +8,9 @@ import (
 
 // DecodeUserDataRegisteredSEI decodes a SEI message of type 4.
 func DecodeUserDataRegisteredSEI(sd *SEIData) (SEIMessage, error) {
+	if len(sd.payload) < 8 {
+		return nil, fmt.Errorf("SEI type 4 (user_data_registered_itu_t_t35) payload too short: %d bytes", len(sd.payload))
+	}
 	itutData := ITUData{
 		CountryCode:      sd.payload[0],
 		ProviderCode:     binary.BigEndian.Uint16(sd.payload[1:3]),
@@ -116,6 +119,9 @@ func (s *CEA608sei) Payload() []byte {
 // ParseCEA608 parsers the the fields of data from CEA-708 encapsulation.
 // This is specified in Section 4.3 of ANSI/CTA-708-E R-2018.
 func ParseCEA608(payload []byte) ([]byte, []byte, error) {
+	if len(payload) == 0 {
+		return nil, nil, fmt.Errorf("empty cc_data payload")
+	}
 	pos := 0
 	ccCount := payload[pos] & 0x1f
 	pos += 2 // Advance 1 and skip reserved byte

--- a/sei/sei4_test.go
+++ b/sei/sei4_test.go
@@ -1,0 +1,26 @@
+package sei_test
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/sei"
+)
+
+func TestDecodeUserDataRegisteredSEIShortPayload(t *testing.T) {
+	// A type-4 (user_data_registered_itu_t_t35) header is 8 bytes. A shorter
+	// payload must return an error instead of panicking on out-of-range indexing.
+	for size := 0; size < 8; size++ {
+		sd := sei.NewSEIData(sei.SEIUserDataRegisteredITUtT35Type, make([]byte, size))
+		msg, err := sei.DecodeUserDataRegisteredSEI(sd)
+		if err == nil {
+			t.Errorf("expected error for %d-byte type-4 payload, got nil (msg %v)", size, msg)
+		}
+	}
+}
+
+func TestParseCEA608EmptyPayload(t *testing.T) {
+	// Empty cc_data payload must return an error instead of panicking on payload[0].
+	if _, _, err := sei.ParseCEA608([]byte{}); err == nil {
+		t.Error("expected error for empty CEA-608 payload, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

mp4ff has decode-side helpers `avc.ParseSEINalu` and `hevc.ParseSEINalu` that parse a full SEI NAL unit (header + payload) into `[]sei.SEIMessage`, plus `sei.WriteSEIMessages` that serializes messages into the SEI payload (EBSP, emulation-prevention, rbsp trailing bits) — but *without* any NAL-unit header. There was no encode-side counterpart producing a full SEI NAL unit, so downstream code had to prepend the codec NAL header by hand. This PR adds that missing symmetric helper.

## What was added

- `avc.CreateSEINalu(msgs []sei.SEIMessage) ([]byte, error)` — the inverse of `avc.ParseSEINalu`.
- `hevc.CreateSEINalu(msgs []sei.SEIMessage) ([]byte, error)` — the inverse of `hevc.ParseSEINalu` (builds a **prefix** SEI NAL unit).

Both use `bytes.Buffer` + `sei.WriteSEIMessages` for the payload and propagate its error, then prepend the codec NAL header.

## Header bytes

- **AVC**: 1-byte NAL header `0x06` = forbidden_zero_bit(1)=0 | nal_ref_idc(2)=0 | nal_unit_type(5)=`NALU_SEI`(6). Written as `byte(NALU_SEI)`. Verified: `GetNaluType(0x06) == NALU_SEI`.
- **HEVC**: 2-byte NAL header `0x4e 0x01` = forbidden(1)=0 | nal_unit_type(6)=`NALU_SEI_PREFIX`(39) | nuh_layer_id(6)=0 | nuh_temporal_id_plus1(3)=1. First byte written as `byte(NALU_SEI_PREFIX) << 1`. Verified: `GetNaluType(0x4e) == NALU_SEI_PREFIX`, layer_id=0, temporal_id_plus1=1.

## Tests

Added round-trip tests in `avc/sei_test.go` and `hevc/sei_test.go`: build SEI messages (registered ITU-T T.35 type 4 and unregistered type 5), call `CreateSEINalu`, then `ParseSEINalu(nalu, nil)` and assert message count, types, and payloads round-trip. Each package also has a multi-message case proving several SEI messages land in one NAL unit, and asserts the NAL header decodes to the expected type via `GetNaluType`.

## VVC deferred

VVC is intentionally out of scope: the `vvc` package has `NALU_SEI_PREFIX`/`NALU_SEI_SUFFIX` constants but no `vvc.ParseSEINalu`, so a lone `vvc.CreateSEINalu` would be asymmetric. It can be added alongside a future `vvc.ParseSEINalu`.

## Decode-side hardening

While writing the round-trip tests, a pre-existing crash surfaced on the decode path for type-4 (`user_data_registered_itu_t_t35`) SEI messages: `sei.DecodeUserDataRegisteredSEI` read `payload[0:8]` unconditionally and `sei.ParseCEA608` read `payload[0]` before its loop, so a short or truncated type-4 payload panicked instead of returning an error. An added commit (`sei: guard DecodeUserDataRegisteredSEI and ParseCEA608 against short payloads`) guards both:

- `DecodeUserDataRegisteredSEI` returns an error if the payload is shorter than the 8-byte T.35 header.
- `ParseCEA608` returns an error on an empty `cc_data` payload (the existing "not enough data for CEA-708 parsing" per-construct guard is kept).

The errors propagate cleanly through `DecodeSEIMessage` → `avc`/`hevc.ParseSEINalu`, so callers now get an error instead of a crash. Tests assert both guards return an error (not a panic), plus an `avc.ParseSEINalu` case on a NAL unit carrying a truncated type-4 SEI.

This is complementary to — and distinct from — the NAL-header guard already on master (`fix(sei): avoid panic on NAL units shorter than the NAL unit header`, commit 146ab87): that fix guards the length of the *NAL unit header* itself, whereas this commit guards the length of the T.35 *payload* inside an otherwise well-formed SEI message. This branch is rebased onto current master (which already contains that fix) and merges cleanly.

## Checks

`gofmt`, `go build ./...`, `go test ./...`, `go vet`, and `golangci-lint run ./sei/... ./avc/... ./hevc/...` all pass (re-run after rebasing onto master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
