### PR TITLE
feat(mp4): name the QuickTime lpcm format flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ElstEntry.MediaRateFixed32` and `SetMediaRateFixed32` combine and split
   the media rate halves as one signed 16.16 fixed-point number, so callers
   no longer need to know the bit layout
+- `QuickTimeFormatFlagIsFloat` and the other CoreAudio/QTFF linear-PCM
+  format flags name the bits of
+  `QuickTimeV2SoundDescription.FormatSpecificFlags`, and the `IsFloat`,
+  `IsBigEndian`, and `IsSignedInteger` accessors read the common ones, so
+  lpcm entries can be interpreted without magic numbers
 
 ### Changed
 

--- a/mp4/audiosampleentry_test.go
+++ b/mp4/audiosampleentry_test.go
@@ -257,3 +257,53 @@ func TestDirtyReservedBytesKeepDecoding(t *testing.T) {
 		})
 	}
 }
+
+// TestQuickTimeLpcmFormatFlags pins the defined CoreAudio/QTFF linear-PCM
+// format flag values and the accessors on QuickTimeV2SoundDescription.
+func TestQuickTimeLpcmFormatFlags(t *testing.T) {
+	definedFlags := []struct {
+		name   string
+		flag   uint32
+		wanted uint32
+	}{
+		{"IsFloat", mp4.QuickTimeFormatFlagIsFloat, 0x1},
+		{"IsBigEndian", mp4.QuickTimeFormatFlagIsBigEndian, 0x2},
+		{"IsSignedInteger", mp4.QuickTimeFormatFlagIsSignedInteger, 0x4},
+		{"IsPacked", mp4.QuickTimeFormatFlagIsPacked, 0x8},
+		{"IsAlignedHigh", mp4.QuickTimeFormatFlagIsAlignedHigh, 0x10},
+		{"IsNonInterleaved", mp4.QuickTimeFormatFlagIsNonInterleaved, 0x20},
+		{"IsNonMixable", mp4.QuickTimeFormatFlagIsNonMixable, 0x40},
+	}
+	for _, d := range definedFlags {
+		if d.flag != d.wanted {
+			t.Errorf("QuickTimeFormatFlag%s is %#x, wanted %#x", d.name, d.flag, d.wanted)
+		}
+	}
+	cases := []struct {
+		desc            string
+		flags           uint32
+		isFloat         bool
+		isBigEndian     bool
+		isSignedInteger bool
+	}{
+		{"zero flags", 0, false, false, false},
+		{"packed float32", mp4.QuickTimeFormatFlagIsFloat | mp4.QuickTimeFormatFlagIsPacked,
+			true, false, false},
+		{"big-endian signed int16", mp4.QuickTimeFormatFlagIsBigEndian | mp4.QuickTimeFormatFlagIsSignedInteger,
+			false, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			q := mp4.QuickTimeV2SoundDescription{FormatSpecificFlags: c.flags}
+			if q.IsFloat() != c.isFloat {
+				t.Errorf("IsFloat() is %t, wanted %t", q.IsFloat(), c.isFloat)
+			}
+			if q.IsBigEndian() != c.isBigEndian {
+				t.Errorf("IsBigEndian() is %t, wanted %t", q.IsBigEndian(), c.isBigEndian)
+			}
+			if q.IsSignedInteger() != c.isSignedInteger {
+				t.Errorf("IsSignedInteger() is %t, wanted %t", q.IsSignedInteger(), c.isSignedInteger)
+			}
+		})
+	}
+}

--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -78,6 +78,34 @@ type QuickTimeV2SoundDescription struct {
 	ConstLPCMFramesPerAudioPacket uint32
 }
 
+// Linear-PCM format flags for QuickTimeV2SoundDescription.FormatSpecificFlags
+// according to the QTFF specification and CoreAudioTypes (kAudioFormatFlag*).
+const (
+	QuickTimeFormatFlagIsFloat          uint32 = 1 << 0 // floating-point, not integer, samples
+	QuickTimeFormatFlagIsBigEndian      uint32 = 1 << 1 // big-endian samples
+	QuickTimeFormatFlagIsSignedInteger  uint32 = 1 << 2 // signed integer samples
+	QuickTimeFormatFlagIsPacked         uint32 = 1 << 3 // sample bits fill their channel bytes
+	QuickTimeFormatFlagIsAlignedHigh    uint32 = 1 << 4 // unpacked sample bits are high-aligned
+	QuickTimeFormatFlagIsNonInterleaved uint32 = 1 << 5 // channels are in separate buffers
+	QuickTimeFormatFlagIsNonMixable     uint32 = 1 << 6 // stream must not be mixed
+)
+
+// IsFloat - whether FormatSpecificFlags marks the samples as floating point.
+// The flags are only meaningful for lpcm-family entries.
+func (q *QuickTimeV2SoundDescription) IsFloat() bool {
+	return q.FormatSpecificFlags&QuickTimeFormatFlagIsFloat != 0
+}
+
+// IsBigEndian - whether FormatSpecificFlags marks the samples as big-endian.
+func (q *QuickTimeV2SoundDescription) IsBigEndian() bool {
+	return q.FormatSpecificFlags&QuickTimeFormatFlagIsBigEndian != 0
+}
+
+// IsSignedInteger - whether FormatSpecificFlags marks the integer samples as signed.
+func (q *QuickTimeV2SoundDescription) IsSignedInteger() bool {
+	return q.FormatSpecificFlags&QuickTimeFormatFlagIsSignedInteger != 0
+}
+
 // NewAudioSampleEntryBox - Create new empty mp4a box
 func NewAudioSampleEntryBox(name string) *AudioSampleEntryBox {
 	return &AudioSampleEntryBox{name: name, DataReferenceIndex: 1}


### PR DESCRIPTION
## Problem

`QuickTimeV2SoundDescription.FormatSpecificFlags` carries the CoreAudio
linear-PCM format flags (float or integer samples, endianness, signedness,
packing), but the values only exist as magic numbers, so deriving a PCM sample
format from a version 2 lpcm entry requires CoreAudioTypes knowledge.

## Fix

Named `QuickTimeFormatFlag*` constants for the seven defined flags (QuickTime
File Format Sound Sample Description v2 / CoreAudioTypes `kAudioFormatFlag*`),
plus `IsFloat`, `IsBigEndian`, and `IsSignedInteger` accessors for the three
flags that drive sample-format decisions, meaningful for lpcm-family entries.
No decode or encode changes, so round-trips are untouched.

## Tests

The seven constant values are pinned against CoreAudio's definitions, and the
accessors are exercised on zero flags, packed float32, and big-endian signed
int16 combinations. `go test ./...`, `go vet`, `gofmt`, `golangci-lint` pass.