### PR TITLE
fix(mp4): clamp too long compressor name length instead of failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   66/77/88, symmetric with `Size()` and decode (e.g. profile 244)
 - unknown bytes after the avcC trailing info are preserved through decode/encode
   in the new `DecConfRec.TrailingBytes` field instead of being dropped
+- visual sample entries with a too long compressor name length byte are decoded
+  by clamping the length to 31 like ffmpeg does, instead of failing
 - Panic in `hevc.ParseSEINalu` and `avc.ParseSEINalu` on NAL units shorter than
   the codec's NAL unit header (e.g. an empty or single-byte HEVC SEI NALU);
   such input now returns `ErrNotSEINalu`

--- a/mp4/visualsampleentry.go
+++ b/mp4/visualsampleentry.go
@@ -142,7 +142,8 @@ func DecodeVisualSampleEntrySR(hdr BoxHeader, startPos uint64, sr bits.SliceRead
 	b.FrameCount = sr.ReadUint16() // Should be 1
 	compressorNameLength := sr.ReadUint8()
 	if compressorNameLength > 31 {
-		return nil, fmt.Errorf("too long compressor name length")
+		// Invalid, but occurs. Clamp like ffmpeg does. The field is 32 bytes in any case.
+		compressorNameLength = 31
 	}
 	b.CompressorName = sr.ReadFixedLengthString(int(compressorNameLength))
 	sr.SkipBytes(int(31 - compressorNameLength))

--- a/mp4/visualsampleentry_test.go
+++ b/mp4/visualsampleentry_test.go
@@ -1,6 +1,7 @@
 package mp4_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"os"
 	"testing"
@@ -139,5 +140,44 @@ func TestAvc1WithAvcCTrailingBytes(t *testing.T) {
 	}
 	if len(decoded.TrailingBytes) != 0 {
 		t.Errorf("sample entry should have no trailing bytes, got %d", len(decoded.TrailingBytes))
+	}
+}
+
+func TestAvc1WithTooLongCompressorNameLength(t *testing.T) {
+	sps1, err := hex.DecodeString(sps1nalu)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pps1, err := hex.DecodeString(pps1nalu)
+	if err != nil {
+		t.Fatal(err)
+	}
+	avcC, err := mp4.CreateAvcC([][]byte{sps1}, [][]byte{pps1}, true /* includePS */)
+	if err != nil {
+		t.Fatal(err)
+	}
+	avc1 := mp4.CreateVisualSampleEntryBox("avc1", 1280, 720, avcC)
+	btrt := &mp4.BtrtBox{BufferSizeDB: 1536, MaxBitrate: 2000000, AvgBitrate: 1500000}
+	avc1.AddChild(btrt)
+	var buf bytes.Buffer
+	if err := avc1.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	data := buf.Bytes()
+	data[50] = 0xc8 // compressorname length byte (box-relative offset 50)
+
+	box, err := mp4.DecodeBox(0, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decoding with an oversized compressor name length: %v", err)
+	}
+	decoded := box.(*mp4.VisualSampleEntryBox)
+	if len(decoded.CompressorName) != 31 {
+		t.Errorf("expected compressor name clamped to 31 bytes, got %d", len(decoded.CompressorName))
+	}
+	if decoded.AvcC == nil {
+		t.Fatal("expected decoded avcC child")
+	}
+	if decoded.Btrt == nil {
+		t.Fatal("expected decoded btrt child")
 	}
 }


### PR DESCRIPTION
The compressorname field of a visual sample entry is a fixed 32-byte pascal string, but some encoders write a length byte above 31. DecodeVisualSampleEntrySR then fails with "too long compressor name length", although the bad byte affects neither the field size nor the position of the child boxes.

Clamp the length to 31 like ffmpeg's mov demuxer does and decode normally.
