### PR TITLE
feat(mp4): add WaveBox.GetChildren and escape control chars in box types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in a wave child of an audio sample entry becomes reachable as `Wave.Esds`.
   Children that are not well-formed boxes (such as the spec-mandated
   terminator atom when written with size zero) are preserved verbatim
+- `WaveBox.GetChildren`, so a wave box satisfies the `ContainerBox` interface
 - `DecoderConfigDescriptor.StreamTypeValue` and `UpStream` decompose the
   packed streamType byte, and named constants cover the common stream types
   (ISO/IEC 14496-1 Table 6) and object type indications (mp4ra.org), so
@@ -30,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Info()` escapes control characters in box types as `\xNN`, so a type such
+  as the four zero bytes of the QuickTime wave terminator atom stays visible
 - audio sample entries whose reserved bytes claim a QuickTime version whose
   layout does not parse fall back to the plain ISO interpretation, so
   previously decodable files keep decoding; the overlaid QuickTime bytes

--- a/mp4/infodumper.go
+++ b/mp4/infodumper.go
@@ -32,10 +32,41 @@ func fixStartingCopyrightChar(boxType string) string {
 	// © is 0xa9 in latin1 (and in Apple boxes/atoms)
 	// In UTF-8 it is two bytes: 0xc2 0xa9
 	bType := []byte(boxType)
-	if bType[0] == 0xa9 {
+	if len(bType) > 0 && bType[0] == 0xa9 {
 		bType = append([]byte{0xc2}, bType...)
 	}
 	return string(bType)
+}
+
+// displayBoxType - make a box type safe to print. Control characters are
+// escaped as \xNN, so that a type such as the four zero bytes of the
+// QuickTime wave terminator atom stays visible in the output.
+func displayBoxType(boxType string) string {
+	boxType = fixStartingCopyrightChar(boxType)
+	nrControlChars := 0
+	for i := 0; i < len(boxType); i++ {
+		if isControlChar(boxType[i]) {
+			nrControlChars++
+		}
+	}
+	if nrControlChars == 0 {
+		return boxType
+	}
+	var sb strings.Builder
+	sb.Grow(len(boxType) + 3*nrControlChars)
+	for i := 0; i < len(boxType); i++ {
+		if c := boxType[i]; isControlChar(c) {
+			fmt.Fprintf(&sb, "\\x%02x", c)
+		} else {
+			sb.WriteByte(c)
+		}
+	}
+	return sb.String()
+}
+
+// isControlChar - C0 control character or DEL
+func isControlChar(c byte) bool {
+	return c < 0x20 || c == 0x7f
 }
 
 // newInfoDumper - make an infoDumper with indent
@@ -45,7 +76,7 @@ func fixStartingCopyrightChar(boxType string) string {
 // set Version to -3 for descriptors
 func newInfoDumper(w io.Writer, indent string, b boxLike, version int, flags uint32) *infoDumper {
 	bd := infoDumper{w, indent, b, nil}
-	utf8BoxType := fixStartingCopyrightChar(b.Type())
+	utf8BoxType := displayBoxType(b.Type())
 	switch {
 	case version >= 0:
 		bd.write("[%s] size=%d version=%d flags=%06x", utf8BoxType, b.Size(), version, flags)

--- a/mp4/wave.go
+++ b/mp4/wave.go
@@ -17,7 +17,19 @@ type WaveBox struct {
 	Frma     *FrmaBox
 	Esds     *EsdsBox
 	Children []Box
-	RawTail  []byte
+	// RawTail holds the bytes from the first position where a well-formed box
+	// header could not be read to the end of the wave payload. Since the
+	// terminator atom comes last, this is normally either empty or just that
+	// atom, but a malformed atom anywhere in the payload puts everything from
+	// it onwards here, so any boxes after it are not decoded into Children.
+	// Encode writes RawTail verbatim after the children.
+	RawTail []byte
+}
+
+// GetChildren - list of child boxes. Note that the bytes in RawTail are not
+// part of the children, so a generic container encode would drop them.
+func (b *WaveBox) GetChildren() []Box {
+	return b.Children
 }
 
 // AddChild - add a child box

--- a/mp4/wave_test.go
+++ b/mp4/wave_test.go
@@ -3,6 +3,7 @@ package mp4_test
 import (
 	"bytes"
 	"encoding/binary"
+	"strings"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/mp4"
@@ -60,6 +61,36 @@ func TestWaveBox(t *testing.T) {
 	}
 	if len(wave.Children) != 4 {
 		t.Errorf("got %d children, wanted 4", len(wave.Children))
+	}
+}
+
+func TestWaveBoxIsContainer(t *testing.T) {
+	wave := &mp4.WaveBox{}
+	var container mp4.ContainerBox = wave // wave must satisfy the container interface
+	frma := &mp4.FrmaBox{DataFormat: "mp4a"}
+	wave.AddChild(frma)
+	children := container.GetChildren()
+	if len(children) != 1 || children[0] != frma {
+		t.Errorf("GetChildren gave %v, wanted the single added frma", children)
+	}
+}
+
+func TestWaveBoxTerminatorInInfo(t *testing.T) {
+	terminator := waveChildBytes(string([]byte{0, 0, 0, 0}), nil)
+	box, err := mp4.DecodeBox(0, bytes.NewReader(waveBytes(terminator)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := box.Info(&buf, "all:1", "", "  "); err != nil {
+		t.Fatal(err)
+	}
+	info := buf.String()
+	if strings.ContainsRune(info, 0) {
+		t.Errorf("info output has a raw NUL byte in a box type: %q", info)
+	}
+	if !strings.Contains(info, `[\x00\x00\x00\x00]`) {
+		t.Errorf("terminator box type not escaped in info output: %q", info)
 	}
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #547, which added the `wave` box. Three small gaps were left:

- `WaveBox` holds `Children` but has no `GetChildren`, so unlike the other
  container boxes it does not satisfy the `ContainerBox` interface.
- The QuickTime terminator atom inside a wave has the four-byte type
  `0x00000000`, which `Info()` wrote out raw. Every `mp4ff-info` dump of a
  QuickTime audio file therefore contained NUL bytes and rendered the atom as
  `[    ]`.
- The `RawTail` semantics were undocumented: a malformed atom anywhere in the
  payload puts everything from it onwards in the tail, so boxes after it are
  not decoded into `Children`.

## Fix

- `WaveBox.GetChildren`, so a wave box is a `ContainerBox`. Its doc comment
  notes that `RawTail` is not part of the children, so a generic container
  encode would drop those bytes.
- `displayBoxType` in the info dumper escapes C0 control characters and DEL as
  `\xNN`. It deliberately leaves `0xa9` alone, so the `©nam`-style Apple atoms
  keep rendering as before and no golden dump changes. While there,
  `fixStartingCopyrightChar` is guarded against an empty box type, which would
  panic on the index of byte 0.
- `RawTail` is documented, including that `Encode` writes it verbatim after
  the children.

`mp4ff-info` on an ffmpeg-written `.mov`, before and after:

```
-                [    ] size=8
+                [\x00\x00\x00\x00] size=8
                  - not implemented or unknown box
```

## Tests

`TestWaveBoxIsContainer` asserts the `ContainerBox` interface and the
`GetChildren` contents; `TestWaveBoxTerminatorInInfo` asserts that no raw NUL
reaches the output and that the escaped form appears. `go test ./...`,
`go vet`, `gofmt`, and `golangci-lint` pass.

Also checked outside the test suite: an ffmpeg-generated AAC-in-`.mov` file
(which carries a real `wave` atom with `frma`, a 12-byte `mp4a` stub, `esds`,
and the terminator) still round trips byte-exact through both the
`io.Reader`/`io.Writer` and the `SliceReader`/`SliceWriter` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
