### PR TITLE
feat(mp4): add labl box for track labels in DASH-IF Ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `LablBox` for the Label box `labl` (ISO/IEC 14496-12:2026 Section 8.10.5) with
+  the `LablIsGroupLabelFlag` flag mask and an `IsGroupLabel()` accessor, as used
+  for track labels in DASH-IF Ingest
+- `UdtaBox.Labls` with the `labl` children of a user data box, and
+  `UdtaBox.GroupLabl()` to find the group label of a label group
+- `TrakBox.Udta` reference to the user data box of a track
 - QuickTime sound sample description versions 1 and 2 are parsed into
   `AudioSampleEntryBox.QuickTimeVersion`, `QuickTimeV1`, and `QuickTimeV2`,
   preserved on encode (along with the QuickTime revision level, vendor, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,39 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## Committing
 
-## What is mp4ff?
-
-Go library and tools for parsing, writing, and manipulating MP4/ISOBMFF (ISO Base Media File Format) files. Specialized for fragmented MP4 (MPEG-DASH, MSS, HLS fMP4), with support for many video codecs (AVC, HEVC, AV1, VVC, AVS3), audio codecs (AAC, AC-3, Opus, FLAC), subtitle formats (WebVTT, TTML), and CENC/CBCS encryption.
-
-## Commands
-
-```bash
-make build          # Build all CLI tools and examples
-make test           # go test ./...
-make check          # Full quality check (prepare + pre-commit + codespell)
-make coverage       # Generate coverage reports (HTML + text)
-go test ./mp4/      # Test a single package
-go test ./mp4/ -run TestName  # Run a single test
-```
-
-Pre-commit hooks (trailing-whitespace, go-fmt, golangci-lint, go-unit-tests, commitlint) are enforced. Activate the venv before committing: `source venv/bin/activate`.
-
-## Commit Convention
+Pre-commit hooks are enforced. Activate the venv first: `source venv/bin/activate`.
 
 Conventional Commits enforced via commitlint: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`.
 
 ## Architecture
-
-### Package structure
-
-- **mp4** — Core package. Box encoding/decoding, file/fragment/segment structures, crypto, streaming.
-- **bits** — Bit-level I/O primitives (SliceReader/SliceWriter, FixedSliceReader/FixedSliceWriter).
-- **avc**, **hevc**, **vvc**, **av1** — Video codec handling (NALU parsing, parameter set extraction).
-- **sei** — Supplementary Enhancement Information messages for AVC/HEVC.
-- **aac** — AAC audio (ADTS headers, codec descriptions).
-- **cmd/** — CLI tools (mp4ff-info, mp4ff-crop, mp4ff-encrypt, mp4ff-decrypt, etc.).
-- **examples/** — Usage demonstrations.
 
 ### File model
 
@@ -71,8 +44,6 @@ External APIs use **1-based** sample numbers (sample 1 = first sample). Internal
 
 ## Key conventions
 
-- golangci-lint with max line length 140 (`lll` linter)
-- Only external dependency: `github.com/go-test/deep`
 - Test roundtrips with `boxDiffAfterEncodeAndDecode(t, box)` helper
 - Test both io.Reader and SliceReader decode paths where possible
-- Primary spec: ISO/IEC 14496-12:2021 (7th edition)
+- Primary spec: ISO/IEC 14496-12:2026 (8th edition)

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -101,6 +101,7 @@ func init() {
 		"jpeg":    DecodeVisualSampleEntry,
 		"jpgC":    DecodeJpgC,
 		"kind":    DecodeKind,
+		"labl":    DecodeLabl,
 		"leva":    DecodeLeva,
 		"lpcm":    DecodeQuickTimeAudioSampleEntry,
 		"ludt":    DecodeLudt,

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -92,6 +92,7 @@ func init() {
 		"jpeg":    DecodeVisualSampleEntrySR,
 		"jpgC":    DecodeJpgCSR,
 		"kind":    DecodeKindSR,
+		"labl":    DecodeLablSR,
 		"leva":    DecodeLevaSR,
 		"lpcm":    DecodeQuickTimeAudioSampleEntrySR,
 		"ludt":    DecodeLudtSR,

--- a/mp4/labl.go
+++ b/mp4/labl.go
@@ -1,0 +1,111 @@
+package mp4
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// LablIsGroupLabelFlag - flag mask telling that the label is a summary label for a group of labels.
+const LablIsGroupLabelFlag uint32 = 0x000001
+
+// LablBox - Label Box (labl)
+// Defined in ISO/IEC 14496-12:2026 Section 8.10.5.
+// Contained in UserDataBox of a TrackBox, AudioElementBox,
+// AudioElementSelectionBox, or PreselectionGroupBox.
+//
+// DASH-IF Ingest signals track labels with labl boxes in the udta box of a track,
+// using one group label as the name to present and one label per language.
+type LablBox struct {
+	Version byte
+	Flags   uint32
+	// LabelID identifies the label group the label belongs to. Zero means no group.
+	LabelID uint16
+	// Language is an IETF BCP 47 compliant language tag such as "en-US".
+	Language string
+	// Label is the textual description.
+	Label string
+}
+
+// IsGroupLabel - true if the label is a summary label for the group given by LabelID.
+func (b *LablBox) IsGroupLabel() bool {
+	return b.Flags&LablIsGroupLabelFlag != 0
+}
+
+// DecodeLabl - box-specific decode
+func DecodeLabl(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	data, err := readBoxBody(r, hdr)
+	if err != nil {
+		return nil, err
+	}
+	sr := bits.NewFixedSliceReader(data)
+	return DecodeLablSR(hdr, startPos, sr)
+}
+
+// DecodeLablSR - box-specific decode
+func DecodeLablSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	payloadLen := hdr.payloadLen()
+	if payloadLen < 8 { // version + flags + label_id + two zero-terminated strings
+		return nil, fmt.Errorf("decode labl: payload too short: %d", payloadLen)
+	}
+	versionAndFlags := sr.ReadUint32()
+	b := LablBox{
+		Version: byte(versionAndFlags >> 24),
+		Flags:   versionAndFlags & flagsMask,
+		LabelID: sr.ReadUint16(),
+	}
+	maxLen := payloadLen - 6 - 1
+	b.Language = sr.ReadZeroTerminatedString(maxLen)
+	maxLen = payloadLen - 6 - len(b.Language) - 1
+	b.Label = sr.ReadZeroTerminatedString(maxLen)
+	if err := sr.AccError(); err != nil {
+		return nil, fmt.Errorf("decode labl: %w", err)
+	}
+	return &b, nil
+}
+
+// Type - box type
+func (b *LablBox) Type() string {
+	return "labl"
+}
+
+// Size - calculated size of box
+func (b *LablBox) Size() uint64 {
+	return uint64(boxHeaderSize + 4 + 2 + len(b.Language) + 1 + len(b.Label) + 1)
+}
+
+// Encode - write box to w
+func (b *LablBox) Encode(w io.Writer) error {
+	sw := bits.NewFixedSliceWriter(int(b.Size()))
+	err := b.EncodeSW(sw)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(sw.Bytes())
+	return err
+}
+
+// EncodeSW - box-specific encode to slicewriter
+func (b *LablBox) EncodeSW(sw bits.SliceWriter) error {
+	err := EncodeHeaderSW(b, sw)
+	if err != nil {
+		return err
+	}
+	versionAndFlags := (uint32(b.Version) << 24) + b.Flags
+	sw.WriteUint32(versionAndFlags)
+	sw.WriteUint16(b.LabelID)
+	sw.WriteString(b.Language, true)
+	sw.WriteString(b.Label, true)
+	return sw.AccError()
+}
+
+// Info - write box-specific information
+func (b *LablBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
+	bd := newInfoDumper(w, indent, b, int(b.Version), b.Flags)
+	bd.write(" - labelID: %d", b.LabelID)
+	bd.write(" - isGroupLabel: %t", b.IsGroupLabel())
+	bd.write(" - language: %s", b.Language)
+	bd.write(" - label: %s", b.Label)
+	return bd.err
+}

--- a/mp4/labl_ingest_test.go
+++ b/mp4/labl_ingest_test.go
@@ -1,0 +1,82 @@
+package mp4_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+// TestLablInTrackUdta checks the shape DASH-IF Ingest asks for: labl boxes in the
+// UserDataBox of a track of a CMAF init segment, with one group label carrying the
+// name to present and one label per language (Dash-Industry-Forum/Ingest PR 167).
+func TestLablInTrackUdta(t *testing.T) {
+	const labelID = 3
+	raw, err := os.ReadFile("testdata/init.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	initSeg, err := mp4.DecodeFile(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	trak := initSeg.Init.Moov.Trak
+	if trak.Udta != nil {
+		t.Fatal("did not expect a udta box in testdata/init.mp4")
+	}
+	udta := &mp4.UdtaBox{}
+	udta.AddChild(&mp4.LablBox{
+		Flags:    mp4.LablIsGroupLabelFlag,
+		LabelID:  labelID,
+		Language: "en",
+		Label:    "Main video",
+	})
+	udta.AddChild(&mp4.LablBox{LabelID: labelID, Language: "sv-SE", Label: "Huvudvideo"})
+	trak.AddChild(udta)
+	if trak.Udta != udta {
+		t.Fatal("trak.Udta was not set by AddChild")
+	}
+
+	out := bytes.Buffer{}
+	if err := initSeg.Encode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	decoded, err := mp4.DecodeFile(bytes.NewReader(out.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decUdta := decoded.Init.Moov.Trak.Udta
+	if decUdta == nil {
+		t.Fatal("no udta box in decoded track")
+	}
+	if len(decUdta.Labls) != 2 {
+		t.Fatalf("expected 2 labl boxes, got %d", len(decUdta.Labls))
+	}
+	group := decUdta.GroupLabl(labelID)
+	if group == nil {
+		t.Fatalf("no group label for labelID %d", labelID)
+	}
+	if group.Label != "Main video" || group.Language != "en" {
+		t.Errorf("unexpected group label %q/%q", group.Language, group.Label)
+	}
+	other := decUdta.Labls[1]
+	if other.IsGroupLabel() {
+		t.Error("second label should not be a group label")
+	}
+	if other.Label != "Huvudvideo" || other.Language != "sv-SE" {
+		t.Errorf("unexpected label %q/%q", other.Language, other.Label)
+	}
+
+	// The same init segment must decode identically via the SliceReader path.
+	sr, err := mp4.DecodeFileSR(bits.NewFixedSliceReader(out.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sr.Init.Moov.Trak.Udta.Labls) != 2 {
+		t.Errorf("expected 2 labl boxes via SliceReader path, got %d",
+			len(sr.Init.Moov.Trak.Udta.Labls))
+	}
+}

--- a/mp4/labl_test.go
+++ b/mp4/labl_test.go
@@ -1,0 +1,89 @@
+package mp4_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+func TestLabl(t *testing.T) {
+	t.Run("encode and decode", func(t *testing.T) {
+		labl := &mp4.LablBox{LabelID: 42, Language: "en-US", Label: "Director's commentary"}
+		boxDiffAfterEncodeAndDecode(t, labl)
+	})
+	t.Run("encode and decode group label", func(t *testing.T) {
+		labl := &mp4.LablBox{
+			Flags:    mp4.LablIsGroupLabelFlag,
+			LabelID:  1,
+			Language: "zh-CN",
+			Label:    "音轨",
+		}
+		boxDiffAfterEncodeAndDecode(t, labl)
+		if !labl.IsGroupLabel() {
+			t.Error("expected group label")
+		}
+	})
+	t.Run("empty strings", func(t *testing.T) {
+		labl := &mp4.LablBox{}
+		if labl.IsGroupLabel() {
+			t.Error("did not expect group label")
+		}
+		boxDiffAfterEncodeAndDecode(t, labl)
+	})
+	t.Run("decode raw bytes", func(t *testing.T) {
+		rawHex := "000000196c61626c00000001" + "0002" + "656e2d555300" + "4d61696e00"
+		rawBytes, err := hex.DecodeString(rawHex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		box, err := mp4.DecodeBox(0, bytes.NewReader(rawBytes))
+		if err != nil {
+			t.Fatalf("error decoding labl box: %v", err)
+		}
+		labl, ok := box.(*mp4.LablBox)
+		if !ok {
+			t.Fatalf("expected *mp4.LablBox, got %T", box)
+		}
+		if labl.Size() != uint64(len(rawBytes)) {
+			t.Errorf("expected size %d, got %d", len(rawBytes), labl.Size())
+		}
+		if !labl.IsGroupLabel() {
+			t.Error("expected is_group_label to be set")
+		}
+		if labl.LabelID != 2 {
+			t.Errorf("expected labelID 2, got %d", labl.LabelID)
+		}
+		if labl.Language != "en-US" {
+			t.Errorf("expected language en-US, got %s", labl.Language)
+		}
+		if labl.Label != "Main" {
+			t.Errorf("expected label Main, got %s", labl.Label)
+		}
+	})
+	t.Run("bad data", func(t *testing.T) {
+		cases := []struct {
+			desc   string
+			rawHex string
+		}{
+			{"too short payload", "0000000f6c61626c" + "00000000" + "0002" + "00"},
+			{"unterminated language", "000000106c61626c" + "00000000" + "0002" + "6565"},
+			{"unterminated label", "000000136c61626c" + "00000000" + "0002" + "656e00" + "4d61"},
+		}
+		for _, c := range cases {
+			rawBytes, err := hex.DecodeString(c.rawHex)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := mp4.DecodeBox(0, bytes.NewReader(rawBytes)); err == nil {
+				t.Errorf("%s: expected error from DecodeBox", c.desc)
+			}
+			sr := bits.NewFixedSliceReader(rawBytes)
+			if _, err := mp4.DecodeBoxSR(0, sr); err == nil {
+				t.Errorf("%s: expected error from DecodeBoxSR", c.desc)
+			}
+		}
+	})
+}

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -20,6 +20,7 @@ type TrakBox struct {
 	Edts     *EdtsBox
 	Mdia     *MdiaBox
 	Trgr     *TrgrBox
+	Udta     *UdtaBox
 	Children []Box
 }
 
@@ -39,6 +40,8 @@ func (t *TrakBox) AddChild(child Box) {
 		t.Edts = box
 	case *TrgrBox:
 		t.Trgr = box
+	case *UdtaBox:
+		t.Udta = box
 	}
 	t.Children = append(t.Children, child)
 }

--- a/mp4/udta.go
+++ b/mp4/udta.go
@@ -10,12 +10,29 @@ import (
 //
 // Contained in : moov, trak, moof, or traf
 type UdtaBox struct {
+	// Labls are the labl children in order. There may be multiple ones, e.g. one per language.
+	Labls    []*LablBox
 	Children []Box
 }
 
 // AddChild - Add a child box
 func (b *UdtaBox) AddChild(box Box) {
+	if labl, ok := box.(*LablBox); ok {
+		b.Labls = append(b.Labls, labl)
+	}
 	b.Children = append(b.Children, box)
+}
+
+// GroupLabl returns the group label of the labl group labelID, or nil if there is none.
+// A group label carries the summary or title of all labels sharing its labelID,
+// e.g. the name to present in a selection menu.
+func (b *UdtaBox) GroupLabl(labelID uint16) *LablBox {
+	for _, labl := range b.Labls {
+		if labl.LabelID == labelID && labl.IsGroupLabel() {
+			return labl
+		}
+	}
+	return nil
 }
 
 // DecodeUdta - box-specific decode

--- a/mp4/udta_test.go
+++ b/mp4/udta_test.go
@@ -12,3 +12,34 @@ func TestUdta(t *testing.T) {
 	udta.AddChild(unknown) // Any arbitrary box
 	boxDiffAfterEncodeAndDecode(t, udta)
 }
+
+func TestUdtaLabls(t *testing.T) {
+	udta := &mp4.UdtaBox{}
+	udta.AddChild(&mp4.KindBox{SchemeURI: "urn:mpeg:dash:role:2011", Value: "main"})
+	udta.AddChild(&mp4.LablBox{Flags: mp4.LablIsGroupLabelFlag, LabelID: 7, Language: "en", Label: "Commentary"})
+	udta.AddChild(&mp4.LablBox{LabelID: 7, Language: "en-US", Label: "Commentary"})
+	udta.AddChild(&mp4.LablBox{LabelID: 7, Language: "sv-SE", Label: "Kommentar"})
+	boxDiffAfterEncodeAndDecode(t, udta)
+
+	if len(udta.Labls) != 3 {
+		t.Fatalf("expected 3 labl children, got %d", len(udta.Labls))
+	}
+	group := udta.GroupLabl(7)
+	if group == nil {
+		t.Fatal("expected a group label for labelID 7")
+	}
+	if group.Label != "Commentary" {
+		t.Errorf("expected group label %q, got %q", "Commentary", group.Label)
+	}
+	if udta.GroupLabl(8) != nil {
+		t.Error("did not expect a group label for labelID 8")
+	}
+
+	t.Run("no group label", func(t *testing.T) {
+		udta := &mp4.UdtaBox{}
+		udta.AddChild(&mp4.LablBox{LabelID: 7, Language: "en", Label: "Commentary"})
+		if udta.GroupLabl(7) != nil {
+			t.Error("did not expect a group label")
+		}
+	})
+}


### PR DESCRIPTION
Implements the Label box (`labl`) from ISO/IEC 14496-12:2026 Section 8.10.5, registered in both the `io.Reader` and `SliceReader` decoder tables.

The driving use case is [Dash-Industry-Forum/Ingest#167](https://github.com/Dash-Industry-Forum/Ingest/pull/167), which adds track labels to CMAF ingest (interface 1). It signals them with `labl` boxes in the `udta` box of a track: one group label carrying the name to present (the HLS `EXT-X-MEDIA` `NAME` attribute), plus one label per language for the localization dictionary.

## Changes

- `LablBox` with `Version`, `Flags`, `LabelID`, `Language`, and `Label`, the `LablIsGroupLabelFlag` mask for the one defined flag, and an `IsGroupLabel()` accessor.
- The two `utf8string` fields are read as zero-terminated strings bounded by the remaining payload, following the sibling `kind` box (Section 8.10.4). Decode rejects payloads below the 8-byte minimum and wraps reader errors, so an unterminated string is an error rather than a silent truncation.
- `UdtaBox.Labls` holds the `labl` children (the existing pattern for repeated children, cf. `MoovBox.Psshs`), and `UdtaBox.GroupLabl(labelID)` returns the group label of a label group.
- `TrakBox.Udta` reference, so track labels are reachable without walking `Children`. This was simply missing from the container box pattern.

## Testing

- Roundtrips via `boxDiffAfterEncodeAndDecode` (plain label, group label with non-ASCII text, empty strings), a fixed raw-hex decode asserting each field, and three malformed inputs checked against both decode paths.
- `TestLablInTrackUdta` exercises the full ingest shape end to end: decode `testdata/init.mp4`, attach a `udta` with a group label plus a per-language label to the track, re-encode, and re-decode through both the `io.Reader` and `SliceReader` paths.

`mp4ff-info` output on such an init segment, next to the `kind` box carrying the DASH role that the same ingest section already required:

```
    [udta] size=108
      [kind] size=41 version=0 flags=000000
       - schemeURI: urn:mpeg:dash:role:2011
       - value: main
      [labl] size=28 version=0 flags=000001
       - labelID: 3
       - isGroupLabel: true
       - language: en
       - label: Main video
      [labl] size=31 version=0 flags=000000
       - labelID: 3
       - isGroupLabel: false
       - language: sv-SE
       - label: Huvudvideo
```

## Note

Section 8.10.5 says `label_id` values "shall be unique among all labels contained in the file", while a group label and its members share an id — so uniqueness has to mean per label group. Nothing here enforces it either way; a file-wide validation helper could be a follow-up.

The containers other than a track `udta` that Section 8.10.5 lists (`AudioElementBox`, `AudioElementSelectionBox`, `PreselectionGroupBox`) are not implemented in this repo yet, so a `labl` inside one of them lands under an `UnknownBox` parent. That is out of scope here.