### PR TITLE
fix(avc): preserve unknown avcC bytes after the trailing info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - avcC encode now writes the 4 trailing-info bytes for all AVC profiles outside
   66/77/88, symmetric with `Size()` and decode (e.g. profile 244)
+- unknown bytes after the avcC trailing info are preserved through decode/encode
+  in the new `DecConfRec.TrailingBytes` field instead of being dropped
 - Panic in `hevc.ParseSEINalu` and `avc.ParseSEINalu` on NAL units shorter than
   the codec's NAL unit header (e.g. an empty or single-byte HEVC SEI NALU);
   such input now returns `ErrNotSEINalu`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- avcC encode now writes the 4 trailing-info bytes for all AVC profiles outside
+  66/77/88, symmetric with `Size()` and decode (e.g. profile 244)
 - Panic in `hevc.ParseSEINalu` and `avc.ParseSEINalu` on NAL units shorter than
   the codec's NAL unit header (e.g. an empty or single-byte HEVC SEI NALU);
   such input now returns `ErrNotSEINalu`

--- a/avc/avcdecoderconfig_test.go
+++ b/avc/avcdecoderconfig_test.go
@@ -139,3 +139,29 @@ func TestCreateAVCDecConfRec(t *testing.T) {
 		t.Error("Error creating AVCDecoderConfigurationRecord")
 	}
 }
+
+func TestAvcDecoderConfigRecordProfile244(t *testing.T) {
+	// Same record as in TestAvcDecoderConfigRecord, but with profile 244
+	byteData, _ := hex.DecodeString("01f4001effe100196764001eacd940a02ff9610000030001000003003c8f162d9601000568ebecb22cfdf8f800")
+
+	got, err := DecodeAVCDecConfRec(byteData)
+	if err != nil {
+		t.Error("Error parsing AVCDecoderConfigurationRecord")
+	}
+	if got.AVCProfileIndication != 244 {
+		t.Errorf("got profile %d instead of 244", got.AVCProfileIndication)
+	}
+	if got.Size() != uint64(len(byteData)) {
+		t.Errorf("Size() = %d, but the record is %d bytes", got.Size(), len(byteData))
+	}
+
+	enc := bytes.Buffer{}
+	err = got.Encode(&enc)
+	if err != nil {
+		t.Error("Error encoding AVCDecoderConfigurationRecord")
+	}
+	if !bytes.Equal(enc.Bytes(), byteData) {
+		t.Errorf("encoded record differs from input:\n got %s\nwant %s",
+			hex.EncodeToString(enc.Bytes()), hex.EncodeToString(byteData))
+	}
+}

--- a/avc/avcdecoderconfig_test.go
+++ b/avc/avcdecoderconfig_test.go
@@ -165,3 +165,44 @@ func TestAvcDecoderConfigRecordProfile244(t *testing.T) {
 			hex.EncodeToString(enc.Bytes()), hex.EncodeToString(byteData))
 	}
 }
+
+func TestAvcDecoderConfigRecordTrailingBytes(t *testing.T) {
+	// Extra bytes after the trailing info as written by some muxers
+	cases := []struct {
+		name     string
+		trailing string
+	}{
+		{"single zero byte", "00"},
+		{"encoder options blob", hex.EncodeToString([]byte("x264 - options: cabac=1 ref=2"))},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			byteData, _ := hex.DecodeString(avcDecoderConfigRecord + c.trailing)
+			trailing, _ := hex.DecodeString(c.trailing)
+
+			got, err := DecodeAVCDecConfRec(byteData)
+			if err != nil {
+				t.Fatalf("Error parsing AVCDecoderConfigurationRecord: %v", err)
+			}
+			if !bytes.Equal(got.TrailingBytes, trailing) {
+				t.Errorf("TrailingBytes = %x, want %x", got.TrailingBytes, trailing)
+			}
+			if got.NoTrailingInfo {
+				t.Error("NoTrailingInfo set although trailing info was parsed")
+			}
+			if got.Size() != uint64(len(byteData)) {
+				t.Errorf("Size() = %d, but the record is %d bytes", got.Size(), len(byteData))
+			}
+
+			enc := bytes.Buffer{}
+			err = got.Encode(&enc)
+			if err != nil {
+				t.Fatalf("Error encoding AVCDecoderConfigurationRecord: %v", err)
+			}
+			if !bytes.Equal(enc.Bytes(), byteData) {
+				t.Errorf("encoded record differs from input:\n got %s\nwant %s",
+					hex.EncodeToString(enc.Bytes()), hex.EncodeToString(byteData))
+			}
+		})
+	}
+}

--- a/avc/avcdecoderconfigurationrecord.go
+++ b/avc/avcdecoderconfigurationrecord.go
@@ -28,6 +28,7 @@ type DecConfRec struct {
 	NumSPSExt            byte
 	NoTrailingInfo       bool // To handle strange cases where trailing info is missing
 	SkipBytes            int
+	TrailingBytes        []byte // Unknown bytes after the trailing info, preserved on encode
 }
 
 // CreateAVCDecConfRec - extract information from sps and insert sps, pps if includePS set
