### PR TITLE
feat(mp4): name the esds vocabulary and add StreamType accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CompressionID`), and the child boxes are read at the version-dependent
   offset. `Info()` reports the effective channel count, sample size, and
   sample rate from the version 2 struct
+- `DecoderConfigDescriptor.StreamTypeValue` and `UpStream` decompose the
+  packed streamType byte, and named constants cover the common stream types
+  (ISO/IEC 14496-1 Table 6) and object type indications (mp4ra.org), so
+  callers no longer need magic numbers for the esds vocabulary
 
 ### Changed
 

--- a/mp4/descriptors.go
+++ b/mp4/descriptors.go
@@ -351,6 +351,35 @@ type DecoderConfigDescriptor struct {
 	UnknownData         []byte // Data, probably erroneous, that we don't understand
 }
 
+// Stream types according to ISO/IEC 14496-1 Table 6.
+const (
+	StreamTypeObjectDescriptor byte = 0x01
+	StreamTypeClockReference   byte = 0x02
+	StreamTypeSceneDescription byte = 0x03
+	StreamTypeVisual           byte = 0x04
+	StreamTypeAudio            byte = 0x05
+)
+
+// Object type indications according to mp4ra.org and ISO/IEC 14496-1 Table 5.
+const (
+	ObjectTypeMPEG4Visual byte = 0x20 // Visual ISO/IEC 14496-2
+	ObjectTypeAVC         byte = 0x21 // Visual ISO/IEC 14496-10 (AVC)
+	ObjectTypeHEVC        byte = 0x23 // Visual ISO/IEC 23008-2 (HEVC)
+	ObjectTypeAAC         byte = 0x40 // Audio ISO/IEC 14496-3 (AAC)
+	ObjectTypeMPEG2Audio  byte = 0x69 // Audio ISO/IEC 13818-3
+	ObjectTypeMP3         byte = 0x6b // Audio ISO/IEC 11172-3
+)
+
+// StreamTypeValue - the 6-bit streamType part of the packed StreamType byte.
+func (d *DecoderConfigDescriptor) StreamTypeValue() byte {
+	return d.StreamType >> 2
+}
+
+// UpStream - the upStream bit of the packed StreamType byte.
+func (d *DecoderConfigDescriptor) UpStream() bool {
+	return d.StreamType&0x02 != 0
+}
+
 func exceedsMaxNrBytes(sizeFieldSizeMinus1 byte, size uint64, maxNrBytes int) bool {
 	return 1+uint64(sizeFieldSizeMinus1)+1+size > uint64(maxNrBytes)
 }
@@ -683,8 +712,8 @@ func CreateESDescriptor(decConfig []byte) ESDescriptor {
 	e := ESDescriptor{
 		EsID: 0x01,
 		DecConfigDescriptor: &DecoderConfigDescriptor{
-			ObjectType: 0x40, // Audio ISO/IEC 14496-3,
-			StreamType: 0x15, // 0x5 << 2 + 0x01 (audioType + upstreamFlag + reserved)
+			ObjectType: ObjectTypeAAC,
+			StreamType: StreamTypeAudio<<2 | 0x01, // streamType, upStream=0, reserved=1
 			DecSpecificInfo: &DecSpecificInfoDescriptor{
 				DecConfig: decConfig,
 			},

--- a/mp4/descriptors_test.go
+++ b/mp4/descriptors_test.go
@@ -54,6 +54,20 @@ func TestDecodeDescriptor(t *testing.T) {
 	}
 }
 
+func TestDecoderConfigStreamTypeAccessors(t *testing.T) {
+	dd := mp4.DecoderConfigDescriptor{StreamType: 0x15} // 0x5 << 2 + 0x01 (audioType + reserved)
+	if dd.StreamTypeValue() != 5 {
+		t.Errorf("got streamType %d, wanted 5", dd.StreamTypeValue())
+	}
+	if dd.UpStream() {
+		t.Error("upStream flag must not be set for 0x15")
+	}
+	dd.StreamType = 0x4<<2 | 0x02 | 0x01 // visual, upStream set
+	if dd.StreamTypeValue() != 4 || !dd.UpStream() {
+		t.Errorf("got streamType %d upStream %t, wanted 4 true", dd.StreamTypeValue(), dd.UpStream())
+	}
+}
+
 func TestDescriptorInfo(t *testing.T) {
 	cases := []struct {
 		desc       string


### PR DESCRIPTION
## Problem

`DecoderConfigDescriptor.StreamType` holds the packed byte from ISO/IEC 14496-1
(6-bit streamType, upStream flag, reserved bit), so reading the stream type
requires knowing the bit layout. The common streamType and objectTypeIndication
values only exist as magic numbers — `CreateESDescriptor` hardcodes `0x40` and
`0x15` itself.

## Fix

`StreamTypeValue()` and `UpStream()` decompose the packed byte (the raw field is
unchanged, so round-trip bytes are untouched), and named constants cover the
Table 6 stream types and the common mp4ra.org object type indications.
`CreateESDescriptor` now uses them; the encoded bytes are identical. As a bonus,
the old comment on the `0x15` literal mislabeled the reserved bit as the
upStream flag — the named expression (`StreamTypeAudio<<2 | 0x01`, upStream=0,
reserved=1) now spells it out correctly.

## Tests

`TestDecoderConfigStreamTypeAccessors` covers both accessors including the
upStream bit; the existing esds round-trip tests and hex fixtures (`4015`,
`6b15`) pin the unchanged bytes. `go test ./...`, `go vet`, `gofmt`,
`golangci-lint` pass.