### PR TITLE
feat(av1): metadata OBUs + CTA-608 create/parse aligned with SEI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tkhd: the transformation matrix is parsed into `TkhdBox.Matrix` and preserved
   on encode, so rotation metadata survives round trips; a zero-value `Matrix`
   still encodes as the unity matrix. New helper `mp4.UnityMatrix()`
+- AV1 metadata OBUs in the `av1` package, in reusable layers: `MetadataOBU`
+  (`metadata_type` + payload) with `ParseMetadataOBU`, `ParseMetadataOBUFromOBU`,
+  `Encode` and `Size`, handling the mandatory `trailing_bits` and the reverse scan
+  for the last non-zero payload byte (AV1 spec 6.7.1), and `MetadataType` constants
+  for HDR CLL/MDCV, scalability, ITU-T T.35 and timecode. A payload that is not
+  byte-aligned shares its last byte with `trailing_bits`; `PayloadHasTrailingBits`
+  marks it so that `Encode` does not add a second `trailing_one_bit`
+- `av1.ITUTT35` for the `metadata_itu_t_t35` body (country code, its `0xff`
+  extension byte, and payload) with `ParseITUTT35`, `Encode`, `Size` and
+  `MetadataOBU`; it carries CTA-608 captions as well as HDR10+
+- CTA-608 closed captions in AV1: `av1.CreateCTA608MetadataOBU` builds a complete
+  caption metadata OBU from a `cc_data()` structure and `av1.ExtractCTA608` reads the
+  field 1 and field 2 byte pairs back from the OBUs of a temporal unit, plus
+  `ITUTT35.ITUData` and `ITUTT35.CTA608CCData`. The payload is identical to the
+  AVC/HEVC SEI one, so only the envelope differs between the codecs
+- `sei.CreateCTA608SEIMessage` builds a CTA-608 `user_data_registered_itu_t_t35`
+  (type 4) SEI message from a `cc_data()` structure, the encode-side counterpart of
+  `sei.ExtractCTA608sei`. Wrap it with `avc.CreateSEINalu` or `hevc.CreateSEINalu`.
+  Supporting helpers: `sei.CTA608ITUData`, `sei.CreateCTA608Payload`,
+  `sei.ITUData.Encode` and `sei.ITUDataSize`
+
+### Changed
+
+- CEA-608 is renamed to its current designation CTA-608 in the `sei` API:
+  `sei.CEA608sei`, `sei.ParseCEA608`, `sei.ExtractCEA608sei` and
+  `sei.ITUData.IsCEA608` become `sei.CTA608sei`, `sei.ParseCTA608`,
+  `sei.ExtractCTA608sei` and `sei.ITUData.IsCTA608`. This is a breaking change; the
+  old names are gone
 
 ### Fixed
 
@@ -27,9 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Panic in `hevc.ParseSEINalu` and `avc.ParseSEINalu` on NAL units shorter than
   the codec's NAL unit header (e.g. an empty or single-byte HEVC SEI NALU);
   such input now returns `ErrNotSEINalu`
-- `sei.DecodeUserDataRegisteredSEI` and `sei.ParseCEA608` no longer panic on a
-  short/truncated type-4 (user_data_registered_itu_t_t35) SEI payload; they return
-  an error that propagates through `avc`/`hevc.ParseSEINalu`
+- `sei.DecodeUserDataRegisteredSEI`, `sei.ExtractCTA608sei` and `sei.ParseCTA608` no
+  longer panic on a short/truncated type-4 (user_data_registered_itu_t_t35) SEI
+  payload; they return an error that propagates through `avc`/`hevc.ParseSEINalu`
 
 ## [0.54.0] - 2026-07-13
 

--- a/av1/cta608.go
+++ b/av1/cta608.go
@@ -1,0 +1,99 @@
+package av1
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/Eyevinn/mp4ff/sei"
+)
+
+// CreateCTA608MetadataOBU returns a complete metadata OBU carrying CTA-608 closed
+// captions: obu_header, obu_size, metadata_type = ITU-T T.35, the CTA-608 T.35/GA94
+// header, ccData, and trailing_bits.
+//
+// ccData is a cc_data() structure as specified in ATSC A/53 Part 4 Section 6.2.2 and
+// CTA-708-E Section 4.3 — the same payload the AVC/HEVC SEI path carries, so this is the
+// AV1 counterpart of sei.CreateCTA608SEIMessage. Unlike a SEI NAL unit, an OBU has no
+// emulation prevention, so the bytes are written as-is.
+//
+// In an MP4 av01 sample, the returned OBU is placed in the temporal unit that holds the
+// frame the captions belong to. ExtractCTA608 is the inverse.
+func CreateCTA608MetadataOBU(ccData []byte) []byte {
+	// The country code is the first byte of the T.35 payload, but ITUTT35 models it
+	// separately, so the itu_t_t35_payload_bytes start at the provider code.
+	payload := sei.CreateCTA608Payload(ccData)
+	t := ITUTT35{CountryCode: payload[0], Payload: payload[1:]}
+	return t.MetadataOBU().Encode()
+}
+
+// ITUData returns the registered-user-data identification at the start of the
+// itu_t_t35 payload, so that the registered format can be recognized. ok is false if the
+// payload is too short to hold the identification.
+//
+// The AV1 country code and its optional extension byte are modelled by ITUTT35 itself,
+// while sei.ITUData assumes a country code other than 0xff; for such a country code the
+// returned value is the same 8-byte identification as in an AVC/HEVC SEI message of
+// type 4, which is what makes sei.ITUData.IsCTA608 usable for AV1.
+func (t ITUTT35) ITUData() (data sei.ITUData, ok bool) {
+	if t.CountryCode == countryCodeExtensionEscape || len(t.Payload) < sei.ITUDataSize-1 {
+		return sei.ITUData{}, false
+	}
+	return sei.ITUData{
+		CountryCode:      t.CountryCode,
+		ProviderCode:     binary.BigEndian.Uint16(t.Payload[0:2]),
+		UserIdentifier:   binary.BigEndian.Uint32(t.Payload[2:6]),
+		UserDataTypeCode: t.Payload[6],
+	}, true
+}
+
+// CTA608CCData returns the cc_data() bytes of a CTA-608 itu_t_t35 payload, or nil if t
+// does not carry CTA-608. Parse them with sei.ParseCTA608.
+func (t ITUTT35) CTA608CCData() []byte {
+	data, ok := t.ITUData()
+	if !ok || !data.IsCTA608() {
+		return nil
+	}
+	ccData := t.Payload[sei.ITUDataSize-1:]
+	if len(ccData) == 0 {
+		return nil
+	}
+	return ccData
+}
+
+// ExtractCTA608 returns the CTA-608 field 1 and field 2 byte pairs carried by the OBUs of
+// one temporal unit, e.g. an MP4 av01 sample split with SplitOBUs. Parity bits are kept.
+// Both fields are nil when the temporal unit carries no CTA-608 captions.
+//
+// OBUs that are not CTA-608 metadata OBUs are skipped, so a whole temporal unit can be
+// passed. An error is only returned for a metadata OBU that is structurally broken or
+// whose cc_data() is malformed. This is the inverse of CreateCTA608MetadataOBU, and the
+// AV1 counterpart of scanning a sample's NAL units for a CTA-608 SEI message.
+func ExtractCTA608(obus []OBU) (field1, field2 []byte, err error) {
+	for i, obu := range obus {
+		if obu.Header.Type != OBUMetadata {
+			continue
+		}
+		m, err := ParseMetadataOBU(obu.Payload)
+		if err != nil {
+			return nil, nil, fmt.Errorf("OBU %d: %w", i, err)
+		}
+		if m.Type != MetadataTypeITUTT35 {
+			continue
+		}
+		t, err := ParseITUTT35(m.Payload)
+		if err != nil {
+			return nil, nil, fmt.Errorf("OBU %d: %w", i, err)
+		}
+		ccData := t.CTA608CCData()
+		if ccData == nil {
+			continue
+		}
+		f1, f2, err := sei.ParseCTA608(ccData)
+		if err != nil {
+			return nil, nil, fmt.Errorf("OBU %d: cc_data: %w", i, err)
+		}
+		field1 = append(field1, f1...)
+		field2 = append(field2, f2...)
+	}
+	return field1, field2, nil
+}

