### PR TITLE
fix(avc): encode avcC trailing info for all profiles outside 66/77/88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- avcC encode now writes the 4 trailing-info bytes for all AVC profiles outside
+  66/77/88, symmetric with `Size()` and decode (e.g. profile 244)
 - Panic in `hevc.ParseSEINalu` and `avc.ParseSEINalu` on NAL units shorter than
   the codec's NAL unit header (e.g. an empty or single-byte HEVC SEI NALU);
   such input now returns `ErrNotSEINalu`

--- a/avc/avcdecoderconfig_test.go
+++ b/avc/avcdecoderconfig_test.go
@@ -139,3 +139,29 @@ func TestCreateAVCDecConfRec(t *testing.T) {
 		t.Error("Error creating AVCDecoderConfigurationRecord")
 	}
 }
+
+func TestAvcDecoderConfigRecordProfile244(t *testing.T) {
+	// Same record as in TestAvcDecoderConfigRecord, but with profile 244
+	byteData, _ := hex.DecodeString("01f4001effe100196764001eacd940a02ff9610000030001000003003c8f162d9601000568ebecb22cfdf8f800")
+
+	got, err := DecodeAVCDecConfRec(byteData)
+	if err != nil {
+		t.Error("Error parsing AVCDecoderConfigurationRecord")
+	}
+	if got.AVCProfileIndication != 244 {
+		t.Errorf("got profile %d instead of 244", got.AVCProfileIndication)
+	}
+	if got.Size() != uint64(len(byteData)) {
+		t.Errorf("Size() = %d, but the record is %d bytes", got.Size(), len(byteData))
+	}
+
+	enc := bytes.Buffer{}
+	err = got.Encode(&enc)
+	if err != nil {
+		t.Error("Error encoding AVCDecoderConfigurationRecord")
+	}
+	if !bytes.Equal(enc.Bytes(), byteData) {
+		t.Errorf("encoded record differs from input:\n got %s\nwant %s",
+			hex.EncodeToString(enc.Bytes()), hex.EncodeToString(byteData))
+	}
+}

--- a/avc/avcdecoderconfigurationrecord.go
+++ b/avc/avcdecoderconfigurationrecord.go
@@ -227,7 +227,7 @@ func (a *DecConfRec) EncodeSW(sw bits.SliceWriter) error {
 		if a.NoTrailingInfo {
 			sw.WriteZeroBytes(a.SkipBytes)
 		}
-	case 100, 110, 122, 144: // From ISO/IEC 14496-15 2017 Section 5.3.3.1.2
+	default: // From ISO/IEC 14496-15 2017 Section 5.3.3.1.2
 		if a.NoTrailingInfo { // Strange content, but consistent with Size()
 			sw.WriteZeroBytes(a.SkipBytes)
 			return sw.AccError()
@@ -236,8 +236,6 @@ func (a *DecConfRec) EncodeSW(sw bits.SliceWriter) error {
 		sw.WriteUint8(0xf8 | a.BitDepthLumaMinus1)
 		sw.WriteUint8(0xf8 | a.BitDepthChromaMinus1)
 		sw.WriteUint8(a.NumSPSExt)
-	default:
-		//Nothing more to write
 	}
 
 	return sw.AccError()


### PR DESCRIPTION
DecodeAVCDecConfRec and Size() treat every AVC profile outside 66/77/88 as having the 4 trailing bytes (chroma format, bit depths, numSPSExt), but EncodeSW only writes them for 100, 110, 122 and 144. For other profiles like 244 the encoded record comes out 4 bytes shorter than Size(), so box sizes go wrong when the record is encoded inside an stsd.

This makes that case the default branch in EncodeSW, matching Size() and the decoder. Added a test that round-trips a profile 244 record.
