### PR TITLE
fix: bound more parameter counts read from bitstreams and boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `avc.ParsePPSNALUnit` rejects an out-of-range `num_slice_groups_minus1`
+  (max 7 for any profile) instead of appending one entry per signalled slice
+  group, which let a 7-byte malformed PPS NAL unit allocate over 10 GiB
+- `hevc.ParseVPSNALUnit` rejects an out-of-range `vps_num_hrd_parameters`
+  (max `vps_num_layer_sets_minus1 + 1`) and `vps_num_layer_sets_minus1`
+  (valid range 0-1023), which let a 33-byte malformed VPS NAL unit churn
+  30 GiB of HRD parameter allocations
+- the `alst` sample group entry no longer underflows its count of optional
+  entries when `roll_count` implies more bytes than the signalled
+  `description_length`, which let a 32-byte `sgpd` box allocate over 4 GiB
 - `avc.ParseSPSNALUnit` rejects an out-of-range
   `num_ref_frames_in_pic_order_cnt_cycle` (valid range 0-255) instead of
   allocating a slice sized from the raw field, which let a tiny malformed SPS

--- a/avc/pps.go
+++ b/avc/pps.go
@@ -45,6 +45,10 @@ var (
 	ErrNotPPS = errors.New("not an PPS NAL unit")
 )
 
