### PR TITLE
ci: bump actions/checkout to v7 (node24)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Download Go dependencies
         run: go mod download

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,7 +11,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
GitHub is deprecating the Node.js 20 runtime. `actions/checkout@v5` runs on node24 already, but v7 is the current major — it moves persisted git credentials out of the local config into `$RUNNER_TEMP` and blocks fork-PR checkout under `pull_request_target`/`workflow_run` (neither trigger is used here, so no behavior change).

Bumps `actions/checkout` v5 → v7 in go.yml, coverage.yml, release.yml, golangci-lint.yml. (golangci-lint-action v9, setup-go v6 and the Go Report Card removal already landed on master.)