### PR TITLE
feat(mp4): add wave box for QuickTime audio decoder configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CompressionID`), and the child boxes are read at the version-dependent
   offset. `Info()` reports the effective channel count, sample size, and
   sample rate from the version 2 struct
+- `WaveBox` for the QuickTime siDecompressionParam atom, so an esds wrapped
+  in a wave child of an audio sample entry becomes reachable as `Wave.Esds`.
+  Children that are not well-formed boxes (such as the spec-mandated
+  terminator atom when written with size zero) are preserved verbatim
 - `DecoderConfigDescriptor.StreamTypeValue` and `UpStream` decompose the
   packed streamType byte, and named constants cover the common stream types
   (ISO/IEC 14496-1 Table 6) and object type indications (mp4ra.org), so

--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -41,6 +41,7 @@ type AudioSampleEntryBox struct {
 	MhaC          *MhaCBox
 	Btrt          *BtrtBox
 	Sinf          *SinfBox
+	Wave          *WaveBox
 	Children      []Box
 }
 
@@ -129,6 +130,8 @@ func (a *AudioSampleEntryBox) AddChild(child Box) {
 		a.Btrt = child.(*BtrtBox)
 	case "sinf":
 		a.Sinf = child.(*SinfBox)
+	case "wave":
+		a.Wave = child.(*WaveBox)
 	}
 
 	a.Children = append(a.Children, child)

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -197,6 +197,7 @@ func init() {
 		"vttc":    DecodeVttc,
 		"vttC":    DecodeVttC,
 		"vtte":    DecodeVtte,
+		"wave":    DecodeWave,
 		"wvtt":    DecodeWvtt,
 	}
 }

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -188,6 +188,7 @@ func init() {
 		"vttc":    DecodeVttcSR,
 		"vttC":    DecodeVttCSR,
 		"vtte":    DecodeVtteSR,
+		"wave":    DecodeWaveSR,
 		"wvtt":    DecodeWvttSR,
 	}
 }

--- a/mp4/wave.go
+++ b/mp4/wave.go
@@ -1,0 +1,137 @@
+package mp4
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// WaveBox - siDecompressionParam atom (QuickTime File Format), a container
+// inside audio sample entries that wraps the decoder configuration,
+// typically frma + esds followed by a terminator atom. Children that do not
+// decode cleanly (such as a 12-byte mp4a stub) are kept as UnknownBox, and a
+// tail that is not a well-formed box (such as a size-zero terminator) is
+// preserved verbatim in RawTail, so the round trip stays byte-exact.
+type WaveBox struct {
+	Frma     *FrmaBox
+	Esds     *EsdsBox
+	Children []Box
+	RawTail  []byte
+}
+
+// AddChild - add a child box
+func (b *WaveBox) AddChild(child Box) {
+	switch box := child.(type) {
+	case *FrmaBox:
+		b.Frma = box
+	case *EsdsBox:
+		b.Esds = box
+	}
+	b.Children = append(b.Children, child)
+}
+
+// DecodeWave - box-specific decode
+func DecodeWave(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	data, err := readBoxBody(r, hdr)
+	if err != nil {
+		return nil, err
+	}
+	return decodeWaveFromData(hdr, startPos, data)
+}
+
+// DecodeWaveSR - box-specific decode
+func DecodeWaveSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	data := sr.ReadBytes(hdr.payloadLen())
+	if sr.AccError() != nil {
+		return nil, sr.AccError()
+	}
+	return decodeWaveFromData(hdr, startPos, data)
+}
+
+func decodeWaveFromData(hdr BoxHeader, startPos uint64, data []byte) (Box, error) {
+	b := &WaveBox{}
+	pos := 0
+	for pos+8 <= len(data) {
+		size := int(binary.BigEndian.Uint32(data[pos : pos+4]))
+		name := string(data[pos+4 : pos+8])
+		if size < 8 || size > len(data)-pos {
+			break // malformed child (e.g. a size-zero terminator): keep the tail verbatim
+		}
+		childData := data[pos : pos+size]
+		childStartPos := startPos + uint64(hdr.Hdrlen) + uint64(pos)
+		child, err := DecodeBoxSR(childStartPos, bits.NewFixedSliceReader(childData))
+		if err != nil || child.Size() != uint64(size) { // malformed child: keep the bytes
+			payload := make([]byte, size-8)
+			copy(payload, childData[8:])
+			child = CreateUnknownBox(name, uint64(size), payload)
+		}
+		b.AddChild(child)
+		pos += size
+	}
+	if pos < len(data) {
+		b.RawTail = make([]byte, len(data)-pos)
+		copy(b.RawTail, data[pos:])
+	}
+	return b, nil
+}
+
+// Type - box type
+func (b *WaveBox) Type() string {
+	return "wave"
+}
+
+// Size - calculated size of box
+func (b *WaveBox) Size() uint64 {
+	size := uint64(boxHeaderSize) + uint64(len(b.RawTail))
+	for _, child := range b.Children {
+		size += child.Size()
+	}
+	return size
+}
+
+// Encode - write box to w
+func (b *WaveBox) Encode(w io.Writer) error {
+	sw := bits.NewFixedSliceWriter(int(b.Size()))
+	err := b.EncodeSW(sw)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(sw.Bytes())
+	return err
+}
+
+// EncodeSW - box-specific encode to slicewriter
+func (b *WaveBox) EncodeSW(sw bits.SliceWriter) error {
+	err := EncodeHeaderSW(b, sw)
+	if err != nil {
+		return err
+	}
+	for _, child := range b.Children {
+		err = child.EncodeSW(sw)
+		if err != nil {
+			return err
+		}
+	}
+	sw.WriteBytes(b.RawTail)
+	return sw.AccError()
+}
+
+// Info - write box-specific information
+func (b *WaveBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
+	bd := newInfoDumper(w, indent, b, -1, 0)
+	if bd.err != nil {
+		return bd.err
+	}
+	if len(b.RawTail) > 0 {
+		bd.write(" - raw_tail: %d bytes", len(b.RawTail))
+	}
+	var err error
+	for _, child := range b.Children {
+		err = child.Info(w, specificBoxLevels, indent+indentStep, indentStep)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/mp4/wave_test.go
+++ b/mp4/wave_test.go
@@ -1,0 +1,133 @@
+package mp4_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+func waveChildBytes(name string, payload []byte) []byte {
+	child := make([]byte, 0, 8+len(payload))
+	child = binary.BigEndian.AppendUint32(child, uint32(8+len(payload)))
+	child = append(child, []byte(name)...)
+	return append(child, payload...)
+}
+
+func waveBytes(children ...[]byte) []byte {
+	size := 8
+	for _, child := range children {
+		size += len(child)
+	}
+	box := make([]byte, 0, size)
+	box = binary.BigEndian.AppendUint32(box, uint32(size))
+	box = append(box, []byte("wave")...)
+	for _, child := range children {
+		box = append(box, child...)
+	}
+	return box
+}
+
+func encodedEsdsBytes(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := mp4.CreateEsdsBox([]byte{0x11, 0x90}).Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestWaveBox(t *testing.T) {
+	esds := encodedEsdsBytes(t)
+	frma := waveChildBytes("frma", []byte("mp4a"))
+	mp4aStub := waveChildBytes("mp4a", make([]byte, 4)) // 12-byte QuickTime stub
+	terminator := waveChildBytes(string([]byte{0, 0, 0, 0}), nil)
+
+	data := waveBytes(frma, mp4aStub, esds, terminator)
+	cmpAfterDecodeEncodeBox(t, data)
+
+	box, err := mp4.DecodeBox(0, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wave := box.(*mp4.WaveBox)
+	if wave.Frma == nil || wave.Frma.DataFormat != "mp4a" {
+		t.Errorf("frma not decoded: %+v", wave.Frma)
+	}
+	if wave.Esds == nil || wave.Esds.DecConfigDescriptor == nil {
+		t.Error("esds not decoded inside wave")
+	}
+	if len(wave.Children) != 4 {
+		t.Errorf("got %d children, wanted 4", len(wave.Children))
+	}
+}
+
+func TestWaveBoxMalformedEsds(t *testing.T) {
+	badEsds := waveChildBytes("esds", []byte{0, 0}) // truncated esds body
+	data := waveBytes(badEsds)
+	cmpAfterDecodeEncodeBox(t, data)
+
+	box, err := mp4.DecodeBox(0, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wave := box.(*mp4.WaveBox)
+	if wave.Esds != nil {
+		t.Error("malformed esds must not become a typed reference")
+	}
+	if len(wave.Children) != 1 {
+		t.Errorf("got %d children, wanted 1 preserved unknown child", len(wave.Children))
+	}
+}
+
+func TestWaveBoxMalformedTail(t *testing.T) {
+	esds := encodedEsdsBytes(t)
+	sizeZeroTerminator := make([]byte, 8) // size 0, type 0: not a well-formed box
+
+	data := waveBytes(esds, sizeZeroTerminator)
+	cmpAfterDecodeEncodeBox(t, data)
+
+	box, err := mp4.DecodeBox(0, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wave := box.(*mp4.WaveBox)
+	if wave.Esds == nil {
+		t.Error("esds not decoded before the malformed tail")
+	}
+	if len(wave.RawTail) != 8 {
+		t.Errorf("got %d raw tail bytes, wanted 8", len(wave.RawTail))
+	}
+}
+
+func TestWaveBoxRoundTrip(t *testing.T) {
+	wave := &mp4.WaveBox{}
+	wave.AddChild(&mp4.FrmaBox{DataFormat: "mp4a"})
+	wave.AddChild(mp4.CreateEsdsBox([]byte{0x11, 0x90}))
+	wave.AddChild(mp4.CreateUnknownBox(string([]byte{0, 0, 0, 0}), 8, nil))
+	boxDiffAfterEncodeAndDecode(t, wave)
+}
+
+func TestWaveWrappedEsdsInAudioSampleEntry(t *testing.T) {
+	esds := encodedEsdsBytes(t)
+	frma := waveChildBytes("frma", []byte("mp4a"))
+	terminator := waveChildBytes(string([]byte{0, 0, 0, 0}), nil)
+	v1Extension := make([]byte, 16)
+	binary.BigEndian.PutUint32(v1Extension, 1024) // samples per packet
+
+	data := quickTimeSoundDescriptionBytes("mp4a", 1, v1Extension, waveBytes(frma, esds, terminator))
+	cmpAfterDecodeEncodeBox(t, data)
+
+	box, err := mp4.DecodeBox(0, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := box.(*mp4.AudioSampleEntryBox)
+	if entry.Wave == nil || entry.Wave.Esds == nil {
+		t.Fatal("wave-wrapped esds not reachable from the audio sample entry")
+	}
+	if entry.Esds != nil {
+		t.Error("wave-wrapped esds should not be a direct esds reference")
+	}
+}


### PR DESCRIPTION
## Problem

The QuickTime siDecompressionParam atom (`wave`) wraps the decoder
configuration of QuickTime audio sample entries, so the esds of such an entry
is unreachable as an opaque `UnknownBox` payload.

## Fix

A `WaveBox` container decodes `frma` and `esds` children (reachable as
`AudioSampleEntryBox.Wave.Esds`), and stays byte-exact for the irregular
content wave atoms carry in the wild:

- a child that does not decode cleanly — e.g. the 12-byte `mp4a` stub, or an
  esds whose decode consumes fewer bytes than its declared size — is kept as
  an `UnknownBox` with its bytes verbatim;
- a tail that is not a well-formed box — e.g. the terminator atom when
  written with size zero — is preserved verbatim in `RawTail`.

Decoding a wave body never fails, so garbage inside a wave cannot make a
sample entry undecodable (and cannot trip the ISO-layout fallback of #544).

## Tests

Typed frma/esds decode, stub and malformed-esds fallback to `UnknownBox`,
size-zero terminator tail, programmatic construction, and a wave-wrapped esds
inside a version 1 sound sample entry — all byte-exact through both decode
paths. `go test ./...`, `go vet`, `gofmt`, `golangci-lint` pass.