+// maxNumSliceGroupsMinus1 is the highest num_slice_groups_minus1 allowed by any
+// AVC profile (ISO/IEC 14496-10 Annex A).
+const maxNumSliceGroupsMinus1 = 7
+
 // ParsePPSNALUnit - Parse AVC PPS NAL unit starting with NAL header
 func ParsePPSNALUnit(data []byte, spsMap map[uint32]*SPS) (*PPS, error) {
 	var err error
@@ -66,6 +70,16 @@ func ParsePPSNALUnit(data []byte, spsMap map[uint32]*SPS) (*PPS, error) {
 	pps.EntropyCodingModeFlag = reader.ReadFlag()
 	pps.BottomFieldPicOrderInFramePresentFlag = reader.ReadFlag()
 	pps.NumSliceGroupsMinus1 = reader.ReadExpGolomb()
+	// The allowed range of num_slice_groups_minus1 is specified in Annex A of
+	// ISO/IEC 14496-10. The widest range of any profile (Baseline in A.2.1 and
+	// Extended in A.2.3) is 0 to 7; all other profiles require 0. Guard against a
+	// bogus value before looping, to avoid gigabytes being appended below from a
+	// tiny malformed NAL unit.
+	if pps.NumSliceGroupsMinus1 > maxNumSliceGroupsMinus1 {
+		reader.SetError(fmt.Errorf("num_slice_groups_minus1 %d out of range [0, %d]",
+			pps.NumSliceGroupsMinus1, maxNumSliceGroupsMinus1))
+		return nil, reader.AccError()
+	}
 
 	if pps.NumSliceGroupsMinus1 > 0 {
 		pps.SliceGroupMapType = reader.ReadExpGolomb()

--- a/avc/pps_test.go
+++ b/avc/pps_test.go
@@ -2,6 +2,7 @@ package avc
 
 import (
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -40,5 +41,27 @@ func TestPPSParser(t *testing.T) {
 	}
 	if diff := deep.Equal(got, wanted); diff != nil {
 		t.Error(diff)
+	}
+}
+
+// TestPPSParserNumSliceGroupsOutOfRange verifies that an out-of-range
+// num_slice_groups_minus1 is rejected up front. Without the bound check, the
+// run_length_minus1 loop keeps appending for every signalled slice group, so a
+// 7-byte NAL unit made ParsePPSNALUnit allocate over 10 GiB.
+func TestPPSParserNumSliceGroupsOutOfRange(t *testing.T) {
+	// num_slice_groups_minus1 = 1 << 20, slice_group_map_type = 0
+	byteData, err := hex.DecodeString("28c0000080000e")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pps, err := ParsePPSNALUnit(byteData, nil)
+	if err == nil {
+		t.Fatal("expected an error for out-of-range num_slice_groups_minus1")
+	}
+	if !strings.Contains(err.Error(), "num_slice_groups_minus1") {
+		t.Errorf("expected a num_slice_groups_minus1 error, got %q", err.Error())
+	}
+	if pps != nil {
+		t.Errorf("expected nil PPS on error, got %+v", pps)
 	}
 }

--- a/hevc/vps.go
+++ b/hevc/vps.go
@@ -12,6 +12,10 @@ import (
 // extension arrays are dimensioned for this bound.
 const maxLayers = 8
 
+// maxNumLayerSetsMinus1 is the highest vps_num_layer_sets_minus1 allowed by
+// ISO/IEC 23008-2 Section 7.4.3.1.
+const maxNumLayerSetsMinus1 = 1023
+
 // VPS is HEVC VPS parameters
 // ISO/IEC 23008-2 (Ed. 5) Sec. 7.3.2.1 page 47 and 7.4.3.1 page 92
 type VPS struct {
@@ -193,6 +197,13 @@ func ParseVPSNALUnit(data []byte) (*VPS, error) {
 
 	vps.MaxLayerID = byte(r.Read(6))
 	vps.NumLayerSetsMinus1 = r.ReadExpGolomb()
+	// vps_num_layer_sets_minus1 shall be in the range of 0 to 1023, inclusive
+	// (ISO/IEC 23008-2 Section 7.4.3.1). Guard before the layer_id_included_flag
+	// loop below, which would otherwise read up to 64 flags per layer set.
+	if vps.NumLayerSetsMinus1 > maxNumLayerSetsMinus1 {
+		return nil, fmt.Errorf("vps_num_layer_sets_minus1 %d out of range [0, %d]",
+			vps.NumLayerSetsMinus1, maxNumLayerSetsMinus1)
+	}
 	// Capture layer set membership for use by the VPS extension (if present).
 	var numLayersInIdList [maxLayers]int
 	var layerSetLayerIdList [maxLayers][maxLayers]byte
@@ -222,6 +233,14 @@ func ParseVPSNALUnit(data []byte) (*VPS, error) {
 			ti.NumTicksPocDiffOneMinus1 = r.ReadExpGolomb()
 		}
 		ti.NumHrdParameters = r.ReadExpGolomb()
+		// vps_num_hrd_parameters shall be in the range of 0 to
+		// vps_num_layer_sets_minus1 + 1, inclusive (ISO/IEC 23008-2 Section 7.4.3.1).
+		// Guard against a bogus value before allocating, to avoid gigabytes being
+		// reserved from a tiny malformed NAL unit.
+		if ti.NumHrdParameters > vps.NumLayerSetsMinus1+1 {
+			return nil, fmt.Errorf("vps_num_hrd_parameters %d out of range [0, %d]",
+				ti.NumHrdParameters, vps.NumLayerSetsMinus1+1)
+		}
 		if ti.NumHrdParameters > 0 {
 			ti.HrdParameters = make([]*HrdParameters, ti.NumHrdParameters)
 			for i := uint(0); i < ti.NumHrdParameters; i++ {

--- a/hevc/vps_test.go
+++ b/hevc/vps_test.go
@@ -2,6 +2,7 @@ package hevc
 
 import (
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -278,5 +279,50 @@ func TestVPSParseError(t *testing.T) {
 	_, err = ParseVPSNALUnit(data)
 	if err == nil {
 		t.Error("expected error for non-VPS NALU type")
+	}
+}
+
+// TestVPSOutOfRangeCounts verifies that out-of-range layer-set and HRD counts
+// are rejected up front. Without the bound checks, vps_num_hrd_parameters sizes
+// a slice and drives a loop that allocates HRD parameters per iteration, so a
+// 33-byte NAL unit made ParseVPSNALUnit churn 30 GiB, and a large
+// vps_num_layer_sets_minus1 spun the layer_id_included_flag loop.
+func TestVPSOutOfRangeCounts(t *testing.T) {
+	cases := []struct {
+		name    string
+		hexData string
+		wantErr string
+	}{
+		{
+			name: "vps_num_hrd_parameters too large",
+			// vps_num_layer_sets_minus1 = 0, vps_timing_info_present_flag = 1,
+			// vps_num_hrd_parameters = 1 << 20
+			hexData: "40010c01ffff01ffffffffffffffffffff78f03ffffffffffffffff00000400006",
+			wantErr: "vps_num_hrd_parameters",
+		},
+		{
+			name: "vps_num_layer_sets_minus1 too large",
+			// vps_max_layer_id = 63, vps_num_layer_sets_minus1 = 1 << 20
+			hexData: "40010c01ffff01ffffffffffffffffffff78ffc00002000030",
+			wantErr: "vps_num_layer_sets_minus1",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			data, err := hex.DecodeString(c.hexData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			vps, err := ParseVPSNALUnit(data)
+			if err == nil {
+				t.Fatalf("expected an error containing %q", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("expected an error containing %q, got %q", c.wantErr, err.Error())
+			}
+			if vps != nil {
+				t.Errorf("expected nil VPS on error, got %+v", vps)
+			}
+		})
 	}
 }

--- a/mp4/samplegroupentries.go
+++ b/mp4/samplegroupentries.go
@@ -288,10 +288,15 @@ func DecodeAlstSampleGroupEntry(name string, length uint32, sr bits.SliceReader)
 		entry.SampleOffset[i] = sr.ReadUint32()
 	}
 
-	remaining := int(length-uint32(entry.Size())) / 4
-	if remaining <= 0 {
+	// The optional part is what is left of the entry after the mandatory part.
+	// Compare in uint64 so that a roll_count implying more bytes than
+	// description_length does not underflow into a huge remaining count and a
+	// multi-gigabyte allocation below.
+	mandatorySize := entry.Size()
+	if uint64(length) <= mandatorySize {
 		return entry, sr.AccError()
 	}
+	remaining := int((uint64(length) - mandatorySize) / 4)
 
 	// Optional
 	entry.NumOutputSamples = make([]uint16, remaining)

--- a/mp4/samplegroupentries_test.go
+++ b/mp4/samplegroupentries_test.go
@@ -1,0 +1,50 @@
+package mp4_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+// TestAlstSampleGroupEntryShortDescriptionLength verifies that an alst entry
+// whose roll_count implies more bytes than the signalled description_length
+// does not underflow the count of optional entries. Before the fix, the uint32
+// subtraction wrapped around and made the decoder allocate over 4 GiB from
+// these 8 bytes.
+func TestAlstSampleGroupEntryShortDescriptionLength(t *testing.T) {
+	// roll_count = 4 needs 4 + 4*4 = 20 bytes, but description_length is 8.
+	data := []byte{0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
+	sr := bits.NewFixedSliceReader(data)
+	sge, err := mp4.DecodeAlstSampleGroupEntry("alst", uint32(len(data)), sr)
+	if err == nil {
+		t.Fatal("expected an error for a too short alst description")
+	}
+	alst, ok := sge.(*mp4.AlstSampleGroupEntry)
+	if !ok {
+		t.Fatalf("expected an *mp4.AlstSampleGroupEntry, got %T", sge)
+	}
+	if len(alst.NumOutputSamples) != 0 || len(alst.NumTotalSamples) != 0 {
+		t.Errorf("expected no optional entries, got %d and %d",
+			len(alst.NumOutputSamples), len(alst.NumTotalSamples))
+	}
+}
+
+// TestSgpdWithShortAlstEntry checks the same case through a full sgpd box.
+func TestSgpdWithShortAlstEntry(t *testing.T) {
+	body := []byte{0x01, 0x00, 0x00, 0x00} // version 1, flags 0
+	body = append(body, []byte("alst")...)
+	body = binary.BigEndian.AppendUint32(body, 8) // default_length
+	body = binary.BigEndian.AppendUint32(body, 1) // entry_count
+	// roll_count = 4 needs more than the 8 bytes of description below
+	body = append(body, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+	box := binary.BigEndian.AppendUint32(nil, uint32(len(body)+8))
+	box = append(box, []byte("sgpd")...)
+	box = append(box, body...)
+
+	sr := bits.NewFixedSliceReader(box)
+	if _, err := mp4.DecodeBoxSR(0, sr); err == nil {
+		t.Error("expected an error for sgpd with a too short alst entry")
+	}
+}


### PR DESCRIPTION
Follow-up to #550. That PR bounded `num_ref_frames_in_pic_order_cnt_cycle` in AVC SPS parsing. Sweeping the rest of the codebase for the same pattern — a count read straight from attacker-controlled input that then sizes an allocation or drives an append loop — turned up three more, all reproduced with a PoC and measured with `/usr/bin/time -l`.

## The three cases

**`avc/pps.go` — `num_slice_groups_minus1`.** The field is an unbounded Exp-Golomb value; Annex A of ISO/IEC 14496-10 caps it at 7 (Baseline in A.2.1 and Extended in A.2.3; every other profile requires 0). It drives the `run_length_minus1`, `top_left`/`bottom_right` and `slice_group_id` append loops, none of which check `AccError`, so the loop runs to completion appending zeros long after EOF.

```
avc PPS NAL unit: 9 bytes  →  TotalAlloc 10.44 GiB, peak RSS 6.5 GiB
```

**`hevc/vps.go` — `vps_num_hrd_parameters`.** Sizes `make([]*HrdParameters, N)` and then calls `parseHrdParameters`, which allocates, once per iteration. Its spec bound (ISO/IEC 23008-2 §7.4.3.1) is `vps_num_layer_sets_minus1 + 1`, so this also bounds `vps_num_layer_sets_minus1` to its own 0–1023 range first. That second check is needed for the first one to mean anything, and it independently stops the `layer_id_included_flag` loop from spinning `N × 64` flag reads.

```
hevc VPS NAL unit: 35 bytes  →  TotalAlloc 30 GiB, peak RSS 10.75 GiB, 41 s wall
```

**`mp4/samplegroupentries.go` — `alst` optional entry count.** Not a missing bound but an integer underflow:

```go
remaining := int(length-uint32(entry.Size())) / 4
```

`entry.Size()` grows with the attacker-controlled `roll_count`, so when `roll_count` implies more bytes than the signalled `description_length` the `uint32` subtraction wraps to ~4e9 and `remaining` lands at ~1.07e9 for two `make([]uint16, …)` calls. Fixed by comparing in `uint64` and returning early. Worth noting that `mp4/fuzz_test.go:FuzzDecodeBox` already covers this entry point.

```
sgpd box: 32 bytes  →  TotalAlloc 4.00 GiB, peak RSS 3.4 GiB
```

## Tests

Each new test fails on `master` and passes here. The committed vectors deliberately use magnitudes that are comfortably over the spec bound but *cheap*, so removing a check fails the assertion in well under a second rather than exhausting memory on the runner:

| test | on master (checks removed) | peak RSS |
|---|---|---|
| `avc.TestPPSParserNumSliceGroupsOutOfRange` | `got "EOF"` | 95 MB |
| `hevc.TestVPSOutOfRangeCounts` (2 subtests) | `got "error parsing VPS: EOF"` | 142 MB |
| `mp4.TestAlstSampleGroupEntryShortDescriptionLength` | `got 1073741821 and 1073741821` | 5.5 GiB |
| `mp4.TestSgpdWithShortAlstEntry` | — | — |

The one exception is the `alst` test: the underflow always wraps to near 2^32 regardless of how small the input is, so there is no cheap variant of it.

`go test ./...` passes and `golangci-lint run ./...` reports 0 issues.

## Not addressed here

Same shape, found by inspection but not reproduced, so left out to keep this reviewable:

- `hevc/slice.go:344` — `num_entry_point_offsets`, unbounded ue → `make([]uint32, N)`. Closest remaining relative of #550. Reachable via the public `hevc.ParseSliceHeader` but needs a PPS with `tiles_enabled_flag` to construct.
- `hevc/vps.go` `vps_extension` — `NumProfileTierLevel` (spec 0–63), `num_add_olss` (0–1023, and the comment at the OLS loop states the bound without enforcing it), `NumRepFormats` (0–255): append/iterate loops with no `AccError` break.
- `vvc/vvcdecoderconfigurationrecord.go:382` — `numOfArrays` (≤255) × `make([][]byte, numNalus)` (≤65535) with no `AccError` break: ~400 MB from a few hundred bytes. Much milder.

Also spotted while reading `avc/pps.go`, unrelated to allocation: the `slice_group_map_type == 6` branch never reads `pic_size_in_map_units_minus1` and uses `num_slice_groups_minus1` as the `slice_group_id` loop bound instead. Left alone deliberately — fixing it introduces another unbounded ue that would need its own bound.

## Coverage gap

The `avc` package has no fuzz targets at all, and there is no `FuzzParseVPSNALUnit` alongside the existing `hevc` SPS/PPS ones. Both gaps line up exactly with the bugs above. Happy to add those targets in a separate PR if you'd like.
