### PR TITLE
fix: bound num_ref_frames_in_pic_order_cnt_cycle in AVC SPS parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `avc.ParseSPSNALUnit` rejects an out-of-range
+  `num_ref_frames_in_pic_order_cnt_cycle` (valid range 0-255) instead of
+  allocating a slice sized from the raw field, which let a tiny malformed SPS
+  NAL unit trigger a multi-gigabyte allocation (found by fuzzing)
 - `MdatBox.HeaderSize` accounts for large lazy payloads, so trun data
   offsets are no longer 8 bytes short for fragments above 4 GiB
 

--- a/avc/sps.go
+++ b/avc/sps.go
@@ -181,6 +181,13 @@ func ParseSPSNALUnit(data []byte, parseVUIBeyondAspectRatio bool) (*SPS, error) 
 		sps.OffsetForNonRefPic = reader.ReadExpGolomb()
 		sps.OffsetForTopToBottomField = reader.ReadExpGolomb()
 		numRefFramesInPicOrderCntCycle := reader.ReadExpGolomb()
+		// num_ref_frames_in_pic_order_cnt_cycle shall be in the range of 0 to 255
+		// (ISO/IEC 14496-10 Section 7.4.2.1.1). Guard against a bogus value before
+		// allocating, to avoid gigabytes being reserved from a tiny malformed NAL unit.
+		if numRefFramesInPicOrderCntCycle > 255 {
+			reader.SetError(fmt.Errorf("num_ref_frames_in_pic_order_cnt_cycle %d out of range [0, 255]", numRefFramesInPicOrderCntCycle))
+			return nil, reader.AccError()
+		}
 		sps.RefFramesInPicOrderCntCycle = make([]uint, numRefFramesInPicOrderCntCycle)
 		for i := 0; i < int(numRefFramesInPicOrderCntCycle); i++ {
 			sps.RefFramesInPicOrderCntCycle[i] = reader.ReadExpGolomb()

--- a/avc/sps_test.go
+++ b/avc/sps_test.go
@@ -325,3 +325,20 @@ func TestCodecString(t *testing.T) {
 		t.Errorf("expected codec: %q, got %q", expected, codec)
 	}
 }
+
+// TestSPSParserNumRefFramesInPicOrderCntCycle verifies that an out-of-range
+// num_ref_frames_in_pic_order_cnt_cycle is rejected instead of triggering a
+// multi-gigabyte allocation. The NAL unit below sets pic_order_cnt_type = 1 and
+// encodes a ~1 billion value for num_ref_frames_in_pic_order_cnt_cycle; before
+// the bound check this caused ParseSPSNALUnit to allocate gigabytes from 22
+// bytes of input. Found by fuzzing.
+func TestSPSParserNumRefFramesInPicOrderCntCycle(t *testing.T) {
+	byteData, _ := hex.DecodeString("27303030032527000000024242311f30313030303030")
+	sps, err := avc.ParseSPSNALUnit(byteData, true)
+	if err == nil {
+		t.Error("expected an error for out-of-range num_ref_frames_in_pic_order_cnt_cycle")
+	}
+	if sps != nil {
+		t.Errorf("expected nil SPS on error, got %+v", sps)
+	}
+}


### PR DESCRIPTION
While fuzzing the un-fuzzed codec bitstream parsers, I found that `avc.ParseSPSNALUnit` uses `num_ref_frames_in_pic_order_cnt_cycle` straight from the bitstream to size a slice, so a tiny malformed SPS NAL unit can force a multi-gigabyte allocation.

**Failure mode:** when `pic_order_cnt_type == 1`, the parser reads `num_ref_frames_in_pic_order_cnt_cycle` as an Exp-Golomb value and immediately does `make([]uint, numRefFramesInPicOrderCntCycle)`. The field is unbounded, so a 22-byte input encoding a ~1e9 value makes ParseSPSNALUnit allocate ~9 GB (measured) before the read loop hits EOF — an out-of-memory / denial-of-service on attacker-controlled input.

**Fix:** the spec (ISO/IEC 14496-10 Section 7.4.2.1.1) constrains `num_ref_frames_in_pic_order_cnt_cycle` to the range 0-255. Reject values above that via `reader.SetError` and return before allocating, matching the existing bound-check style used in `hevc/sps.go`. Valid streams decode byte-identically.

**Test:** added `TestSPSParserNumRefFramesInPicOrderCntCycle`, which feeds the fuzzer-found NAL unit and asserts an error is returned. Before the fix the test hangs the process in a multi-GB allocation (20s timeout); after the fix it returns an error in microseconds. Existing tests still pass.