### PR TITLE
fix(mp4): report large mdat header size for large lazy payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `MdatBox.HeaderSize` accounts for large lazy payloads, so trun data
+  offsets are no longer 8 bytes short for fragments above 4 GiB
+
 ## [0.55.0] - 2026-07-27
 
 ### Added

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -69,21 +69,21 @@ func (m *MdatBox) Type() string {
 	return "mdat"
 }
 
-// Size - return calculated size, depending on largeSize set or not
-func (m *MdatBox) Size() uint64 {
-	dataSize := m.DataLength()
-
+// payloadSize - the mdat payload size, in memory or lazy
+func (m *MdatBox) payloadSize() uint64 {
 	if m.lazyDataSize > 0 {
-		dataSize = m.lazyDataSize
+		return m.lazyDataSize
 	}
-	if dataSize > maxNormalPayloadSize {
+	return m.DataLength()
+}
+
+// Size - return calculated size, depending on largeSize set or not.
+// Sets the LargeSize flag if the payload requires a large header.
+func (m *MdatBox) Size() uint64 {
+	if m.payloadSize() > maxNormalPayloadSize {
 		m.LargeSize = true
 	}
-	size := boxHeaderSize + dataSize
-	if m.LargeSize {
-		size += 8
-	}
-	return size
+	return m.HeaderSize() + m.payloadSize()
 }
 
 // AddSampleData -  a sample data to an mdat box
@@ -163,13 +163,16 @@ func (m *MdatBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 	return bd.err
 }
 
-// HeaderSize - 8 or 16 (bytes) depending o whether largeSize is used
+// HeaderSize - 8 or 16 (bytes) depending on whether largeSize is used.
+// A large header is reported whenever the (possibly lazy) payload needs one,
+// so the value is right even before Size() or Encode() has flipped the
+// LargeSize flag. The flag is not mutated. This matters for
+// Fragment.SetTrunDataOffsets, which reads the header size before encoding.
 func (m *MdatBox) HeaderSize() uint64 {
-	hSize := boxHeaderSize
-	if m.LargeSize {
-		hSize += largeSizeLen
+	if m.LargeSize || m.payloadSize() > maxNormalPayloadSize {
+		return boxHeaderSize + largeSizeLen
 	}
-	return uint64(hSize)
+	return boxHeaderSize
 }
 
 // PayloadAbsoluteOffset - position of mdat payload start (works after header)

--- a/mp4/mdat_test.go
+++ b/mp4/mdat_test.go
@@ -2,6 +2,7 @@ package mp4_test
 
 import (
 	"bytes"
+	"math"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/mp4"
@@ -204,5 +205,28 @@ func TestAddParts(t *testing.T) {
 	}
 	if !bytes.Equal(outBuf.Bytes(), outBufExp.Bytes()) {
 		t.Errorf("expected %v, got %v", outBufExp.Bytes(), outBuf.Bytes())
+	}
+}
+
+func TestMdatHeaderSizeForLargeLazyPayload(t *testing.T) {
+	cases := []struct {
+		lazyDataSize   uint64
+		wantHeaderSize uint64
+	}{
+		{1, 8},
+		{math.MaxUint32 - 8, 8},  // largest payload where size fits 32 bits
+		{math.MaxUint32 - 7, 16}, // one byte more needs the large header
+		{1 << 32, 16},
+	}
+	for _, c := range cases {
+		mdat := &mp4.MdatBox{}
+		mdat.SetLazyDataSize(c.lazyDataSize)
+		// HeaderSize must be right before Size() has flipped the LargeSize flag.
+		if got := mdat.HeaderSize(); got != c.wantHeaderSize {
+			t.Errorf("lazy payload %d: got header size %d, wanted %d", c.lazyDataSize, got, c.wantHeaderSize)
+		}
+		if size := mdat.Size(); size != c.wantHeaderSize+c.lazyDataSize {
+			t.Errorf("lazy payload %d: size %d does not match header size %d", c.lazyDataSize, size, c.wantHeaderSize)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

`Fragment.Encode`/`EncodeSW` call `SetTrunDataOffsets` before any child box is
encoded, and the first trun data offset is `Moof.Size() + Mdat.HeaderSize()`.
`MdatBox.HeaderSize()` only looked at the `LargeSize` flag, which `Size()` flips
lazily — so for a lazy mdat payload larger than 2^32−9 bytes (~4 GiB),
`HeaderSize()` reported 8 while the encode wrote a 16-byte large header, leaving
every trun data offset 8 bytes short.

## Fix

`HeaderSize()` now applies the same rule as `Size()` — large header whenever the
(possibly lazy) payload needs one — without mutating `LargeSize`. A pre-set
`LargeSize` (e.g. from decoding a large-header mdat) is still honored, so
round-trip bytes are unchanged. Payload selection and the threshold live in one
private `payloadSize()` helper and `Size()` is now `HeaderSize() + payloadSize()`,
so the two can no longer drift apart.

## Tests

`TestMdatHeaderSizeForLargeLazyPayload` covers the boundary payloads and the
resulting `Size()`. `go test ./...`, `go vet`, `gofmt`, `golangci-lint` pass.
