### PR TITLE
feat(mp4): add QuickTime-to-ISO audio sample entry normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `AudioSampleEntryBox.NormalizeQuickTime` rewrites a QuickTime-shaped audio
+  sample entry (sound sample description version 1 or 2, QuickTime residue in
+  the version 0 reserved fields, or a wave-wrapped esds) to the plain ISO
+  version 0 form with the esds as a direct child. Entries without a reachable
+  esds, and wave boxes holding anything besides their recognized decoder-init
+  atoms, are left untouched
+
 ### Changed
 
 - `TrunBox.GetFullSamples` returns an error when the trun-declared sample

--- a/mp4/audiosampleentry_test.go
+++ b/mp4/audiosampleentry_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Eyevinn/mp4ff/aac"
 	"github.com/Eyevinn/mp4ff/bits"
 	"github.com/Eyevinn/mp4ff/mp4"
 )
@@ -372,6 +373,229 @@ func TestQuickTimeAudioSampleEntryNames(t *testing.T) {
 		q := entry.QuickTimeV2
 		if q == nil || q.AudioSampleRate != 44100 || q.NumAudioChannels != 2 || q.ConstBitsPerChannel != 16 {
 			t.Errorf("quickTimeV2 fields not decoded: %+v", q)
+		}
+	})
+}
+
+func TestNormalizeQuickTime(t *testing.T) {
+	esds := encodedEsdsBytes(t) // AAC-LC, 48000 Hz, 2 channels
+	frma := waveChildBytes("frma", []byte("mp4a"))
+	mp4aStub := waveChildBytes("mp4a", make([]byte, 4)) // 12-byte QuickTime stub
+	terminator := waveChildBytes(string([]byte{0, 0, 0, 0}), nil)
+	wave := waveBytes(frma, mp4aStub, esds, terminator)
+
+	decodeEntry := func(t *testing.T, data []byte) *mp4.AudioSampleEntryBox {
+		t.Helper()
+		box, err := mp4.DecodeBox(0, bytes.NewReader(data))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return box.(*mp4.AudioSampleEntryBox)
+	}
+	encodedBytes := func(t *testing.T, box mp4.Box) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		if err := box.Encode(&buf); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+	v2Extension := func(sampleRate float64, channels, bitsPerChannel uint32) []byte {
+		ext := make([]byte, 0, 36)
+		ext = binary.BigEndian.AppendUint32(ext, 72)
+		ext = binary.BigEndian.AppendUint64(ext, math.Float64bits(sampleRate))
+		for _, val := range []uint32{channels, mp4.QuickTimeV2Marker, bitsPerChannel, 0, 0, 1024} {
+			ext = binary.BigEndian.AppendUint32(ext, val)
+		}
+		return ext
+	}
+
+	t.Run("version 1 with wave-wrapped esds matches a fresh ISO entry", func(t *testing.T) {
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 1, make([]byte, 16), wave))
+		if !entry.NormalizeQuickTime() {
+			t.Fatal("entry not normalized")
+		}
+		if entry.QuickTimeVersion != 0 || entry.QuickTimeRevisionLevel != 0 || entry.QuickTimeVendor != 0 ||
+			entry.QuickTimeV1 != nil || entry.Wave != nil {
+			t.Errorf("QuickTime shape left after normalization: %+v", entry)
+		}
+		want := mp4.CreateAudioSampleEntryBox("mp4a", 2, 16, 48000, mp4.CreateEsdsBox([]byte{0x11, 0x90}))
+		if !bytes.Equal(encodedBytes(t, entry), encodedBytes(t, want)) {
+			t.Error("normalized entry does not match the freshly created ISO entry")
+		}
+	})
+
+	t.Run("version 2 restores rate and channels", func(t *testing.T) {
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 2, v2Extension(48000, 6, 0), wave))
+		if !entry.NormalizeQuickTime() {
+			t.Fatal("entry not normalized")
+		}
+		if entry.ChannelCount != 6 || entry.SampleRate != 48000 || entry.SampleSize != 16 {
+			t.Errorf("version 2 fields not restored: channels %d, rate %d, size %d",
+				entry.ChannelCount, entry.SampleRate, entry.SampleSize)
+		}
+		if entry.Esds == nil {
+			t.Error("esds not hoisted out of wave")
+		}
+	})
+
+	t.Run("version 2 keeps the declared bits per channel", func(t *testing.T) {
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 2, v2Extension(48000, 2, 24), wave))
+		if !entry.NormalizeQuickTime() {
+			t.Fatal("entry not normalized")
+		}
+		if entry.SampleSize != 24 {
+			t.Errorf("got sample size %d, wanted the declared 24 bits per channel", entry.SampleSize)
+		}
+	})
+
+	t.Run("version 2 fractional rate rounds to nearest", func(t *testing.T) {
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 2, v2Extension(44099.9999, 2, 0), wave))
+		if !entry.NormalizeQuickTime() {
+			t.Fatal("entry not normalized")
+		}
+		if entry.SampleRate != 44100 {
+			t.Errorf("got sample rate %d, wanted the rounded 44100", entry.SampleRate)
+		}
+	})
+
+	t.Run("rate above 65535 Hz leaves the fixed field 0", func(t *testing.T) {
+		esds96k := encodedBytes(t, mp4.CreateEsdsBox([]byte{0x10, 0x10})) // AAC-LC, 96000 Hz, 2 channels
+		wave96k := waveBytes(frma, esds96k, terminator)
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 2, v2Extension(96000, 2, 0), wave96k))
+		if !entry.NormalizeQuickTime() {
+			t.Fatal("entry not normalized")
+		}
+		if entry.SampleRate != 0 || entry.ChannelCount != 2 {
+			t.Errorf("got rate %d and channels %d, wanted the unrepresentable rate left 0",
+				entry.SampleRate, entry.ChannelCount)
+		}
+		hdr, err := aac.DecodeAudioSpecificConfigHeader(
+			bytes.NewReader(entry.Esds.DecConfigDescriptor.DecSpecificInfo.DecConfig))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.SamplingFrequency != 96000 {
+			t.Errorf("the hoisted esds carries %d Hz, wanted the authoritative 96000", hdr.SamplingFrequency)
+		}
+	})
+
+	t.Run("direct esds beats a wave-wrapped esds", func(t *testing.T) {
+		directASC := []byte{0x11, 0x90}
+		waveEsds := waveBytes(frma, encodedBytes(t, mp4.CreateEsdsBox([]byte{0x10, 0x10})), terminator)
+		children := append(encodedBytes(t, mp4.CreateEsdsBox(directASC)), waveEsds...)
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 1, make([]byte, 16), children))
+		if !entry.NormalizeQuickTime() {
+			t.Fatal("entry not normalized")
+		}
+		if len(entry.Children) != 1 {
+			t.Errorf("got %d children, wanted only the kept esds", len(entry.Children))
+		}
+		if got := entry.Esds.DecConfigDescriptor.DecSpecificInfo.DecConfig; !bytes.Equal(got, directASC) {
+			t.Errorf("got decoder config %x, wanted the direct esds to win over the wave-wrapped one", got)
+		}
+	})
+
+	t.Run("version 1 without any esds is left alone", func(t *testing.T) {
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 1, make([]byte, 16), nil))
+		if entry.NormalizeQuickTime() {
+			t.Error("entry without an esds must not be normalized")
+		}
+		if entry.QuickTimeV1 == nil {
+			t.Error("version 1 fields must be preserved")
+		}
+	})
+
+	t.Run("wave without esds is left alone", func(t *testing.T) {
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 0, nil, waveBytes(frma, terminator)))
+		if entry.NormalizeQuickTime() {
+			t.Error("entry without a reachable esds must not be normalized")
+		}
+		if entry.Wave == nil {
+			t.Error("wave box must be preserved")
+		}
+	})
+
+	t.Run("wave with an unrecognized child is left alone", func(t *testing.T) {
+		chanChild := waveChildBytes("chan", make([]byte, 12))
+		data := quickTimeSoundDescriptionBytes("mp4a", 0, nil, waveBytes(frma, esds, chanChild, terminator))
+		entry := decodeEntry(t, data)
+		if entry.NormalizeQuickTime() {
+			t.Error("wave content beyond the decoder-init atoms must not be dropped")
+		}
+		if !bytes.Equal(encodedBytes(t, entry), data) {
+			t.Error("refused entry must stay byte-identical to its input")
+		}
+	})
+
+	t.Run("wave with a nonzero RawTail is left alone", func(t *testing.T) {
+		badTail := []byte{0, 0, 0, 1, 'j', 'u', 'n', 'k'} // size 1: malformed, nonzero tail
+		data := quickTimeSoundDescriptionBytes("mp4a", 0, nil, waveBytes(frma, esds, badTail))
+		entry := decodeEntry(t, data)
+		if entry.Wave == nil || len(entry.Wave.RawTail) == 0 {
+			t.Fatal("test setup: wave must decode with a nonzero RawTail")
+		}
+		if entry.NormalizeQuickTime() {
+			t.Error("a nonzero wave RawTail must not be dropped")
+		}
+		if !bytes.Equal(encodedBytes(t, entry), data) {
+			t.Error("refused entry must stay byte-identical to its input")
+		}
+	})
+
+	t.Run("wave with an oversized same-name child is left alone", func(t *testing.T) {
+		bigStub := waveChildBytes("mp4a", make([]byte, 24)) // 32 bytes: not the 12-byte stub
+		data := quickTimeSoundDescriptionBytes("mp4a", 0, nil, waveBytes(frma, esds, bigStub, terminator))
+		entry := decodeEntry(t, data)
+		if entry.NormalizeQuickTime() {
+			t.Error("a same-name wave child beyond the 12-byte stub must not be dropped")
+		}
+		if !bytes.Equal(encodedBytes(t, entry), data) {
+			t.Error("refused entry must stay byte-identical to its input")
+		}
+	})
+
+	t.Run("version 2 hostile rate leaves the fixed field 0", func(t *testing.T) {
+		for _, rate := range []float64{math.NaN(), math.Inf(1), -44100} {
+			entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 2, v2Extension(rate, 2, 0), wave))
+			if !entry.NormalizeQuickTime() {
+				t.Fatal("entry not normalized")
+			}
+			if entry.SampleRate != 0 {
+				t.Errorf("rate %v: got sample rate %d, wanted 0", rate, entry.SampleRate)
+			}
+		}
+	})
+
+	t.Run("wave with a size-zero terminator tail still normalizes", func(t *testing.T) {
+		sizeZeroTerminator := make([]byte, 8) // size 0, type 0: all-zero RawTail
+		data := quickTimeSoundDescriptionBytes("mp4a", 0, nil, waveBytes(frma, esds, sizeZeroTerminator))
+		entry := decodeEntry(t, data)
+		if !entry.NormalizeQuickTime() {
+			t.Fatal("entry not normalized")
+		}
+		if entry.Wave != nil || entry.Esds == nil {
+			t.Error("esds not hoisted out of wave")
+		}
+	})
+
+	t.Run("version 0 with QuickTime residue is cleaned", func(t *testing.T) {
+		// The helper stamps revision level 1 and vendor "appl" into an
+		// otherwise plain version 0 entry.
+		entry := decodeEntry(t, quickTimeSoundDescriptionBytes("mp4a", 0, nil, esds))
+		if !entry.NormalizeQuickTime() {
+			t.Fatal("entry with QuickTime residue not normalized")
+		}
+		want := mp4.CreateAudioSampleEntryBox("mp4a", 2, 16, 48000, mp4.CreateEsdsBox([]byte{0x11, 0x90}))
+		if !bytes.Equal(encodedBytes(t, entry), encodedBytes(t, want)) {
+			t.Error("cleaned entry does not match the freshly created ISO entry")
+		}
+	})
+
+	t.Run("ISO entry is a no-op", func(t *testing.T) {
+		entry := mp4.CreateAudioSampleEntryBox("mp4a", 2, 16, 48000, mp4.CreateEsdsBox([]byte{0x11, 0x90}))
+		if entry.NormalizeQuickTime() {
+			t.Error("clean ISO version 0 entry must not change")
 		}
 	})
 }