@@ -161,6 +162,9 @@ func DecodeAVCDecConfRec(data []byte) (DecConfRec, error) {
 		if adcr.NumSPSExt != 0 {
 			return adcr, ErrCannotParseAVCExtension
 		}
+		if pos+4 < len(data) {
+			adcr.TrailingBytes = data[pos+4:]
+		}
 	}
 
 	return adcr, nil
@@ -184,6 +188,7 @@ func (a *DecConfRec) Size() uint64 {
 		}
 	}
 	totalSize += a.SkipBytes
+	totalSize += len(a.TrailingBytes)
 	return uint64(totalSize)
 }
 
@@ -230,13 +235,14 @@ func (a *DecConfRec) EncodeSW(sw bits.SliceWriter) error {
 	default: // From ISO/IEC 14496-15 2017 Section 5.3.3.1.2
 		if a.NoTrailingInfo { // Strange content, but consistent with Size()
 			sw.WriteZeroBytes(a.SkipBytes)
-			return sw.AccError()
+			break
 		}
 		sw.WriteUint8(0xfc | a.ChromaFormat)
 		sw.WriteUint8(0xf8 | a.BitDepthLumaMinus1)
 		sw.WriteUint8(0xf8 | a.BitDepthChromaMinus1)
 		sw.WriteUint8(a.NumSPSExt)
 	}
+	sw.WriteBytes(a.TrailingBytes)
 
 	return sw.AccError()
 }

--- a/avc/avcdecoderconfigurationrecord.go
+++ b/avc/avcdecoderconfigurationrecord.go
@@ -227,7 +227,7 @@ func (a *DecConfRec) EncodeSW(sw bits.SliceWriter) error {
 		if a.NoTrailingInfo {
 			sw.WriteZeroBytes(a.SkipBytes)
 		}
-	case 100, 110, 122, 144: // From ISO/IEC 14496-15 2017 Section 5.3.3.1.2
+	default: // From ISO/IEC 14496-15 2017 Section 5.3.3.1.2
 		if a.NoTrailingInfo { // Strange content, but consistent with Size()
 			sw.WriteZeroBytes(a.SkipBytes)
 			return sw.AccError()
@@ -236,8 +236,6 @@ func (a *DecConfRec) EncodeSW(sw bits.SliceWriter) error {
 		sw.WriteUint8(0xf8 | a.BitDepthLumaMinus1)
 		sw.WriteUint8(0xf8 | a.BitDepthChromaMinus1)
 		sw.WriteUint8(a.NumSPSExt)
-	default:
-		//Nothing more to write
 	}
 
 	return sw.AccError()

--- a/mp4/visualsampleentry_test.go
+++ b/mp4/visualsampleentry_test.go
@@ -105,3 +105,39 @@ func TestAvc1WithTrailingBytes(t *testing.T) {
 	}
 	boxDiffAfterEncodeAndDecode(t, avc1)
 }
+
+func TestAvc1WithAvcCTrailingBytes(t *testing.T) {
+	// High-profile SPS so that the avcC carries trailing info followed by an extra byte
+	sps1, err := hex.DecodeString("6764001eacd940a02ff9610000030001000003003c8f162d96")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pps1, err := hex.DecodeString("68ebecb22c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	avcC, err := mp4.CreateAvcC([][]byte{sps1}, [][]byte{pps1}, true /* includePS */)
+	if err != nil {
+		t.Fatal(err)
+	}
+	avcC.TrailingBytes = []byte{0}
+	avc1 := mp4.CreateVisualSampleEntryBox("avc1", 1280, 720, avcC)
+	btrt := &mp4.BtrtBox{BufferSizeDB: 1536, MaxBitrate: 2000000, AvgBitrate: 1500000}
+	avc1.AddChild(btrt)
+
+	boxDiffAfterEncodeAndDecode(t, avc1)
+
+	decoded := boxAfterEncodeAndDecode(t, avc1).(*mp4.VisualSampleEntryBox)
+	if decoded.AvcC == nil {
+		t.Fatal("expected decoded avcC child")
+	}
+	if len(decoded.AvcC.TrailingBytes) != 1 {
+		t.Errorf("expected 1 trailing byte in avcC, got %d", len(decoded.AvcC.TrailingBytes))
+	}
+	if decoded.Btrt == nil {
+		t.Fatal("expected decoded btrt child after the avcC")
+	}
+	if len(decoded.TrailingBytes) != 0 {
+		t.Errorf("sample entry should have no trailing bytes, got %d", len(decoded.TrailingBytes))
+	}
+}


### PR DESCRIPTION
Depends on #536, which restructures the same switch in EncodeSW, so that commit is included here until #536 is merged.

Some muxers write extra bytes after numOfSequenceParameterSetExt in the avcC (a padding zero, or even a text blob). ISO/IEC 14496-15 says readers should ignore unrecognized data at the end of the record, but DecodeAVCDecConfRec drops such bytes, so Size() no longer matches the number of bytes the record occupied and stsd parsing fails with "child avc1 size mismatch in stsd". A single stray byte makes the whole file undecodable.

The new DecConfRec.TrailingBytes field keeps the bytes, Size() counts them, and EncodeSW writes them back, so such records round-trip. Tests cover the record round trip and that an avc1 with such an avcC still decodes with its btrt child intact.