--- a/av1/cta608_test.go
+++ b/av1/cta608_test.go
@@ -1,0 +1,228 @@
+package av1
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/sei"
+)
+
+// ccData for one frame with the field-1 control pair 0x94 0x2c, an empty field 2 and
+// cc_count = 3, i.e. one DTVCC padding construct (ATSC A/53 Part 4 Section 6.2.2).
+const ccData942c = "c3ff" + "fc942c" + "f90000" + "fa0000" + "ff"
+
+func TestCreateCTA608MetadataOBU(t *testing.T) {
+	ccData, err := hex.DecodeString(ccData942c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The complete OBU, byte by byte:
+	//   2a                       obu_header: type = OBUMetadata(5), obu_has_size_field = 1
+	//   16                       obu_size = 22
+	//   04                       metadata_type = METADATA_TYPE_ITUT_T35 (4)
+	//   b5 0031 47413934 03      country USA, provider ATSC, "GA94", cc_data
+	//   c3ff fc942c f90000 fa0000 ff    cc_data()
+	//   80                       trailing_bits
+	want := "2a" + "16" + "04" + "b5003147413934" + "03" + ccData942c + "80"
+	got := CreateCTA608MetadataOBU(ccData)
+	if hex.EncodeToString(got) != want {
+		t.Errorf("got  %s\nwant %s", hex.EncodeToString(got), want)
+	}
+	if len(got) != 24 {
+		t.Errorf("got %d bytes, want 24", len(got))
+	}
+}
+
+// TestCTA608PayloadAlignedWithSEI locks in that the AV1 and the AVC/HEVC path carry the
+// exact same T.35 payload, so only the envelope differs between the codecs.
+func TestCTA608PayloadAlignedWithSEI(t *testing.T) {
+	ccData, err := hex.DecodeString(ccData942c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obu := CreateCTA608MetadataOBU(ccData)
+	obus, err := SplitOBUs(obu)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseMetadataOBUFromOBU(obus[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	seiPayload := sei.CreateCTA608SEIMessage(ccData).Payload()
+	if hex.EncodeToString(m.Payload) != hex.EncodeToString(seiPayload) {
+		t.Errorf("OBU payload %s differs from SEI payload %s",
+			hex.EncodeToString(m.Payload), hex.EncodeToString(seiPayload))
+	}
+}
+
+func TestExtractCTA608(t *testing.T) {
+	// A temporal unit as found in an av01 sample: temporal delimiter, the caption
+	// metadata OBU, and a frame OBU.
+	td := OBU{Header: OBUHeader{Type: OBUTemporalDelimiter, HasSizeField: true, HeaderSize: 1}}
+	frame := OBU{Header: OBUHeader{Type: OBUFrame, HasSizeField: true, HeaderSize: 1}, Payload: []byte{0x10, 0x20}}
+
+	cases := []struct {
+		name       string
+		ccData     string
+		wantField1 string
+		wantField2 string
+	}{
+		{
+			name:       "field 1 only",
+			ccData:     ccData942c,
+			wantField1: "942c",
+		},
+		{
+			name:       "both fields",
+			ccData:     "c2ff" + "fc942c" + "fd1529" + "ff",
+			wantField1: "942c",
+			wantField2: "1529",
+		},
+		{
+			name:   "no valid pairs",
+			ccData: "c2ff" + "f80000" + "f90000" + "ff",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ccData, err := hex.DecodeString(c.ccData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tu := append([]byte{}, td.Encode()...)
+			tu = append(tu, CreateCTA608MetadataOBU(ccData)...)
+			tu = append(tu, frame.Encode()...)
+
+			obus, err := SplitOBUs(tu)
+			if err != nil {
+				t.Fatalf("SplitOBUs: %v", err)
+			}
+			if len(obus) != 3 {
+				t.Fatalf("got %d OBUs, want 3", len(obus))
+			}
+			field1, field2, err := ExtractCTA608(obus)
+			if err != nil {
+				t.Fatalf("ExtractCTA608: %v", err)
+			}
+			if hex.EncodeToString(field1) != c.wantField1 {
+				t.Errorf("field1: got %s, want %s", hex.EncodeToString(field1), c.wantField1)
+			}
+			if hex.EncodeToString(field2) != c.wantField2 {
+				t.Errorf("field2: got %s, want %s", hex.EncodeToString(field2), c.wantField2)
+			}
+		})
+	}
+}
+
+func TestExtractCTA608SkipsOtherOBUs(t *testing.T) {
+	hdrCLL := MetadataOBU{Type: MetadataTypeHDRCLL, Payload: []byte{0x03, 0xe8, 0x01, 0x90}}
+	// HDR10+ shares country code 0xb5 with CTA-608 but uses provider code 0x003c.
+	hdr10Plus := ITUTT35{CountryCode: 0xb5, Payload: []byte{0x00, 0x3c, 0x00, 0x01, 0x04, 0x00, 0x40}}
+	seqHdr := OBU{Header: OBUHeader{Type: OBUSequenceHeader, HasSizeField: true, HeaderSize: 1}, Payload: []byte{0x00}}
+
+	tu := append([]byte{}, seqHdr.Encode()...)
+	tu = append(tu, hdrCLL.Encode()...)
+	tu = append(tu, hdr10Plus.MetadataOBU().Encode()...)
+
+	obus, err := SplitOBUs(tu)
+	if err != nil {
+		t.Fatal(err)
+	}
+	field1, field2, err := ExtractCTA608(obus)
+	if err != nil {
+		t.Fatalf("ExtractCTA608: %v", err)
+	}
+	if field1 != nil || field2 != nil {
+		t.Errorf("got fields %x / %x, want none", field1, field2)
+	}
+}
+
+func TestExtractCTA608Errors(t *testing.T) {
+	// A metadata OBU whose metadata_type LEB128 never terminates.
+	broken := OBU{Header: OBUHeader{Type: OBUMetadata, HasSizeField: true, HeaderSize: 1}, Payload: []byte{0x80}}
+	if _, _, err := ExtractCTA608([]OBU{broken}); err == nil {
+		t.Error("expected error for unterminated metadata_type, got nil")
+	}
+	// A CTA-608 payload whose cc_data() is truncated: cc_count promises 3 constructs.
+	ccData, err := hex.DecodeString("c3ff" + "fc942c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	obus, err := SplitOBUs(CreateCTA608MetadataOBU(ccData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ExtractCTA608(obus); err == nil {
+		t.Error("expected error for truncated cc_data, got nil")
+	}
+}
+
+func TestITUTT35ITUData(t *testing.T) {
+	ccData, err := hex.DecodeString(ccData942c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obus, err := SplitOBUs(CreateCTA608MetadataOBU(ccData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseMetadataOBUFromOBU(obus[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	tt35, err := ParseITUTT35(m.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, ok := tt35.ITUData()
+	if !ok {
+		t.Fatal("ITUData not recognized")
+	}
+	if data != sei.CTA608ITUData() {
+		t.Errorf("got %+v, want %+v", data, sei.CTA608ITUData())
+	}
+	if !data.IsCTA608() {
+		t.Error("IsCTA608 is false")
+	}
+	if hex.EncodeToString(tt35.CTA608CCData()) != ccData942c {
+		t.Errorf("cc_data: got %s, want %s", hex.EncodeToString(tt35.CTA608CCData()), ccData942c)
+	}
+}
+
+func TestITUTT35ITUDataNotRecognized(t *testing.T) {
+	cases := []struct {
+		name string
+		tt35 ITUTT35
+	}{
+		{
+			name: "too short for the identification",
+			tt35: ITUTT35{CountryCode: 0xb5, Payload: []byte{0x00, 0x31}},
+		},
+		{
+			name: "country code with extension byte",
+			tt35: ITUTT35{CountryCode: 0xff, CountryCodeExtension: 0x2a,
+				Payload: []byte{0x00, 0x31, 0x47, 0x41, 0x39, 0x34, 0x03, 0xc3}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, ok := c.tt35.ITUData(); ok {
+				t.Error("ITUData: got ok, want not ok")
+			}
+			if got := c.tt35.CTA608CCData(); got != nil {
+				t.Errorf("CTA608CCData: got %x, want nil", got)
+			}
+		})
+	}
+	// A well-formed identification that is not CTA-608 carries no cc_data either.
+	notCC := ITUTT35{CountryCode: 0xb5, Payload: []byte{0x00, 0x3c, 0x00, 0x01, 0x04, 0x00, 0x40, 0x00}}
+	if got := notCC.CTA608CCData(); got != nil {
+		t.Errorf("HDR10+: got cc_data %x, want nil", got)
+	}
+	// A CTA-608 identification with an empty cc_data() is not usable either.
+	empty := ITUTT35{CountryCode: 0xb5, Payload: sei.CTA608ITUData().Encode()[1:]}
+	if got := empty.CTA608CCData(); got != nil {
+		t.Errorf("empty cc_data: got %x, want nil", got)
+	}
+}

--- a/av1/doc.go
+++ b/av1/doc.go
@@ -1,5 +1,11 @@
 /*
 Package av1 decodes (parses) and encodes (writes) the AV1 CodecConfigurationRecord
 and parses the OBU (Open Bitstream Unit) structure of AV1 streams.
+
+Metadata OBUs are handled in layers: MetadataOBU is any metadata OBU (a metadata_type
+with its payload and trailing_bits), ITUTT35 is the metadata_itu_t_t35 body carried by
+one, and CreateCTA608MetadataOBU/ExtractCTA608 form the CTA-608 closed-caption layer on
+top of those. The CTA-608 payload is the same cc_data() as in an AVC/HEVC SEI message,
+so it is built from the same input as sei.CreateCTA608SEIMessage.
 */
 package av1

--- a/av1/metadata.go
+++ b/av1/metadata.go
@@ -1,0 +1,209 @@
+package av1
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Metadata OBU errors
+var (
+	ErrTruncatedITUTT35 = errors.New("truncated metadata_itu_t_t35 payload")
+	ErrNotMetadataOBU   = errors.New("OBU is not a metadata OBU")
+	ErrNotITUTT35       = errors.New("metadata OBU is not of type ITU-T T.35")
+)
+
+// MetadataType is metadata_type in a metadata OBU (AV1 spec 6.7.1).
+type MetadataType uint64
+
+const (
+	MetadataTypeHDRCLL      MetadataType = 1 // HDR content light level
+	MetadataTypeHDRMDCV     MetadataType = 2 // HDR mastering display colour volume
+	MetadataTypeScalability MetadataType = 3
+	MetadataTypeITUTT35     MetadataType = 4 // user data registered by ITU-T Rec. T.35
+	MetadataTypeTimecode    MetadataType = 5
+)
+
+func (t MetadataType) String() string {
+	switch t {
+	case MetadataTypeHDRCLL:
+		return "HDRCLL"
+	case MetadataTypeHDRMDCV:
+		return "HDRMDCV"
+	case MetadataTypeScalability:
+		return "Scalability"
+	case MetadataTypeITUTT35:
+		return "ITUTT35"
+	case MetadataTypeTimecode:
+		return "Timecode"
+	default:
+		return fmt.Sprintf("Reserved(%d)", uint64(t))
+	}
+}
+
+// metadataTrailingByte is trailing_bits() for a byte-aligned metadata payload: the
+// trailing_one_bit followed by zero padding to the byte boundary (AV1 spec 5.3.4).
+const metadataTrailingByte = 0x80
+
+// countryCodeExtensionEscape signals that itu_t_t35_country_code is followed by an
+// extension byte (ITU-T T.35 Annex A).
+const countryCodeExtensionEscape = 0xff
+
+// MetadataOBU is a parsed metadata_obu() (AV1 spec 5.8.1): a metadata_type and the
+// metadata payload that follows it. It is codec metadata rather than coded video, and
+// carries HDR light levels, mastering display colour volume, scalability structure,
+// timecodes or ITU-T T.35 registered user data such as closed captions or HDR10+.
+type MetadataOBU struct {
+	Type MetadataType
+	// Payload is the metadata payload after metadata_type, with trailing_bits removed.
+	Payload []byte
+	// PayloadHasTrailingBits tells OBU and Encode that the last byte of Payload already
+	// holds trailing_bits, so that no trailing_bits byte of their own is added.
+	// ParseMetadataOBU sets it when the payload is not byte-aligned and therefore shares
+	// its last byte with trailing_bits. It stays false for a payload built from scratch,
+	// which is byte-aligned and needs its own trailing_bits byte.
+	PayloadHasTrailingBits bool
+}
+
+// ParseMetadataOBU parses the payload of an OBU_METADATA, i.e. the Payload of an OBU
+// with Header.Type == OBUMetadata as returned by SplitOBUs.
+//
+// The metadata payload has no explicit length — it runs to the end of the OBU, which
+// also holds trailing_bits — so its end is found by scanning back from the end of the
+// OBU. AV1 spec 6.7.1 requires that the last byte of valid content is the last byte
+// that is not equal to zero, so trailing zero bytes are dropped and a final
+// trailing_one_bit byte (0x80) is dropped with them.
+//
+// A payload that is not byte-aligned (possible for metadata_timecode) shares its last
+// byte with trailing_bits; such a byte is not 0x80 and is therefore kept, so the caller
+// can parse it bit-wise, and PayloadHasTrailingBits is set so that Encode does not add a
+// second trailing_one_bit. A non-conformant OBU that omits trailing_bits altogether keeps
+// all of its bytes, unless its payload happens to end with 0x80; it is indistinguishable
+// from the unaligned case and is therefore re-encoded without trailing_bits as well.
+func ParseMetadataOBU(payload []byte) (MetadataOBU, error) {
+	mt, n, err := ReadLEB128(payload)
+	if err != nil {
+		return MetadataOBU{}, fmt.Errorf("metadata_type: %w", err)
+	}
+	body, hasTrailingBits := trimMetadataTrailingBits(payload[n:])
+	return MetadataOBU{
+		Type:                   MetadataType(mt),
+		Payload:                body,
+		PayloadHasTrailingBits: hasTrailingBits,
+	}, nil
+}
+
+// ParseMetadataOBUFromOBU is ParseMetadataOBU for a full OBU. It returns
+// ErrNotMetadataOBU unless obu is a metadata OBU.
+func ParseMetadataOBUFromOBU(obu OBU) (MetadataOBU, error) {
+	if obu.Header.Type != OBUMetadata {
+		return MetadataOBU{}, ErrNotMetadataOBU
+	}
+	return ParseMetadataOBU(obu.Payload)
+}
+
+// trimMetadataTrailingBits drops trailing zero bytes and a final trailing_one_bit byte.
+// hasTrailingBits reports that the last remaining byte still holds trailing_bits, which is
+// the case when the payload does not end on a byte boundary so that its last byte is not
+// 0x80. An empty result never has trailing bits, so that it is re-encoded with them.
+func trimMetadataTrailingBits(payload []byte) (trimmed []byte, hasTrailingBits bool) {
+	end := len(payload)
+	for end > 0 && payload[end-1] == 0 {
+		end--
+	}
+	if end > 0 && payload[end-1] == metadataTrailingByte {
+		return payload[:end-1], false
+	}
+	return payload[:end], end > 0
+}
+
+// OBU returns m as an OBU ready for Encode: metadata_type, the payload, and the
+// mandatory trailing_bits byte. Metadata OBUs always carry trailing_bits (AV1 spec 5.2:
+// every OBU type except tile group, tile list and frame does), but the byte is left out
+// when PayloadHasTrailingBits says the payload already ends with them, since a second
+// trailing_one_bit would make the OBU non-conformant.
+func (m MetadataOBU) OBU() OBU {
+	size := leb128Len(uint64(m.Type)) + len(m.Payload)
+	if !m.PayloadHasTrailingBits {
+		size++
+	}
+	payload := make([]byte, 0, size)
+	payload = appendLEB128(payload, uint64(m.Type))
+	payload = append(payload, m.Payload...)
+	if !m.PayloadHasTrailingBits {
+		payload = append(payload, metadataTrailingByte)
+	}
+	return OBU{
+		Header:  OBUHeader{Type: OBUMetadata, HasSizeField: true, HeaderSize: 1},
+		Payload: payload,
+	}
+}
+
+// Encode returns the complete metadata OBU: obu_header, obu_size, metadata_type, the
+// payload and trailing_bits. AV1 OBUs carry no emulation-prevention bytes, so the
+// payload is written as-is.
+func (m MetadataOBU) Encode() []byte {
+	return m.OBU().Encode()
+}
+
+// Size returns the number of bytes Encode would write.
+func (m MetadataOBU) Size() int {
+	return m.OBU().Size()
+}
+
+// ITUTT35 is a parsed metadata_itu_t_t35() (AV1 spec 5.8.2): user data registered by
+// ITU-T Rec. T.35, identified by a country code. Country code 0xb5 (USA) covers both
+// ATSC A/53 closed captions (see CreateCTA608MetadataOBU) and SMPTE ST 2094-40 (HDR10+),
+// which differ by the provider code at the start of the payload.
+type ITUTT35 struct {
+	CountryCode byte
+	// CountryCodeExtension is itu_t_t35_country_code_extension_byte. It is only present,
+	// and only valid, when CountryCode is 0xff.
+	CountryCodeExtension byte
+	// Payload is itu_t_t35_payload_bytes: everything after the country code, starting
+	// with the terminal provider code.
+	Payload []byte
+}
+
+// ParseITUTT35 parses a metadata_itu_t_t35() from the payload of a metadata OBU of type
+// MetadataTypeITUTT35, i.e. from MetadataOBU.Payload.
+func ParseITUTT35(payload []byte) (ITUTT35, error) {
+	if len(payload) < 1 {
+		return ITUTT35{}, ErrTruncatedITUTT35
+	}
+	t := ITUTT35{CountryCode: payload[0]}
+	pos := 1
+	if t.CountryCode == countryCodeExtensionEscape {
+		if len(payload) < 2 {
+			return ITUTT35{}, ErrTruncatedITUTT35
+		}
+		t.CountryCodeExtension = payload[1]
+		pos = 2
+	}
+	t.Payload = payload[pos:]
+	return t, nil
+}
+
+// Encode returns the metadata_itu_t_t35() body: the country code, its extension byte
+// when the country code is 0xff, and the payload.
+func (t ITUTT35) Encode() []byte {
+	out := make([]byte, 0, t.Size())
+	out = append(out, t.CountryCode)
+	if t.CountryCode == countryCodeExtensionEscape {
+		out = append(out, t.CountryCodeExtension)
+	}
+	return append(out, t.Payload...)
+}
+
+// Size returns the number of bytes Encode would write.
+func (t ITUTT35) Size() int {
+	n := 1 + len(t.Payload)
+	if t.CountryCode == countryCodeExtensionEscape {
+		n++
+	}
+	return n
+}
+
+// MetadataOBU wraps t as a metadata OBU of type ITU-T T.35.
+func (t ITUTT35) MetadataOBU() MetadataOBU {
+	return MetadataOBU{Type: MetadataTypeITUTT35, Payload: t.Encode()}
+}

--- a/av1/metadata_test.go
+++ b/av1/metadata_test.go
@@ -1,0 +1,284 @@
+package av1
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestMetadataOBUEncode(t *testing.T) {
+	cases := []struct {
+		name string
+		obu  MetadataOBU
+		want string // full OBU: header, obu_size, metadata_type, payload, trailing_bits
+	}{
+		{
+			name: "HDR content light level",
+			obu:  MetadataOBU{Type: MetadataTypeHDRCLL, Payload: []byte{0x03, 0xe8, 0x01, 0x90}},
+			want: "2a06" + "01" + "03e80190" + "80",
+		},
+		{
+			name: "empty payload",
+			obu:  MetadataOBU{Type: MetadataTypeTimecode},
+			want: "2a02" + "05" + "80",
+		},
+		{
+			name: "metadata type needing two LEB128 bytes",
+			obu:  MetadataOBU{Type: 200, Payload: []byte{0xaa}},
+			want: "2a04" + "c801" + "aa" + "80",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.obu.Encode()
+			if hex.EncodeToString(got) != c.want {
+				t.Errorf("got %s, want %s", hex.EncodeToString(got), c.want)
+			}
+			if c.obu.Size() != len(got) {
+				t.Errorf("Size() %d, but encoded %d bytes", c.obu.Size(), len(got))
+			}
+			// The encoded OBU must split and parse back into the same metadata OBU.
+			obus, err := SplitOBUs(got)
+			if err != nil {
+				t.Fatalf("SplitOBUs: %v", err)
+			}
+			if len(obus) != 1 {
+				t.Fatalf("got %d OBUs, want 1", len(obus))
+			}
+			if obus[0].Header.Type != OBUMetadata {
+				t.Fatalf("got OBU of type %s, want %s", obus[0].Header.Type, OBUMetadata)
+			}
+			back, err := ParseMetadataOBUFromOBU(obus[0])
+			if err != nil {
+				t.Fatalf("ParseMetadataOBUFromOBU: %v", err)
+			}
+			if back.Type != c.obu.Type {
+				t.Errorf("type: got %s, want %s", back.Type, c.obu.Type)
+			}
+			// bytes.Equal treats a nil and an empty payload as equal, which they are here.
+			if !bytes.Equal(back.Payload, c.obu.Payload) {
+				t.Errorf("payload: got %x, want %x", back.Payload, c.obu.Payload)
+			}
+			// Encoding the parsed OBU again must not add a second trailing_bits byte.
+			if again := hex.EncodeToString(back.Encode()); again != c.want {
+				t.Errorf("re-encode: got %s, want %s", again, c.want)
+			}
+		})
+	}
+}
+
+func TestParseMetadataOBUTrailingBits(t *testing.T) {
+	cases := []struct {
+		name         string
+		payload      string // OBU payload: metadata_type + body
+		wantType     MetadataType
+		wantPayload  string
+		wantHasTBits bool
+		wantReencode string // OBU payload after Payload is encoded again
+	}{
+		{
+			name:         "trailing_bits byte is dropped",
+			payload:      "01" + "03e8" + "80",
+			wantType:     MetadataTypeHDRCLL,
+			wantPayload:  "03e8",
+			wantReencode: "01" + "03e8" + "80",
+		},
+		{
+			name:         "padding zeros after trailing_bits are dropped",
+			payload:      "01" + "03e8" + "80" + "000000",
+			wantType:     MetadataTypeHDRCLL,
+			wantPayload:  "03e8",
+			wantReencode: "01" + "03e8" + "80",
+		},
+		{
+			name:         "zero bytes before trailing_bits are kept",
+			payload:      "04" + "b50000" + "80" + "00",
+			wantType:     MetadataTypeITUTT35,
+			wantPayload:  "b50000",
+			wantReencode: "04" + "b50000" + "80",
+		},
+		{
+			name: "missing trailing_bits is tolerated",
+			// Indistinguishable from an unaligned payload, so it stays without
+			// trailing_bits rather than gaining a byte that may not belong there.
+			payload:      "01" + "03e8",
+			wantType:     MetadataTypeHDRCLL,
+			wantPayload:  "03e8",
+			wantHasTBits: true,
+			wantReencode: "01" + "03e8",
+		},
+		{
+			name: "byte shared with trailing_bits is kept",
+			// A payload that is not byte-aligned ends in a byte that is not 0x80. Adding
+			// a trailing_bits byte on re-encode would give it two trailing_one_bits.
+			payload:      "05" + "1234" + "90",
+			wantType:     MetadataTypeTimecode,
+			wantPayload:  "123490",
+			wantHasTBits: true,
+			wantReencode: "05" + "123490",
+		},
+		{
+			name:         "trailing_bits only",
+			payload:      "05" + "80",
+			wantType:     MetadataTypeTimecode,
+			wantPayload:  "",
+			wantReencode: "05" + "80",
+		},
+		{
+			name:         "no payload at all",
+			payload:      "05",
+			wantType:     MetadataTypeTimecode,
+			wantPayload:  "",
+			wantReencode: "05" + "80",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data, err := hex.DecodeString(c.payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := ParseMetadataOBU(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Type != c.wantType {
+				t.Errorf("type: got %s, want %s", got.Type, c.wantType)
+			}
+			if hex.EncodeToString(got.Payload) != c.wantPayload {
+				t.Errorf("payload: got %s, want %s", hex.EncodeToString(got.Payload), c.wantPayload)
+			}
+			if got.PayloadHasTrailingBits != c.wantHasTBits {
+				t.Errorf("PayloadHasTrailingBits: got %t, want %t", got.PayloadHasTrailingBits, c.wantHasTBits)
+			}
+			if enc := hex.EncodeToString(got.OBU().Payload); enc != c.wantReencode {
+				t.Errorf("re-encoded OBU payload: got %s, want %s", enc, c.wantReencode)
+			}
+			if got.Size() != len(got.Encode()) {
+				t.Errorf("Size() %d, but encoded %d bytes", got.Size(), len(got.Encode()))
+			}
+			// Re-encoding is stable: parsing the result gives the same metadata OBU back.
+			obus, err := SplitOBUs(got.Encode())
+			if err != nil {
+				t.Fatalf("SplitOBUs: %v", err)
+			}
+			if len(obus) != 1 {
+				t.Fatalf("got %d OBUs, want 1", len(obus))
+			}
+			again, err := ParseMetadataOBUFromOBU(obus[0])
+			if err != nil {
+				t.Fatalf("ParseMetadataOBUFromOBU: %v", err)
+			}
+			if diff := deep.Equal(again, got); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestParseMetadataOBUErrors(t *testing.T) {
+	if _, err := ParseMetadataOBU(nil); !errors.Is(err, ErrTruncatedLEB128) {
+		t.Errorf("empty payload: got %v, want ErrTruncatedLEB128", err)
+	}
+	// A metadata_type LEB128 that never terminates.
+	if _, err := ParseMetadataOBU([]byte{0x80}); !errors.Is(err, ErrTruncatedLEB128) {
+		t.Errorf("unterminated metadata_type: got %v, want ErrTruncatedLEB128", err)
+	}
+	td := OBU{Header: OBUHeader{Type: OBUTemporalDelimiter, HasSizeField: true, HeaderSize: 1}}
+	if _, err := ParseMetadataOBUFromOBU(td); !errors.Is(err, ErrNotMetadataOBU) {
+		t.Errorf("temporal delimiter: got %v, want ErrNotMetadataOBU", err)
+	}
+}
+
+func TestITUTT35(t *testing.T) {
+	cases := []struct {
+		name string
+		hex  string // metadata_itu_t_t35() body
+		want ITUTT35
+	}{
+		{
+			name: "USA country code",
+			hex:  "b5" + "0031",
+			want: ITUTT35{CountryCode: 0xb5, Payload: []byte{0x00, 0x31}},
+		},
+		{
+			name: "country code with extension byte",
+			hex:  "ff" + "2a" + "0102",
+			want: ITUTT35{CountryCode: 0xff, CountryCodeExtension: 0x2a, Payload: []byte{0x01, 0x02}},
+		},
+		{
+			name: "empty payload",
+			hex:  "b5",
+			want: ITUTT35{CountryCode: 0xb5, Payload: []byte{}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data, err := hex.DecodeString(c.hex)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := ParseITUTT35(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := deep.Equal(got, c.want); diff != nil {
+				t.Error(diff)
+			}
+			if enc := got.Encode(); hex.EncodeToString(enc) != c.hex {
+				t.Errorf("Encode: got %s, want %s", hex.EncodeToString(enc), c.hex)
+			}
+			if got.Size() != len(data) {
+				t.Errorf("Size() %d, want %d", got.Size(), len(data))
+			}
+			// The wrapped metadata OBU must round-trip back to the same body.
+			m := got.MetadataOBU()
+			if m.Type != MetadataTypeITUTT35 {
+				t.Errorf("metadata type: got %s, want ITUTT35", m.Type)
+			}
+			obus, err := SplitOBUs(m.Encode())
+			if err != nil {
+				t.Fatalf("SplitOBUs: %v", err)
+			}
+			back, err := ParseMetadataOBUFromOBU(obus[0])
+			if err != nil {
+				t.Fatalf("ParseMetadataOBUFromOBU: %v", err)
+			}
+			if hex.EncodeToString(back.Payload) != c.hex {
+				t.Errorf("round trip: got %s, want %s", hex.EncodeToString(back.Payload), c.hex)
+			}
+		})
+	}
+}
+
+func TestParseITUTT35Errors(t *testing.T) {
+	if _, err := ParseITUTT35(nil); !errors.Is(err, ErrTruncatedITUTT35) {
+		t.Errorf("empty payload: got %v, want ErrTruncatedITUTT35", err)
+	}
+	// Country code 0xff promises an extension byte that is not there.
+	if _, err := ParseITUTT35([]byte{0xff}); !errors.Is(err, ErrTruncatedITUTT35) {
+		t.Errorf("missing extension byte: got %v, want ErrTruncatedITUTT35", err)
+	}
+}
+
+func TestMetadataTypeString(t *testing.T) {
+	cases := []struct {
+		mt   MetadataType
+		want string
+	}{
+		{MetadataTypeHDRCLL, "HDRCLL"},
+		{MetadataTypeHDRMDCV, "HDRMDCV"},
+		{MetadataTypeScalability, "Scalability"},
+		{MetadataTypeITUTT35, "ITUTT35"},
+		{MetadataTypeTimecode, "Timecode"},
+		{6, "Reserved(6)"},
+	}
+	for _, c := range cases {
+		if got := c.mt.String(); got != c.want {
+			t.Errorf("got %s, want %s", got, c.want)
+		}
+	}
+}

--- a/mp4/dec3_test.go
+++ b/mp4/dec3_test.go
@@ -77,11 +77,11 @@ func TestGetChannelInfoDec3(t *testing.T) {
 
 func TestDec3JOCComplexity(t *testing.T) {
 	testCases := []struct {
-		name              string
-		hexIn             string
-		wantedJOC         uint8
-		wantedNrChannels  int
-		wantedChannelMap  uint16
+		name             string
+		hexIn            string
+		wantedJOC        uint8
+		wantedNrChannels int
+		wantedChannelMap uint16
 	}{
 		{
 			name:             "5.1 with JOC complexity 16",

--- a/sei/sei4.go
+++ b/sei/sei4.go
@@ -8,8 +8,8 @@ import (
 
 // DecodeUserDataRegisteredSEI decodes a SEI message of type 4.
 func DecodeUserDataRegisteredSEI(sd *SEIData) (SEIMessage, error) {
-	if len(sd.payload) < 8 {
-		return nil, fmt.Errorf("SEI type 4 (user_data_registered_itu_t_t35) payload too short: %d bytes", len(sd.payload))
+	if len(sd.payload) < ITUDataSize {
+		return nil, errShortITUTT35Payload(len(sd.payload))
 	}
 	itutData := ITUData{
 		CountryCode:      sd.payload[0],
@@ -17,8 +17,8 @@ func DecodeUserDataRegisteredSEI(sd *SEIData) (SEIMessage, error) {
 		UserIdentifier:   binary.BigEndian.Uint32(sd.payload[3:7]),
 		UserDataTypeCode: sd.payload[7],
 	}
-	if itutData.IsCEA608() {
-		return ExtractCEA608sei(sd)
+	if itutData.IsCTA608() {
+		return ExtractCTA608sei(sd)
 	}
 	return NewRegisteredSEI(sd, itutData), nil
 }
@@ -31,12 +31,69 @@ type ITUData struct {
 	UserIdentifier   uint32
 }
 
-// IsCEA608 checks if ITU-T data corresponds to CEA-608.
-func (i ITUData) IsCEA608() bool {
+// ITUDataSize is the size in bytes of the ITUData header that starts a
+// user_data_registered_itu_t_t35 payload.
+const ITUDataSize = 8
+
+// errShortITUTT35Payload reports a type 4 payload too short to hold the ITUData header.
+func errShortITUTT35Payload(n int) error {
+	return fmt.Errorf("SEI type 4 (user_data_registered_itu_t_t35) payload too short: %d bytes", n)
+}
+
+// CTA608ITUData returns the ITUData that identifies ATSC A/53 CTA-608 closed captions:
+// country code 0xb5 (USA), provider code 0x0031 (ATSC), user identifier "GA94" and
+// user_data_type_code 0x03. The same identification is used in an AVC/HEVC SEI message
+// of type 4 and in an AV1 metadata OBU of type ITU-T T.35.
+func CTA608ITUData() ITUData {
+	return ITUData{
+		CountryCode:      0xb5,
+		ProviderCode:     0x31,
+		UserIdentifier:   0x47413934, // "GA94"
+		UserDataTypeCode: 0x03,
+	}
+}
+
+// IsCTA608 checks if ITU-T data corresponds to CTA-608.
+func (i ITUData) IsCTA608() bool {
 	return (i.CountryCode == 0xb5 &&
 		i.ProviderCode == 0x31 &&
 		i.UserIdentifier == 0x47413934 &&
 		i.UserDataTypeCode == 0x3)
+}
+
+// Encode returns the ITUDataSize bytes that start a user_data_registered_itu_t_t35
+// payload. Like the decoder, it assumes a country code other than 0xff, i.e. that no
+// itu_t_t35_country_code_extension_byte is present.
+func (i ITUData) Encode() []byte {
+	out := make([]byte, ITUDataSize)
+	out[0] = i.CountryCode
+	binary.BigEndian.PutUint16(out[1:3], i.ProviderCode)
+	binary.BigEndian.PutUint32(out[3:7], i.UserIdentifier)
+	out[7] = i.UserDataTypeCode
+	return out
+}
+
+// CreateCTA608Payload returns the payload of a CTA-608 user_data_registered_itu_t_t35
+// message: the CTA608ITUData header followed by ccData.
+//
+// ccData is a cc_data() structure as specified in ATSC A/53 Part 4 Section 6.2.2 and
+// CTA-708-E Section 4.3. It is the same payload in AVC/HEVC and AV1, so this is the
+// common part of CreateCTA608SEIMessage and av1.CreateCTA608MetadataOBU. The bytes are
+// not validated here; ParseCTA608 is the inverse.
+func CreateCTA608Payload(ccData []byte) []byte {
+	payload := make([]byte, 0, ITUDataSize+len(ccData))
+	payload = append(payload, CTA608ITUData().Encode()...)
+	return append(payload, ccData...)
+}
+
+// CreateCTA608SEIMessage returns a user_data_registered_itu_t_t35 (type 4) SEI message
+// carrying CTA-608 closed captions, the encode-side counterpart of ExtractCTA608sei.
+// Turn it into a NAL unit with avc.CreateSEINalu or hevc.CreateSEINalu; the AV1
+// counterpart is av1.CreateCTA608MetadataOBU.
+//
+// ccData is a cc_data() structure (see CreateCTA608Payload).
+func CreateCTA608SEIMessage(ccData []byte) SEIMessage {
+	return NewSEIData(SEIUserDataRegisteredITUtT35Type, CreateCTA608Payload(ccData))
 }
 
 // RegisteredSEI is user_data_registered_itu_t_t35 (type 4) SEI message.
@@ -73,52 +130,59 @@ func (s *RegisteredSEI) Payload() []byte {
 	return s.payload
 }
 
-// ExtractCEA608sei returns payload and parsed field for CEA 608 SEI message.
-// CEA-608 encapsulation in SEI nal unit is defined in ATSC-120 and further
-// in CTA-708 specification (previously CEA-708).
-func ExtractCEA608sei(sd *SEIData) (*CEA608sei, error) {
-	field1, field2, err := ParseCEA608(sd.payload[8:])
+// ExtractCTA608sei returns payload and parsed field for a CTA-608 SEI message.
+// CTA-608 encapsulation in SEI nal unit is defined in ATSC-120 and further
+// in CTA-708 specification. CTA-608 and CTA-708 were previously named CEA-608
+// and CEA-708. CreateCTA608SEIMessage is the inverse.
+//
+// An error is returned for a payload too short to hold the ITUData header, so that the
+// function is safe to call on an arbitrary type 4 SEI message.
+func ExtractCTA608sei(sd *SEIData) (*CTA608sei, error) {
+	if len(sd.payload) < ITUDataSize {
+		return nil, errShortITUTT35Payload(len(sd.payload))
+	}
+	field1, field2, err := ParseCTA608(sd.payload[ITUDataSize:])
 	if err != nil {
 		return nil, err
 	}
-	return &CEA608sei{
+	return &CTA608sei{
 		payload: sd.payload,
 		Field1:  field1,
 		Field2:  field2,
 	}, nil
 }
 
-// CEA608sei data structure.
-type CEA608sei struct {
+// CTA608sei data structure.
+type CTA608sei struct {
 	payload []byte // full raw payload
 	Field1  []byte
 	Field2  []byte
 }
 
 // Type returns the SEI payload type.
-func (s *CEA608sei) Type() uint {
+func (s *CTA608sei) Type() uint {
 	return SEIUserDataRegisteredITUtT35Type
 }
 
 // Size is size in bytes of raw SEI message rbsp payload.
-func (s *CEA608sei) Size() uint {
+func (s *CTA608sei) Size() uint {
 	return uint(len(s.payload))
 }
 
-// String provides a simple representation of the CEA608 data.
-func (s *CEA608sei) String() string {
-	return fmt.Sprintf("SEI type %d CEA-608, size=%d, field1: %q, field2: %q", s.Type(), s.Size(),
+// String provides a simple representation of the CTA608 data.
+func (s *CTA608sei) String() string {
+	return fmt.Sprintf("SEI type %d CTA-608, size=%d, field1: %q, field2: %q", s.Type(), s.Size(),
 		hex.EncodeToString(s.Field1), hex.EncodeToString(s.Field2))
 }
 
 // Payload returns the SEI raw rbsp payload.
-func (s *CEA608sei) Payload() []byte {
+func (s *CTA608sei) Payload() []byte {
 	return s.payload
 }
 
-// ParseCEA608 parsers the the fields of data from CEA-708 encapsulation.
+// ParseCTA608 parses the fields of data from CTA-708 encapsulation.
 // This is specified in Section 4.3 of ANSI/CTA-708-E R-2018.
-func ParseCEA608(payload []byte) ([]byte, []byte, error) {
+func ParseCTA608(payload []byte) ([]byte, []byte, error) {
 	if len(payload) == 0 {
 		return nil, nil, fmt.Errorf("empty cc_data payload")
 	}
@@ -130,7 +194,7 @@ func ParseCEA608(payload []byte) ([]byte, []byte, error) {
 
 	for i := byte(0); i < ccCount; i++ {
 		if len(payload) < pos+3 {
-			return nil, nil, fmt.Errorf("not enough data for CEA-708 parsing")
+			return nil, nil, fmt.Errorf("not enough data for CTA-708 parsing")
 		}
 		b := payload[pos]
 		ccValid := b & 0x4

--- a/sei/sei4_test.go
+++ b/sei/sei4_test.go
@@ -1,10 +1,85 @@
 package sei_test
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/sei"
 )
+
+func TestCTA608ITUDataEncode(t *testing.T) {
+	// The T.35 header that identifies CTA-608: country USA, provider ATSC, "GA94",
+	// user_data_type_code 0x03. Identical in an AVC/HEVC SEI message and an AV1 OBU.
+	want := "b5003147413934" + "03"
+	got := sei.CTA608ITUData().Encode()
+	if hex.EncodeToString(got) != want {
+		t.Errorf("got %s, want %s", hex.EncodeToString(got), want)
+	}
+	if len(got) != sei.ITUDataSize {
+		t.Errorf("got %d bytes, want %d", len(got), sei.ITUDataSize)
+	}
+	if !sei.CTA608ITUData().IsCTA608() {
+		t.Error("IsCTA608 is false for CTA608ITUData")
+	}
+}
+
+func TestCreateCTA608SEIMessage(t *testing.T) {
+	// Rebuild the CTA-608 SEI message used in TestParseSEI from its own cc_data():
+	// the creator must reproduce the payload byte-exactly.
+	rbsp, err := hex.DecodeString(seiCTA608Hex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seis, err := sei.ExtractSEIData(bytes.NewReader(rbsp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seis) != 1 {
+		t.Fatalf("got %d SEI messages, want 1", len(seis))
+	}
+	payload := seis[0].Payload()
+	ccData := payload[sei.ITUDataSize:]
+
+	msg := sei.CreateCTA608SEIMessage(ccData)
+	if msg.Type() != sei.SEIUserDataRegisteredITUtT35Type {
+		t.Errorf("got SEI type %d, want %d", msg.Type(), sei.SEIUserDataRegisteredITUtT35Type)
+	}
+	if !bytes.Equal(msg.Payload(), payload) {
+		t.Errorf("got payload %s, want %s", hex.EncodeToString(msg.Payload()), hex.EncodeToString(payload))
+	}
+	if msg.Size() != uint(len(payload)) {
+		t.Errorf("got size %d, want %d", msg.Size(), len(payload))
+	}
+
+	// The created message must survive the SEI framing and decode back to CTA-608.
+	var buf bytes.Buffer
+	if err := sei.WriteSEIMessages(&buf, []sei.SEIMessage{msg}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buf.Bytes(), rbsp) {
+		t.Errorf("got RBSP %s, want %s", hex.EncodeToString(buf.Bytes()), hex.EncodeToString(rbsp))
+	}
+	back, err := sei.ExtractSEIData(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := sei.DecodeSEIMessage(&back[0], sei.AVC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cta, ok := decoded.(*sei.CTA608sei)
+	if !ok {
+		t.Fatalf("got %T, want *sei.CTA608sei", decoded)
+	}
+	wantField1 := "942094ae9162e56e67ba91b9b0b0bab0b0bab031bab0b080942c942f"
+	if hex.EncodeToString(cta.Field1) != wantField1 {
+		t.Errorf("field1: got %s, want %s", hex.EncodeToString(cta.Field1), wantField1)
+	}
+	if len(cta.Field2) != 0 {
+		t.Errorf("field2: got %s, want empty", hex.EncodeToString(cta.Field2))
+	}
+}
 
 func TestDecodeUserDataRegisteredSEIShortPayload(t *testing.T) {
 	// A type-4 (user_data_registered_itu_t_t35) header is 8 bytes. A shorter
@@ -18,9 +93,21 @@ func TestDecodeUserDataRegisteredSEIShortPayload(t *testing.T) {
 	}
 }
 
-func TestParseCEA608EmptyPayload(t *testing.T) {
+func TestExtractCTA608seiShortPayload(t *testing.T) {
+	// ExtractCTA608sei is exported, so it must guard the ITUData header itself instead
+	// of relying on the length check in DecodeUserDataRegisteredSEI.
+	for size := 0; size < sei.ITUDataSize; size++ {
+		sd := sei.NewSEIData(sei.SEIUserDataRegisteredITUtT35Type, make([]byte, size))
+		cta, err := sei.ExtractCTA608sei(sd)
+		if err == nil {
+			t.Errorf("expected error for %d-byte type-4 payload, got nil (msg %v)", size, cta)
+		}
+	}
+}
+
+func TestParseCTA608EmptyPayload(t *testing.T) {
 	// Empty cc_data payload must return an error instead of panicking on payload[0].
-	if _, _, err := sei.ParseCEA608([]byte{}); err == nil {
-		t.Error("expected error for empty CEA-608 payload, got nil")
+	if _, _, err := sei.ParseCTA608([]byte{}); err == nil {
+		t.Error("expected error for empty CTA-608 payload, got nil")
 	}
 }

--- a/sei/sei_test.go
+++ b/sei/sei_test.go
@@ -280,7 +280,7 @@ func TestTimeCodeSEI(t *testing.T) {
 const (
 	// The following examples are without NAL Unit header
 	sei0Hex      = "0007810f1c0050744080"
-	seiCEA608Hex = "0434b500314741393403cefffc9420fc94aefc9162fce56efc67bafc91b9" +
+	seiCTA608Hex = "0434b500314741393403cefffc9420fc94aefc9162fce56efc67bafc91b9" +
 		"fcb0b0fcbab0fcb0bafcb031fcbab0fcb080fc942cfc942f80"
 	seiAVCMulti             = "0001c001061b0509b8000080"
 	seiAVCPicTiming         = "010f00011a00000300090c2e268a000003004080"
@@ -334,8 +334,8 @@ func TestParseSEI(t *testing.T) {
 			sei.ErrRbspTrailingBitsMissing,
 		},
 		{"Type 0", sei.AVC, sei0Hex, nil, []uint{0}, []string{`SEIBufferingPeriodType (0), size=7, "810f1c00507440"`}, nil},
-		{"CEA-608", sei.AVC, seiCEA608Hex, nil, []uint{4},
-			[]string{`SEI type 4 CEA-608, size=52, field1: "942094ae9162e56e67ba91b9b0b0bab0b0bab031bab0b080942c942f", field2: ""`}, nil},
+		{"CTA-608", sei.AVC, seiCTA608Hex, nil, []uint{4},
+			[]string{`SEI type 4 CTA-608, size=52, field1: "942094ae9162e56e67ba91b9b0b0bab0b0bab031bab0b080942c942f", field2: ""`}, nil},
 		{"HEVC multi", sei.HEVC, seiHEVCMulti, nil, []uint{0, 1, 136},
 			[]string{
 				`SEIBufferingPeriodType (0), size=10, "80000000403dc017a690"`,


### PR DESCRIPTION
Adds AV1 metadata OBU support in reusable layers, and closes the encode-side gap for
CTA-608 closed captions so that AVC/HEVC (SEI) and AV1 (metadata OBU) are handled
symmetrically. Driven by [go-608#53](https://github.com/Eyevinn/go-608/issues/53), where
AV1 CTA-608 caption carriage needs these primitives.

## Layers

1. **Generic metadata OBU** (`av1`) — `MetadataOBU{Type, Payload,
   PayloadHasTrailingBits}` with `ParseMetadataOBU`, `ParseMetadataOBUFromOBU`, `Encode`,
   `Size`, and `MetadataType` constants for HDR CLL, HDR MDCV, scalability, ITU-T T.35 and
   timecode. Not caption-specific: HDR10+, timecode and HDR metadata build on this
   directly.
2. **Generic `metadata_itu_t_t35`** (`av1`) — `ITUTT35{CountryCode,
   CountryCodeExtension, Payload}` with `ParseITUTT35`, `Encode`, `Size` and
   `MetadataOBU`, including the `0xff` country-code extension-byte rule. Country code
   `0xb5` covers both ATSC A/53 captions and SMPTE ST 2094-40 (HDR10+), which differ by
   provider code.
3. **CTA-608 layer** — `av1.CreateCTA608MetadataOBU(ccData)` and
   `av1.ExtractCTA608(obus)`, plus `ITUTT35.ITUData()` and `ITUTT35.CTA608CCData()`.
   Thin over layers 1 and 2, and reusing `sei.ParseCTA608` for the `cc_data()` itself.

On the SEI side, the missing encode direction: `sei.CreateCTA608SEIMessage` (the
counterpart of `sei.ExtractCTA608sei`), plus `sei.CTA608ITUData`,
`sei.CreateCTA608Payload`, `sei.ITUData.Encode` and `sei.ITUDataSize`. The T.35 payload
is byte-identical for AVC/HEVC and AV1, so both creators take the same `cc_data()` input
and only the envelope differs — no emulation prevention for the OBU, and `trailing_bits`
instead of `rbsp_trailing_bits`.

Also hardens `sei.ExtractCTA608sei`: it is exported, but only its internal caller
`DecodeUserDataRegisteredSEI` checked the length, so calling it directly with a type-4
payload shorter than the 8-byte `ITUData` header panicked on `payload[8:]`. It now
returns an error, and both length checks in `sei4.go` use `ITUDataSize` rather than a
literal `8`.

## trailing_bits handling

A metadata payload has no explicit length — it runs to the end of the OBU, which also
carries `trailing_bits`. Parse applies the conformance rule of AV1 spec 6.7.1 (the last
byte of valid content is the last non-zero byte): trailing zero padding is dropped, and a
final `trailing_one_bit` byte with it. A payload byte *shared* with `trailing_bits`, which
`metadata_timecode` can have, is not `0x80` and is therefore kept, so such a payload stays
parseable bit-wise.

Encode appends the `0x80` that the spec requires for every metadata OBU, except when
`MetadataOBU.PayloadHasTrailingBits` says the payload already ends with them. Parse sets
that flag for the shared-byte case above; without it, re-encoding a parsed
`metadata_timecode` OBU would emit a second `trailing_one_bit` and produce a
non-conformant OBU. An OBU that omits `trailing_bits` altogether is
byte-indistinguishable from the shared-byte case, so it is tolerated on parse and
re-encoded as it came in, rather than gaining a `trailing_one_bit` that may not belong
there.

## Verification

- `sei.CreateCTA608SEIMessage` reproduces the existing real CTA-608 SEI vector in
  `sei_test.go` byte-for-byte, including the full RBSP through `WriteSEIMessages`.
- `av1.CreateCTA608MetadataOBU` emits the hand-computed 24-byte reference OBU
  (`2a 16 04 b5 00 31 47 41 39 34 03 c3 ff fc 94 2c f9 00 00 fa 00 00 ff 80`).
- A test asserts the AV1 OBU payload and the SEI payload are identical for the same
  `cc_data()`, locking in that only the envelope differs.
- Round trips for metadata OBUs and `metadata_itu_t_t35` (incl. the extension byte)
  through `SplitOBUs`, extraction from a full temporal unit, and skipping of non-caption
  OBUs (HDR CLL, HDR10+, sequence header).
- Every `trailing_bits` variant is checked for re-encode stability: the flag, the
  re-encoded OBU payload, `Size()` agreement against `len(Encode())`, and
  `parse(encode(x)) == x`.
- `sei.ExtractCTA608sei` is checked for every payload length below `ITUDataSize`.

## Breaking change

CEA-608 is renamed to its current designation CTA-608 in the `sei` API:

| before | after |
|---|---|
| `sei.CEA608sei` | `sei.CTA608sei` |
| `sei.ParseCEA608` | `sei.ParseCTA608` |
| `sei.ExtractCEA608sei` | `sei.ExtractCTA608sei` |
| `sei.ITUData.IsCEA608` | `sei.ITUData.IsCTA608` |

No aliases are kept. Within mp4ff the rename touches only `sei` and its tests; for
comparison, building go-608 (a heavy consumer of this API) against this branch needed a
single one-line change.

The second commit is an unrelated `gofmt` fix for `mp4/dec3_test.go`, which was already
misaligned on master and is what the pre-commit hook wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
