### PR TITLE
Release/v0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-07-27
+
 ### Added
 
 - `Dec3Box.JOCComplexity` from the JOC (Joint Object Coding) extension of the `dec3` box
@@ -999,7 +1001,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New unique repo name: `mp4ff`
 
-[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.54.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp4ff/compare/v0.55.0...HEAD
+[0.55.0]: https://github.com/Eyevinn/mp4ff/compare/v0.54.0...v0.55.0
 [0.54.0]: https://github.com/Eyevinn/mp4ff/compare/v0.53.0...v0.54.0
 [0.53.0]: https://github.com/Eyevinn/mp4ff/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/Eyevinn/mp4ff/compare/v0.51.0...v0.52.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sei.DecodeUserDataRegisteredSEI`, `sei.ExtractCTA608sei` and `sei.ParseCTA608` no
   longer panic on a short/truncated type-4 (user_data_registered_itu_t_t35) SEI
   payload; they return an error that propagates through `avc`/`hevc.ParseSEINalu`
+- the build date in the `--version` output of the command line tools is rendered in
+  UTC, so that a commit made close to midnight is no longer reported as the
+  neighbouring day for users west of UTC
 
 ## [0.54.0] - 2026-07-13
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -15,7 +15,9 @@ var (
 func GetVersion() string {
 	seconds, _ := strconv.Atoi(commitDate)
 	if commitDate != "" {
-		t := time.Unix(int64(seconds), 0)
+		// UTC so that the reported date is the same everywhere. In a local time zone,
+		// a commit made near midnight UTC would be reported as the neighbouring day.
+		t := time.Unix(int64(seconds), 0).UTC()
 		return fmt.Sprintf("%s, date: %s", commitVersion, t.Format("2006-01-02"))
 	}
 	return commitVersion

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.54.0"    // May be updated using build flags
-	commitDate    string = "1783900800" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.55.0"    // May be updated using build flags
+	commitDate    string = "1785110400" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -1,8 +1,62 @@
 package internal
 
-import "fmt"
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
 
-func ExampleGetVersion() {
-	fmt.Println(GetVersion())
-	// Output: v0.54.0, date: 2026-07-13
+func TestGetVersion(t *testing.T) {
+	// GetVersion reads package-level variables that the Makefile overrides through build
+	// flags. Drive them with fixed values so that this test survives a release bump
+	// instead of having to be edited every time version.go is. The two timestamps sit at
+	// either end of a UTC day, so the expected strings only hold in every time zone as
+	// long as GetVersion keeps rendering the date in UTC.
+	origVersion, origDate := commitVersion, commitDate
+	t.Cleanup(func() { commitVersion, commitDate = origVersion, origDate })
+
+	cases := []struct {
+		name    string
+		version string
+		date    string
+		want    string
+	}{
+		{
+			name:    "version and date",
+			version: "v1.2.3",
+			date:    "1783900800", // 2026-07-13 00:00:00 UTC
+			want:    "v1.2.3, date: 2026-07-13",
+		},
+		{
+			name:    "date at the end of the day",
+			version: "v1.2.3",
+			date:    "1783987199", // 2026-07-13 23:59:59 UTC
+			want:    "v1.2.3, date: 2026-07-13",
+		},
+		{
+			name:    "no date",
+			version: "v1.2.3",
+			date:    "",
+			want:    "v1.2.3",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			commitVersion, commitDate = c.version, c.date
+			if got := GetVersion(); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestBuiltInVersion checks the values compiled into the binary in a way that does not
+// pin them to one release, so that a malformed version.go is still caught.
+func TestBuiltInVersion(t *testing.T) {
+	if !strings.HasPrefix(commitVersion, "v") {
+		t.Errorf("commitVersion %q does not look like a version", commitVersion)
+	}
+	if _, err := strconv.Atoi(commitDate); err != nil {
+		t.Errorf("commitDate %q is not an epoch timestamp: %v", commitDate, err)
+	}
 }


### PR DESCRIPTION
### Added

- `Dec3Box.JOCComplexity` from the JOC (Joint Object Coding) extension of the `dec3` box
  (ETSI TS 103 420 C.3) to detect Dolby Atmos in E-AC-3 tracks
- `avc.CreateSEINalu` and `hevc.CreateSEINalu` to build a full SEI NAL unit (codec
  NAL header + EBSP payload) from `sei.SEIMessage` values; the encode-side inverse of
  `ParseSEINalu`
- tkhd: the transformation matrix is parsed into `TkhdBox.Matrix` and preserved
  on encode, so rotation metadata survives round trips; a zero-value `Matrix`
  still encodes as the unity matrix. New helper `mp4.UnityMatrix()`
- AV1 metadata OBUs in the `av1` package, in reusable layers: `MetadataOBU`
  (`metadata_type` + payload) with `ParseMetadataOBU`, `ParseMetadataOBUFromOBU`,
  `Encode` and `Size`, handling the mandatory `trailing_bits` and the reverse scan
  for the last non-zero payload byte (AV1 spec 6.7.1), and `MetadataType` constants
  for HDR CLL/MDCV, scalability, ITU-T T.35 and timecode. A payload that is not
  byte-aligned shares its last byte with `trailing_bits`; `PayloadHasTrailingBits`
  marks it so that `Encode` does not add a second `trailing_one_bit`
- `av1.ITUTT35` for the `metadata_itu_t_t35` body (country code, its `0xff`
  extension byte, and payload) with `ParseITUTT35`, `Encode`, `Size` and
  `MetadataOBU`; it carries CTA-608 captions as well as HDR10+
- CTA-608 closed captions in AV1: `av1.CreateCTA608MetadataOBU` builds a complete
  caption metadata OBU from a `cc_data()` structure and `av1.ExtractCTA608` reads the
  field 1 and field 2 byte pairs back from the OBUs of a temporal unit, plus
  `ITUTT35.ITUData` and `ITUTT35.CTA608CCData`. The payload is identical to the
  AVC/HEVC SEI one, so only the envelope differs between the codecs
- `sei.CreateCTA608SEIMessage` builds a CTA-608 `user_data_registered_itu_t_t35`
  (type 4) SEI message from a `cc_data()` structure, the encode-side counterpart of
  `sei.ExtractCTA608sei`. Wrap it with `avc.CreateSEINalu` or `hevc.CreateSEINalu`.
  Supporting helpers: `sei.CTA608ITUData`, `sei.CreateCTA608Payload`,
  `sei.ITUData.Encode` and `sei.ITUDataSize`
- Motion JPEG support: `mjpg` sample entry (JPEG image sequences, ISO/IEC 23008-12 Annex H)
  with the `jpgC` (JPEGConfigurationBox) and `fiel` (field handling) boxes.
  `mp4.TrakBox.SetMJpegDescriptor` creates an mjpg sample entry with an optional jpgC JPEG prefix
- Decode support for the legacy motion JPEG sample entries `mp4v` (with esds JPEG object type,
  ISO/IEC 14496-14) and `jpeg` (QuickTime), and `Esds` child access in `VisualSampleEntryBox`

### Changed

- CEA-608 is renamed to its current designation CTA-608 in the `sei` API:
  `sei.CEA608sei`, `sei.ParseCEA608`, `sei.ExtractCEA608sei` and
  `sei.ITUData.IsCEA608` become `sei.CTA608sei`, `sei.ParseCTA608`,
  `sei.ExtractCTA608sei` and `sei.ITUData.IsCTA608`. This is a breaking change; the
  old names are gone

### Fixed

- avcC encode now writes the 4 trailing-info bytes for all AVC profiles outside
  66/77/88, symmetric with `Size()` and decode (e.g. profile 244)
- unknown bytes after the avcC trailing info are preserved through decode/encode
  in the new `DecConfRec.TrailingBytes` field instead of being dropped
- visual sample entries with a too long compressor name length byte are decoded
  by clamping the length to 31 like ffmpeg does, instead of failing
- Panic in `hevc.ParseSEINalu` and `avc.ParseSEINalu` on NAL units shorter than
  the codec's NAL unit header (e.g. an empty or single-byte HEVC SEI NALU);
  such input now returns `ErrNotSEINalu`
- `sei.DecodeUserDataRegisteredSEI`, `sei.ExtractCTA608sei` and `sei.ParseCTA608` no
  longer panic on a short/truncated type-4 (user_data_registered_itu_t_t35) SEI
  payload; they return an error that propagates through `avc`/`hevc.ParseSEINalu`
- the build date in the `--version` output of the command line tools is rendered in
  UTC, so that a commit made close to midnight is no longer reported as the
  neighbouring day for users west of UTC