--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -491,6 +491,96 @@ func (a *AudioSampleEntryBox) Info(w io.Writer, specificBoxLevels, indent, inden
 	return nil
 }
 
+// waveDropSafe reports whether the wave box holds only the decoder-init
+// atoms that normalization knowingly discards — frma, esds, the terminator
+// atom, and the 12-byte QuickTime stub named after the entry — with at most
+// an all-zero RawTail (a size-zero terminator).
+func waveDropSafe(wave *WaveBox, entryName string) bool {
+	for _, child := range wave.Children {
+		switch child.Type() {
+		case "frma", "esds", "\x00\x00\x00\x00":
+		case entryName:
+			if child.Size() > 12 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	for _, b := range wave.RawTail {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// NormalizeQuickTime rewrites a QuickTime-shaped entry (sound sample
+// description version 1 or 2, QuickTime residue in the version 0 reserved
+// fields, or an esds wrapped in a wave box) to the plain ISO version 0 form:
+// the esds becomes a direct child, and the wave box and the QuickTime
+// version, revision level, vendor, and compressionID are dropped. A version
+// 2 entry gets its channel count, sample size, and sample rate restored.
+// It is a no-op (returns false) without a QuickTime shape or a reachable
+// esds, or when the wave box holds anything besides its recognized
+// decoder-init atoms.
+func (a *AudioSampleEntryBox) NormalizeQuickTime() bool {
+	if a.QuickTimeVersion == 0 && a.Wave == nil &&
+		a.QuickTimeRevisionLevel == 0 && a.QuickTimeVendor == 0 && a.CompressionID == 0 {
+		return false
+	}
+	esds := a.Esds
+	if esds == nil && a.Wave != nil {
+		esds = a.Wave.Esds
+	}
+	if esds == nil {
+		// No esds means the decode parameters live in the version fields or
+		// the wave content itself (e.g. lpcm, ima4); such an entry has no
+		// ISO version 0 form and must keep its QuickTime shape.
+		return false
+	}
+	if a.Wave != nil && !waveDropSafe(a.Wave, a.name) {
+		// The wave box holds something beyond the decoder-init atoms that
+		// the esds replaces; dropping it would silently lose that content.
+		return false
+	}
+	children := []Box{esds}
+	for _, child := range a.Children {
+		if child.Type() == "esds" || child.Type() == "wave" {
+			continue
+		}
+		children = append(children, child)
+	}
+	if a.QuickTimeV2 != nil {
+		q := a.QuickTimeV2
+		a.ChannelCount = 0
+		if q.NumAudioChannels <= math.MaxUint16 {
+			a.ChannelCount = uint16(q.NumAudioChannels)
+		}
+		a.SampleSize = 16
+		if q.ConstBitsPerChannel > 0 && q.ConstBitsPerChannel <= math.MaxUint16 {
+			a.SampleSize = uint16(q.ConstBitsPerChannel)
+		}
+		// A rate above 65535 Hz does not fit the 16.16 sample rate field and
+		// leaves 0, as ffmpeg writes; the authoritative rate is in the esds
+		// AudioSpecificConfig.
+		a.SampleRate = 0
+		if q.AudioSampleRate > 0 && q.AudioSampleRate <= math.MaxUint16 {
+			a.SampleRate = uint16(math.Round(q.AudioSampleRate))
+		}
+	}
+	a.QuickTimeVersion = 0
+	a.QuickTimeRevisionLevel = 0
+	a.QuickTimeVendor = 0
+	a.CompressionID = 0
+	a.QuickTimeV1 = nil
+	a.QuickTimeV2 = nil
+	a.Esds = esds
+	a.Wave = nil
+	a.Children = children
+	return true
+}
+
 // RemoveEncryption - remove sinf box and set type to unencrypted type
 func (a *AudioSampleEntryBox) RemoveEncryption() (*SinfBox, error) {
 	if a.name != "enca" {


### PR DESCRIPTION
## Problem

QuickTime-shaped audio sample entries (sound sample description version 1 or
2, or an esds wrapped in a wave box) decode fine since #544 and #547, but
repackaging such content into isom-branded files calls for the plain ISO
version 0 form: esds as a direct child and the overlaid QuickTime fields
cleared. Callers currently have to do that rewrite by hand.

## Fix

`AudioSampleEntryBox.NormalizeQuickTime()` rewrites the entry in place (the
same shape as `RemoveEncryption`): the esds is hoisted out of the wave box,
the wave box and the QuickTime version, revision level, vendor, and
compressionID are dropped, and a version 2 entry gets its effective channel
count, sample size, and sample rate restored into the fixed fields. Entries
without a reachable esds are left alone (returns false), since their codec
parameters live in the QuickTime fields themselves.

A version 2 rate above 65535 Hz cannot be represented in the fixed 16.16
field; it is written as 0, matching what ffmpeg writes there, and the
authoritative rate stays in the esds AudioSpecificConfig.

## Tests

Eight cases: a version 1 entry with wave-wrapped esds normalizes
byte-identical to a freshly created ISO entry; version 2 restores
channels/rate/bit depth (24-bit preserved); 96 kHz leaves the fixed field 0
while the hoisted esds decodes to 96000 Hz via
`aac.DecodeAudioSpecificConfigHeader`; a direct esds wins over a wave-wrapped
one; and no-ops for ISO entries and QuickTime shapes without esds. `go test
./...`, `go vet`, `gofmt`, `golangci-lint` pass.