### PR TITLE
feat(aac): decode the AudioSpecificConfig header for any audio object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   packed streamType byte, and named constants cover the common stream types
   (ISO/IEC 14496-1 Table 6) and object type indications (mp4ra.org), so
   callers no longer need magic numbers for the esds vocabulary
+- `aac.DecodeAudioSpecificConfigHeader` parses the leading
+  AudioSpecificConfig fields (object type including the 31-escape, base
+  sampling frequency, channel configuration) for every audio object type,
+  not just the AAC-LC and HE-AAC types the full decoder supports
 
 ### Changed
 

--- a/aac/aac.go
+++ b/aac/aac.go
@@ -73,6 +73,41 @@ var ReverseFrequencies = map[int]byte{
 8-15: Reserved
 */
 
+// AudioSpecificConfigHeader - the leading fields shared by every audio
+// object type in an AudioSpecificConfig (ISO/IEC 14496-3 Table 1.15).
+type AudioSpecificConfigHeader struct {
+	ObjectType           byte
+	ChannelConfiguration byte
+	SamplingFrequency    int
+}
+
+// DecodeAudioSpecificConfigHeader decodes the leading AudioSpecificConfig
+// fields and stops before the object-type-specific payload, so it works for
+// object types that DecodeAudioSpecificConfig does not support. The sampling
+// frequency is the base frequency, without any HE-AAC extension.
+func DecodeAudioSpecificConfigHeader(r io.Reader) (*AudioSpecificConfigHeader, error) {
+	br := bits.NewReader(r)
+	hdr := &AudioSpecificConfigHeader{}
+	objectType := br.Read(5)
+	if objectType == 31 {
+		objectType = 32 + br.Read(6)
+	}
+	hdr.ObjectType = byte(objectType)
+	frequency, ok := getFrequency(br)
+	if !ok {
+		if br.AccError() != nil {
+			return nil, fmt.Errorf("audio specific config too short: %w", br.AccError())
+		}
+		return nil, fmt.Errorf("strange frequency index")
+	}
+	hdr.SamplingFrequency = frequency
+	hdr.ChannelConfiguration = byte(br.Read(4))
+	if br.AccError() != nil {
+		return nil, fmt.Errorf("audio specific config too short: %w", br.AccError())
+	}
+	return hdr, nil
+}
+
 // DecodeAudioSpecificConfig -
 func DecodeAudioSpecificConfig(r io.Reader) (*AudioSpecificConfig, error) {
 	br := bits.NewReader(r)

--- a/aac/aac_test.go
+++ b/aac/aac_test.go
@@ -3,10 +3,97 @@ package aac
 import (
 	"bytes"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
 )
+
+func encodeASC(t *testing.T, asc AudioSpecificConfig) []byte {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	if err := asc.Encode(buf); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestDecodeAudioSpecificConfigHeader(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		asc       []byte
+		wanted    AudioSpecificConfigHeader
+		wantedErr string
+	}{
+		{
+			desc:   "AAC-LC 48000 stereo",
+			asc:    []byte{0x11, 0x90},
+			wanted: AudioSpecificConfigHeader{ObjectType: 2, SamplingFrequency: 48000, ChannelConfiguration: 2},
+		},
+		{
+			desc: "HE-AACv1 24000 stereo (base frequency, not the extension)",
+			asc: encodeASC(t, AudioSpecificConfig{ObjectType: HEAACv1, ChannelConfiguration: 2,
+				SamplingFrequency: 24000, ExtensionFrequency: 48000, SBRPresentFlag: true}),
+			wanted: AudioSpecificConfigHeader{ObjectType: 5, SamplingFrequency: 24000, ChannelConfiguration: 2},
+		},
+		{
+			desc: "object type 39 (ER AAC ELD), unsupported by the full decoder",
+			asc:  []byte{0xf8, 0xe8, 0x40},
+			wanted: AudioSpecificConfigHeader{
+				ObjectType: 39, SamplingFrequency: 44100, ChannelConfiguration: 2,
+			},
+		},
+		{
+			desc: "explicit 24-bit frequency",
+			asc:  []byte{0x17, 0x80, 0x2e, 0x6c, 0x08},
+			wanted: AudioSpecificConfigHeader{
+				ObjectType: 2, SamplingFrequency: 23768, ChannelConfiguration: 1,
+			},
+		},
+		{
+			desc:      "invalid frequency index 13",
+			asc:       []byte{0x16, 0x90},
+			wantedErr: "strange frequency index",
+		},
+		{
+			desc:      "truncated config",
+			asc:       []byte{0x11},
+			wantedErr: "audio specific config too short",
+		},
+		{
+			desc:      "truncated inside the object type escape",
+			asc:       []byte{0xf8},
+			wantedErr: "audio specific config too short",
+		},
+		{
+			desc:      "truncated inside the 24-bit frequency",
+			asc:       []byte{0x17, 0x80},
+			wantedErr: "audio specific config too short",
+		},
+		{
+			desc:      "truncated at the channel configuration",
+			asc:       []byte{0xf8, 0xe8},
+			wantedErr: "audio specific config too short",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			hdr, err := DecodeAudioSpecificConfigHeader(bytes.NewReader(tc.asc))
+			if tc.wantedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantedErr) {
+					t.Errorf("wanted error %q, got %v", tc.wantedErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := deep.Equal(*hdr, tc.wanted); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
 
 func TestAudioSpecificConfigEncodeDecode(t *testing.T) {
 


### PR DESCRIPTION
## Problem

`DecodeAudioSpecificConfig` rejects audio object types other than AAC-LC and
HE-AAC v1/v2, so callers that only need the identity of a track (object type,
base sampling frequency, channel configuration) have to hand-roll a bit reader
for anything else — e.g. AOT 39 (ER AAC ELD) fails with `unsupported object
type: 31` before the escape is even resolved.

## Fix

`DecodeAudioSpecificConfigHeader` parses the fields shared by every audio
object type (ISO/IEC 14496-3 Table 1.15) — the 5-bit object type including the
31-escape for types 32 and above, the sampling frequency from the index table
or the 24-bit escape (reusing `getFrequency`), and the channel configuration —
and stops before the object-type-specific payload. The sampling frequency is
the base frequency; any HE-AAC extension frequency is not read.

It is a separate function rather than a refactor of `DecodeAudioSpecificConfig`
on purpose: the full decoder returns a partially-populated config alongside its
errors and checks the object type before the frequency, so building it on the
header decoder would change its error behavior. Happy to unify them in a
follow-up if you prefer.

## Tests

Table-driven cases cover AAC-LC, HE-AACv1 (base frequency pinned, not the
extension), the 31-escape (AOT 39), an explicit 24-bit frequency, a reserved
frequency index, and truncation at every field boundary (inside the object
type escape, inside the 24-bit frequency, at the channel configuration).
`go test ./...`, `go vet`, `gofmt`, `golangci-lint` pass.