### PR TITLE
feat(mp4): parse and preserve the tkhd transformation matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `avc.CreateSEINalu` and `hevc.CreateSEINalu` to build a full SEI NAL unit (codec
   NAL header + EBSP payload) from `sei.SEIMessage` values; the encode-side inverse of
   `ParseSEINalu`
+- tkhd: the transformation matrix is parsed into `TkhdBox.Matrix` and preserved
+  on encode, so rotation metadata survives round trips; a zero-value `Matrix`
+  still encodes as the unity matrix. New helper `mp4.UnityMatrix()`
 
 ### Fixed
 

--- a/mp4/tkhd.go
+++ b/mp4/tkhd.go
@@ -24,7 +24,15 @@ type TkhdBox struct {
 	Layer            int16
 	AlternateGroup   int16 // should be int16
 	Volume           Fixed16
-	Width, Height    Fixed32
+	// Matrix - transformation matrix {a, b, u, c, d, v, x, y, w} (16.16 fixed point, u/v/w 2.30).
+	// The zero value is encoded as the unity matrix.
+	Matrix        [9]int32
+	Width, Height Fixed32
+}
+
+// UnityMatrix - the identity transformation matrix according to ISO/IEC 14496-12 Section 6.2.2
+func UnityMatrix() [9]int32 {
+	return [9]int32{0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000}
 }
 
 // CreateTkhd - create tkhd box with common settings
@@ -33,6 +41,7 @@ func CreateTkhd() *TkhdBox {
 		Version: 0,
 		Flags:   0x000007,      // Enabled, inMovie, inPreview set
 		TrackID: DefaultTrakID, // Typically just have one track
+		Matrix:  UnityMatrix(),
 	}
 }
 
@@ -75,7 +84,9 @@ func DecodeTkhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 	t.AlternateGroup = sr.ReadInt16()
 	t.Volume = Fixed16(sr.ReadInt16())
 	sr.SkipBytes(2)
-	sr.SkipBytes(36) // 3x3 matrixdata
+	for i := range t.Matrix {
+		t.Matrix[i] = sr.ReadInt32()
+	}
 	t.Width = Fixed32(sr.ReadUint32())
 	t.Height = Fixed32(sr.ReadUint32())
 
@@ -131,8 +142,14 @@ func (b *TkhdBox) EncodeSW(sw bits.SliceWriter) error {
 	sw.WriteInt16(b.Layer)
 	sw.WriteInt16(b.AlternateGroup)
 	sw.WriteUint16(uint16(b.Volume))
-	sw.WriteZeroBytes(2)  // Reserved
-	sw.WriteUnityMatrix() // unity matrix according to 8.3.2.2
+	sw.WriteZeroBytes(2) // Reserved
+	matrix := b.Matrix
+	if matrix == ([9]int32{}) {
+		matrix = UnityMatrix() // for backwards compatibility, according to 8.3.2.2
+	}
+	for _, v := range matrix {
+		sw.WriteInt32(v)
+	}
 	sw.WriteUint32(uint32(b.Width))
 	sw.WriteUint32(uint32(b.Height))
 

--- a/mp4/tkhd_test.go
+++ b/mp4/tkhd_test.go
@@ -34,3 +34,53 @@ func TestTkhd(t *testing.T) {
 		t.Errorf("Mismatch mvhdCreated vs mvhdRead:\n%+v\n%+v", tkhdCreated, tkhdRead)
 	}
 }
+
+func TestTkhdMatrixPreserved(t *testing.T) {
+	// 90-degree rotation matrix as written by phone cameras
+	rotation90 := [9]int32{0, 0x00010000, 0, -0x00010000, 0, 0, 1280 << 16, 0, 0x40000000}
+	tkhd := mp4.CreateTkhd()
+	tkhd.Matrix = rotation90
+	tkhd.Width = 1280 << 16
+	tkhd.Height = 720 << 16
+
+	var buf bytes.Buffer
+	if err := tkhd.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	hdr, err := mp4.DecodeHeader(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := mp4.DecodeTkhd(hdr, 0, &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tkhdRead := decoded.(*mp4.TkhdBox)
+	if tkhdRead.Matrix != rotation90 {
+		t.Errorf("matrix not preserved: got %v, want %v", tkhdRead.Matrix, rotation90)
+	}
+	if !reflect.DeepEqual(tkhdRead, tkhd) {
+		t.Errorf("Mismatch tkhd created vs read:\n%+v\n%+v", tkhd, tkhdRead)
+	}
+}
+
+func TestTkhdZeroMatrixEncodesAsUnity(t *testing.T) {
+	tkhd := mp4.TkhdBox{TrackID: 1}
+
+	var buf bytes.Buffer
+	if err := tkhd.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	hdr, err := mp4.DecodeHeader(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := mp4.DecodeTkhd(hdr, 0, &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tkhdRead := decoded.(*mp4.TkhdBox)
+	if tkhdRead.Matrix != mp4.UnityMatrix() {
+		t.Errorf("zero matrix should encode as unity, decoded %v", tkhdRead.Matrix)
+	}
+}


### PR DESCRIPTION
DecodeTkhdSR skips the 36-byte transformation matrix and EncodeSW always writes the unity matrix, so rotation set by phone cameras is lost on a decode/encode round trip and cannot be read programmatically.

This parses the matrix into a new TkhdBox.Matrix [9]int32 field and encodes it back. A zero-value Matrix still encodes as the unity matrix, so existing code that builds TkhdBox directly gives the same output as before. CreateTkhd sets the new UnityMatrix() explicitly.

One consequence is that an all-zero matrix read from a file comes back as unity. A zero matrix is degenerate, so this seemed like the right trade-off for backwards compatibility, but happy to change it. mvhd skips its matrix in the same way and could get the same treatment in a follow-up.
