### PR TITLE
feat(dec3): parse JOC extension for Dolby Atmos detection

### DIFF
--- a/mp4/dec3.go
+++ b/mp4/dec3.go
@@ -44,12 +44,13 @@ var EC3ChannelLocationBits = []string{
 	"LFE2", //MSB
 }
 
-// Dec3Box - AC3SpecificBox from ETSI TS 102 366 V1.4.1 F.4 (2017)
+// Dec3Box - EC3SpecificBox from ETSI TS 102 366 V1.4.1 F.6 (2017), extended by ETSI TS 103 420 C.3 (2018)
 type Dec3Box struct {
-	DataRate  uint16
-	NumIndSub uint16
-	EC3Subs   []EC3Sub
-	Reserved  []byte
+	DataRate      uint16
+	NumIndSub     uint16
+	EC3Subs       []EC3Sub
+	JOCComplexity uint8
+	Reserved      []byte
 }
 
 // EC3Sub - Enhanced AC-3 substream information
@@ -109,7 +110,13 @@ func decodeDec3FromData(data []byte) (Box, error) {
 		}
 		b.EC3Subs = append(b.EC3Subs, es)
 	}
-	b.Reserved = br.ReadRemainingBytes()
+	remaining := br.ReadRemainingBytes()
+	if len(remaining) >= 2 && remaining[0]&0x01 == 1 {
+		b.JOCComplexity = remaining[1]
+		b.Reserved = remaining[2:]
+	} else {
+		b.Reserved = remaining
+	}
 	return &b, br.AccError()
 }
 
@@ -126,6 +133,9 @@ func (b *Dec3Box) Size() uint64 {
 		if es.NumDepSub > 0 {
 			size += 1
 		}
+	}
+	if b.JOCComplexity > 0 {
+		size += 2
 	}
 	size += len(b.Reserved)
 	return uint64(size)
@@ -166,6 +176,9 @@ func (b *Dec3Box) EncodeSW(sw bits.SliceWriter) error {
 			sw.WriteBits(0, 1) // Reserved 0d
 		}
 	}
+	if b.JOCComplexity > 0 {
+		sw.WriteBytes([]byte{0x01, b.JOCComplexity})
+	}
 	if len(b.Reserved) > 0 {
 		sw.WriteBytes(b.Reserved)
 	}
@@ -179,6 +192,9 @@ func (b *Dec3Box) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 	bd.write(" - sampleRateCode=%d => sampleRate=%d", fscod, AC3SampleRates[fscod])
 	nrChannels, chanmap := b.ChannelInfo()
 	bd.write(" - nrChannels=%d, chanmap=%04x", nrChannels, chanmap)
+	if b.JOCComplexity > 0 {
+		bd.write(" - JOC complexity=%d", b.JOCComplexity)
+	}
 	bd.write(" - nrSubstreams=%d", len(b.EC3Subs))
 	for i, es := range b.EC3Subs {
 		bd.write("   - %d fscod=%d bsid=%d asvc=%d bsmod=%d acmod=%d lfeon=%d num_dep_sub=%d chan_loc=%x",

--- a/mp4/dec3_test.go
+++ b/mp4/dec3_test.go
@@ -17,6 +17,17 @@ func TestEncDecDec3(t *testing.T) {
 	boxDiffAfterEncodeAndDecode(t, b)
 }
 
+func TestEncDecDec3WithJOC(t *testing.T) {
+	b := &mp4.Dec3Box{
+		DataRate:      768,
+		NumIndSub:     0,
+		EC3Subs:       []mp4.EC3Sub{{FSCod: 0, BSID: 16, ACMod: 7, LFEOn: 1}},
+		JOCComplexity: 16,
+		Reserved:      []byte{},
+	}
+	boxDiffAfterEncodeAndDecode(t, b)
+}
+
 func TestGetChannelInfoDec3(t *testing.T) {
 	testCases := []struct {
 		name             string
@@ -61,5 +72,61 @@ func TestGetChannelInfoDec3(t *testing.T) {
 		if gotChanmap != tc.wantedChannelMap {
 			t.Errorf("got chanmap %d instead of %d", gotChanmap, tc.wantedChannelMap)
 		}
+	}
+}
+
+func TestDec3JOCComplexity(t *testing.T) {
+	testCases := []struct {
+		name              string
+		hexIn             string
+		wantedJOC         uint8
+		wantedNrChannels  int
+		wantedChannelMap  uint16
+	}{
+		{
+			name:             "5.1 with JOC complexity 16",
+			hexIn:            "0000000f646563331800200f000110",
+			wantedJOC:        16,
+			wantedNrChannels: 6,
+			wantedChannelMap: 0xf801,
+		},
+		{
+			name:             "5.1 without JOC",
+			hexIn:            "0000000d646563330800200f00",
+			wantedJOC:        0,
+			wantedNrChannels: 6,
+			wantedChannelMap: 0xf801,
+		},
+		{
+			name:             "5.1 with flag byte but no JOC",
+			hexIn:            "0000000e646563330800200f0000",
+			wantedJOC:        0,
+			wantedNrChannels: 6,
+			wantedChannelMap: 0xf801,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dec3Bytes, err := hex.DecodeString(tc.hexIn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sr := bits.NewFixedSliceReader(dec3Bytes)
+			box, err := mp4.DecodeBoxSR(0, sr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dec3 := box.(*mp4.Dec3Box)
+			if dec3.JOCComplexity != tc.wantedJOC {
+				t.Errorf("got JOCComplexity %d, wanted %d", dec3.JOCComplexity, tc.wantedJOC)
+			}
+			gotNrChannels, gotChanmap := dec3.ChannelInfo()
+			if gotNrChannels != tc.wantedNrChannels {
+				t.Errorf("got %d channels, wanted %d", gotNrChannels, tc.wantedNrChannels)
+			}
+			if gotChanmap != tc.wantedChannelMap {
+				t.Errorf("got chanmap %04x, wanted %04x", gotChanmap, tc.wantedChannelMap)
+			}
+		})
 	}
 }


### PR DESCRIPTION

Parse JOC (Joint Object Coding) extension from EC3SpecificBox (`dec3`) per ETSI TS 103 420 C.3, that is in `reserved` bytes of ETSI TS 102 366 F.6.


🤖 Generated with [Claude Code](https://claude.com/claude-code)