### PR TITLE
feat(mp4): convert fragmented files to progressive (defragmentation)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,15 @@ builds:
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
 
+  - id: mp4ff-defragment
+    main: ./cmd/mp4ff-defragment
+    binary: mp4ff-defragment
+    ldflags:
+      - -X github.com/Eyevinn/mp4ff/internal.commitVersion={{.Tag}}
+      - -X github.com/Eyevinn/mp4ff/internal.commitDate={{.CommitTimestamp}}
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+
   - id: mp4ff-encrypt
     main: ./cmd/mp4ff-encrypt
     binary: mp4ff-encrypt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output is byte-identical to adding the samples one by one with
   `AddFullSample`
 
+- `mp4.Defragment` and `mp4.DefragmentTracks` convert a fragmented file to a
+  progressive one: sample tables (stts, ctts, stsc, stsz, stss, stco/co64)
+  are synthesized from the fragment metadata while sample data and sample
+  descriptions are preserved. Every track is rebased so that its first tfdt
+  becomes media time zero, edit-list media times are shifted along, a final
+  edit with zero segment duration (open-ended in a fragmented file, where the
+  movie duration is unknown) is resolved to the remaining media duration so
+  progressive readers do not apply it as a zero-length edit, and a track
+  starting later than the earliest one keeps its presentation alignment
+  through an empty edit; a trivial identity edit list is dropped.
+  Fragment-format brands (dash, cmfc, isml, and friends) are removed from
+  the output ftyp. Encrypted content, unsupported edit lists, zero
+  timescales, truncated byte ranges, and payloads larger than the input
+  file are rejected
+- `mp4ff-defragment` command line tool exposing the defragmentation with
+  optional track selection
+
 ### Changed
 
 - The commands and examples that create their own output file now buffer their

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@
 all: test check coverage build
 
 .PHONY: build
-build: mp4ff-crop mp4ff-decrypt mp4ff-encrypt mp4ff-info mp4ff-mvhevc mp4ff-nallister mp4ff-pslister mp4ff-subslister examples
+build: mp4ff-crop mp4ff-decrypt mp4ff-defragment mp4ff-encrypt mp4ff-info mp4ff-mvhevc mp4ff-nallister mp4ff-pslister mp4ff-subslister examples
 
 .PHONY: prepare
 prepare:
 	go mod tidy
 
-.PHONY: mp4ff-crop mp4ff-decrypt mp4ff-encrypt mp4ff-info mp4ff-mvhevc mp4ff-nallister mp4ff-pslister mp4ff-subslister
-mp4ff-crop mp4ff-decrypt mp4ff-encrypt mp4ff-info mp4ff-mvhevc mp4ff-nallister mp4ff-pslister mp4ff-subslister:
+.PHONY: mp4ff-crop mp4ff-decrypt mp4ff-defragment mp4ff-encrypt mp4ff-info mp4ff-mvhevc mp4ff-nallister mp4ff-pslister mp4ff-subslister
+mp4ff-crop mp4ff-decrypt mp4ff-defragment mp4ff-encrypt mp4ff-info mp4ff-mvhevc mp4ff-nallister mp4ff-pslister mp4ff-subslister:
 	go build -ldflags "-X github.com/Eyevinn/mp4ff/internal.commitVersion=$$(git describe --tags HEAD) -X github.com/Eyevinn/mp4ff/internal.commitDate=$$(git log -1 --format=%ct)" -o out/$@ ./cmd/$@/main.go
 
 .PHONY: examples

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Some useful command line tools are available in [cmd](cmd) directory.
 6. [mp4ff-encrypt](cmd/mp4ff-encrypt) encrypts a fragmented file using cenc or cbcs Common Encryption scheme
 7. [mp4ff-decrypt](cmd/mp4ff-decrypt) decrypts a fragmented file encrypted using cenc or cbcs Common Encryption scheme
 8. [mp4ff-mvhevc](cmd/mp4ff-mvhevc) inspects MV-HEVC (Multi-View HEVC) files and muxes HEVC (Annex B or mp4) into an MV-HEVC mp4
+9. [mp4ff-defragment](cmd/mp4ff-defragment) converts a fragmented mp4 file into a progressive mp4 file
 
 ## Installing the command line tools
 

--- a/cmd/mp4ff-defragment/doc.go
+++ b/cmd/mp4ff-defragment/doc.go
@@ -1,0 +1,17 @@
+/*
+mp4ff-defragment converts a fragmented mp4 file into a progressive (moov-before-mdat) mp4 file.
+Sample data is copied unchanged while progressive sample tables are synthesized
+from the fragment metadata.
+
+Usage of mp4ff-defragment:
+
+mp4ff-defragment [options] <inFile> <outFile>
+
+options:
+
+	-t string
+		Comma-separated track IDs to keep (default all tracks)
+	-version
+		Get mp4ff version
+*/
+package main

--- a/cmd/mp4ff-defragment/main.go
+++ b/cmd/mp4ff-defragment/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Eyevinn/mp4ff/internal"
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+const (
+	appName = "mp4ff-defragment"
+)
+
+var usg = `%s converts a fragmented mp4 file into a progressive (moov-before-mdat) mp4 file.
+Sample data is copied unchanged while progressive sample tables are synthesized
+from the fragment metadata.
+
+Usage of %s:
+`
+
+type options struct {
+	trackIDs string
+	version  bool
+}
+
+func parseOptions(fs *flag.FlagSet, args []string) (*options, error) {
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, usg, appName, appName)
+		fmt.Fprintf(os.Stderr, "\n%s [options] <inFile> <outFile>\n\noptions:\n", appName)
+		fs.PrintDefaults()
+	}
+
+	opts := options{}
+
+	fs.StringVar(&opts.trackIDs, "t", "", "Comma-separated track IDs to keep (default all tracks)")
+	fs.BoolVar(&opts.version, "version", false, "Get mp4ff version")
+
+	err := fs.Parse(args[1:])
+	return &opts, err
+}
+
+func main() {
+	if err := run(os.Args, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet(appName, flag.ContinueOnError)
+	o, err := parseOptions(fs, args)
+
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	if o.version {
+		fmt.Fprintf(stdout, "%s %s\n", appName, internal.GetVersion())
+		return nil
+	}
+
+	if len(fs.Args()) != 2 {
+		fs.Usage()
+		return fmt.Errorf("must specify inFile and outFile")
+	}
+
+	trackIDs, err := parseTrackIDs(o.trackIDs)
+	if err != nil {
+		return err
+	}
+
+	inFilePath := fs.Arg(0)
+	outFilePath := fs.Arg(1)
+
+	ifh, err := os.Open(inFilePath)
+	if err != nil {
+		return fmt.Errorf("error opening input file: %w", err)
+	}
+	defer ifh.Close()
+	parsedMp4, err := mp4.DecodeFile(ifh, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+	if err != nil {
+		return fmt.Errorf("error decoding mp4 file: %w", err)
+	}
+
+	ofh, err := os.Create(outFilePath)
+	if err != nil {
+		return fmt.Errorf("error creating output file: %w", err)
+	}
+	defer ofh.Close()
+
+	if len(trackIDs) == 0 {
+		err = mp4.Defragment(parsedMp4, ifh, ofh)
+	} else {
+		err = mp4.DefragmentTracks(parsedMp4, ifh, ofh, trackIDs...)
+	}
+	if err != nil {
+		return fmt.Errorf("error defragmenting mp4 file: %w", err)
+	}
+	return nil
+}
+
+func parseTrackIDs(spec string) ([]uint32, error) {
+	if spec == "" {
+		return nil, nil
+	}
+	var trackIDs []uint32
+	for _, part := range strings.Split(spec, ",") {
+		id, err := strconv.ParseUint(strings.TrimSpace(part), 10, 32)
+		if err != nil || id == 0 {
+			return nil, fmt.Errorf("invalid track ID %q", part)
+		}
+		trackIDs = append(trackIDs, uint32(id))
+	}
+	return trackIDs, nil
+}

--- a/cmd/mp4ff-defragment/main_test.go
+++ b/cmd/mp4ff-defragment/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+func TestCommandLines(t *testing.T) {
+	inFile := "../../mp4/testdata/prog_8s_dec_dashinit.mp4"
+	tmpDir := t.TempDir()
+	outFile := path.Join(tmpDir, "out.mp4")
+	cases := []struct {
+		desc string
+		args []string
+		err  bool
+	}{
+		{desc: "no args", args: []string{appName}, err: true},
+		{desc: "unknown args", args: []string{appName, "-x"}, err: true},
+		{desc: "no outFile", args: []string{appName, inFile}, err: true},
+		{desc: "bad track IDs", args: []string{appName, "-t", "1,x", inFile, outFile}, err: true},
+		{desc: "unknown track ID", args: []string{appName, "-t", "7", inFile, outFile}, err: true},
+		{desc: "version", args: []string{appName, "-version"}, err: false},
+		{desc: "help", args: []string{appName, "-h"}, err: false},
+		{desc: "all tracks", args: []string{appName, inFile, outFile}, err: false},
+		{desc: "track selection", args: []string{appName, "-t", "1", inFile, outFile}, err: false},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			err := run(c.args, io.Discard)
+			if c.err && err == nil {
+				t.Error("expected error but got nil")
+			}
+			if !c.err && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDefragmentedOutputIsProgressive(t *testing.T) {
+	inFile := "../../mp4/testdata/prog_8s_dec_dashinit.mp4"
+	outFile := path.Join(t.TempDir(), "out.mp4")
+	if err := run([]string{appName, inFile, outFile}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outMp4, err := mp4.DecodeFile(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outMp4.IsFragmented() {
+		t.Error("output is still fragmented")
+	}
+	if outMp4.Moov == nil || outMp4.Mdat == nil {
+		t.Error("output lacks moov or mdat")
+	}
+}

--- a/mp4/defragmenter.go
+++ b/mp4/defragmenter.go
@@ -1,0 +1,894 @@
+package mp4
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"math/bits"
+)
+
+// Defragment converts the fragmented file f, decoded from rs, into a
+// progressive (moov-before-mdat) file written to w. f is modified in place.
+//
+// Sample data is copied byte-verbatim while progressive sample tables
+// (stts, ctts, stsc, stsz, stss, stco/co64) are synthesized from the
+// fragment metadata, with each traf becoming one chunk. Every track is
+// rebased so that its first tfdt becomes media time zero: edit-list media
+// times shift along, and a track starting later than the earliest one keeps
+// its presentation alignment through an empty edit (with at most half a
+// movie-timescale tick of rounding). Encrypted content, overlapping
+// timelines, and edits that cannot be shifted exactly are rejected.
+func Defragment(f *File, rs io.ReadSeeker, w io.Writer) error {
+	d, err := newDefragmenter(f, rs, nil)
+	if err != nil {
+		return err
+	}
+	return d.writeProgressive(w)
+}
+
+// DefragmentTracks is like [Defragment], but only keeps the tracks with the
+// given track IDs. At least one track ID must be given, and every given track
+// ID must exist in the moov box. Track IDs are preserved in the output, and
+// the fragments of the dropped tracks are neither validated nor copied.
+func DefragmentTracks(f *File, rs io.ReadSeeker, w io.Writer, trackIDs ...uint32) error {
+	if len(trackIDs) == 0 {
+		return fmt.Errorf("no track IDs given")
+	}
+	d, err := newDefragmenter(f, rs, trackIDs)
+	if err != nil {
+		return err
+	}
+	return d.writeProgressive(w)
+}
+
+type defragSample struct {
+	dur     uint32
+	size    uint32
+	cts     int32
+	nonSync bool
+}
+
+type defragRange struct {
+	offset uint64 // absolute offset in the input file
+	size   uint64
+}
+
+// defragChunk is one output chunk: the samples of one traf.
+type defragChunk struct {
+	track     *defragTrack
+	sdi       uint32 // sample description index
+	nrSamples uint32
+	size      uint64
+	ranges    []defragRange // input byte ranges, coalesced
+	offset    uint64        // output chunk offset, assigned before writing
+}
+
+func (c *defragChunk) addRange(offset, size uint64) {
+	c.size += size
+	if size == 0 {
+		return
+	}
+	if n := len(c.ranges); n > 0 && c.ranges[n-1].offset+c.ranges[n-1].size == offset {
+		c.ranges[n-1].size += size
+		return
+	}
+	c.ranges = append(c.ranges, defragRange{offset: offset, size: size})
+}
+
+type defragTrack struct {
+	trak    *TrakBox
+	trex    *TrexBox
+	keep    bool
+	samples []defragSample
+	chunks  []*defragChunk
+	started bool   // some traf established the timeline
+	origin  uint64 // decode time of the first sample
+	endDts  uint64 // decode time just after the last sample
+	delay   uint64 // presentation delay relative to the earliest track, in movie ticks
+}
+
+type defragmenter struct {
+	rs          io.ReadSeeker
+	fileSize    uint64
+	payloadSize uint64 // total sample payload of the kept tracks
+	ftyp        *FtypBox
+	moov        *MoovBox
+	tracks      []*defragTrack
+	byID        map[uint32]*defragTrack
+	chunks      []*defragChunk // all output chunks in output order
+}
+
+// newDefragmenter collects the sample and chunk layout of the kept tracks.
+// A nil keptTrackIDs keeps every track.
+func newDefragmenter(f *File, rs io.ReadSeeker, keptTrackIDs []uint32) (*defragmenter, error) {
+	fileSize, err := rs.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, fmt.Errorf("could not seek to end: %w", err)
+	}
+	if !f.IsFragmented() {
+		return nil, fmt.Errorf("input file is not fragmented")
+	}
+	if f.Moov == nil {
+		return nil, fmt.Errorf("no moov box found")
+	}
+	if f.Moov.Mvhd == nil {
+		return nil, fmt.Errorf("moov box lacks mvhd")
+	}
+	if f.Moov.Mvhd.Timescale == 0 {
+		return nil, fmt.Errorf("mvhd has zero movie timescale")
+	}
+	d := &defragmenter{
+		rs:       rs,
+		fileSize: uint64(fileSize),
+		ftyp:     f.Ftyp,
+		moov:     f.Moov,
+		byID:     make(map[uint32]*defragTrack),
+	}
+	for _, trak := range f.Moov.Traks {
+		if trak.Tkhd == nil || trak.Mdia == nil || trak.Mdia.Mdhd == nil {
+			return nil, fmt.Errorf("trak box lacks tkhd or mdhd")
+		}
+		track := &defragTrack{trak: trak, keep: true}
+		if f.Moov.Mvex != nil {
+			for _, trex := range f.Moov.Mvex.Trexs {
+				if trex.TrackID == trak.Tkhd.TrackID {
+					track.trex = trex
+					break
+				}
+			}
+		}
+		if _, exists := d.byID[trak.Tkhd.TrackID]; exists {
+			return nil, fmt.Errorf("duplicate track ID %d", trak.Tkhd.TrackID)
+		}
+		d.tracks = append(d.tracks, track)
+		d.byID[trak.Tkhd.TrackID] = track
+	}
+	if keptTrackIDs != nil {
+		for _, track := range d.tracks {
+			track.keep = false
+		}
+		for _, trackID := range keptTrackIDs {
+			track, ok := d.byID[trackID]
+			if !ok {
+				return nil, fmt.Errorf("track ID %d not found in moov", trackID)
+			}
+			track.keep = true
+		}
+	}
+	for _, track := range d.tracks {
+		if !track.keep {
+			continue
+		}
+		if stbl := trackStbl(track.trak); stbl != nil && stbl.Stsz != nil && stbl.Stsz.GetNrSamples() > 0 {
+			return nil, fmt.Errorf("track %d already carries progressive samples, "+
+				"only purely fragmented input is supported", track.trak.Tkhd.TrackID)
+		}
+	}
+	for _, seg := range f.Segments {
+		for _, frag := range seg.Fragments {
+			if frag.Moof == nil {
+				continue
+			}
+			if err := d.collectFragment(frag.Moof); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, track := range d.tracks {
+		// A track without samples would get a 0-entry stts, which
+		// classifies the output as fragmented on decode.
+		if track.keep && len(track.samples) == 0 {
+			return nil, fmt.Errorf("track %d has no samples, drop it with DefragmentTracks to convert the rest",
+				track.trak.Tkhd.TrackID)
+		}
+	}
+	for _, chunk := range d.chunks {
+		if chunk.size > d.fileSize-d.payloadSize {
+			return nil, fmt.Errorf("declared sample payload exceeds the %d bytes of the input file", d.fileSize)
+		}
+		d.payloadSize += chunk.size
+	}
+	if err := d.computeTrackAlignment(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// computeTrackAlignment gives every kept track with samples a presentation
+// delay matching its decode-time start relative to the earliest kept track,
+// and validates that its edit list survives the origin rebase exactly.
+func (d *defragmenter) computeTrackAlignment() error {
+	var earliest *defragTrack
+	for _, track := range d.tracks {
+		if !track.keep || len(track.samples) == 0 {
+			continue
+		}
+		if track.trak.Mdia.Mdhd.Timescale == 0 {
+			return fmt.Errorf("track %d has zero media timescale", track.trak.Tkhd.TrackID)
+		}
+		if earliest == nil || originBefore(track, earliest) {
+			earliest = track
+		}
+	}
+	for _, track := range d.tracks {
+		if !track.keep || len(track.samples) == 0 {
+			continue
+		}
+		delay, err := residualMovieTicks(track, earliest, d.moov.Mvhd.Timescale)
+		if err != nil {
+			return fmt.Errorf("track %d: %w", track.trak.Tkhd.TrackID, err)
+		}
+		track.delay = delay
+		dropTrivialEdits(track, d.moov.Mvhd.Timescale)
+		if err := validateTrackEdits(track); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// dropTrivialEdits removes an identity edit list: a single entry presenting
+// the whole media from time 0 at rate 1.0, whose segment duration is zero or
+// exactly the presentation length. Any other segment duration trims the
+// media and stays. Alignment synthesizes its own edit list when needed.
+func dropTrivialEdits(track *defragTrack, movieTs uint32) {
+	trak := track.trak
+	if trak.Edts == nil || len(trak.Edts.Elst) != 1 || len(trak.Edts.Elst[0].Entries) != 1 {
+		return
+	}
+	entry := trak.Edts.Elst[0].Entries[0]
+	if entry.MediaTime != 0 || entry.MediaRateInteger != 1 || entry.MediaRateFraction != 0 {
+		return
+	}
+	presLen := rescaleDur(track.endDts-track.origin, trak.Mdia.Mdhd.Timescale, movieTs)
+	if entry.SegmentDuration != 0 && entry.SegmentDuration != presLen {
+		return
+	}
+	children := make([]Box, 0, len(trak.Children)-1)
+	for _, child := range trak.Children {
+		if child != Box(trak.Edts) {
+			children = append(children, child)
+		}
+	}
+	trak.Children = children
+	trak.Edts = nil
+}
+
+// originBefore tells whether track a starts before track b on the decode
+// timeline, comparing origin/timescale as exact rationals.
+func originBefore(a, b *defragTrack) bool {
+	hiA, loA := bits.Mul64(a.origin, uint64(b.trak.Mdia.Mdhd.Timescale))
+	hiB, loB := bits.Mul64(b.origin, uint64(a.trak.Mdia.Mdhd.Timescale))
+	return hiA < hiB || (hiA == hiB && loA < loB)
+}
+
+// residualMovieTicks converts the decode-time start of track relative to the
+// earliest track, origin/ts - minOrigin/minTs seconds, to movie timescale
+// ticks: round((origin*minTs - minOrigin*ts) * movieTs / (ts*minTs)).
+func residualMovieTicks(track, earliest *defragTrack, movieTs uint32) (uint64, error) {
+	if movieTs == 0 {
+		return 0, nil
+	}
+	ts := uint64(track.trak.Mdia.Mdhd.Timescale)
+	minTs := uint64(earliest.trak.Mdia.Mdhd.Timescale)
+	hiA, loA := bits.Mul64(track.origin, minTs)
+	hiB, loB := bits.Mul64(earliest.origin, ts)
+	lo, borrow := bits.Sub64(loA, loB, 0)
+	hi, _ := bits.Sub64(hiA, hiB, borrow) // nonnegative since earliest starts first
+	den := ts * minTs                     // no overflow: both timescales fit uint32
+	if hi >= den {
+		return 0, fmt.Errorf("start offset after the earliest track is too large to align")
+	}
+	secs, rem := bits.Div64(hi, lo, den)
+	// frac = round(rem*movieTs/den) < movieTs, so the 128-bit division fits.
+	hiF, loF := bits.Mul64(rem, uint64(movieTs))
+	loF, carry := bits.Add64(loF, den/2, 0)
+	frac, _ := bits.Div64(hiF+carry, loF, den)
+	if secs > (math.MaxUint64-frac)/uint64(movieTs) {
+		return 0, fmt.Errorf("start offset after the earliest track is too large to align")
+	}
+	return secs*uint64(movieTs) + frac, nil
+}
+
+// validateTrackEdits checks that every nonempty edit survives the origin
+// shift exactly: media times must stay at or after the origin, at the normal
+// rate 1.0. Empty edits pass through, but a leading one that will absorb the
+// alignment delay must not overflow.
+func validateTrackEdits(track *defragTrack) error {
+	if track.trak.Edts == nil {
+		return nil
+	}
+	trackID := track.trak.Tkhd.TrackID
+	for ei, elst := range track.trak.Edts.Elst {
+		for i, entry := range elst.Entries {
+			if entry.MediaTime == -1 {
+				if ei == 0 && i == 0 && entry.SegmentDuration > math.MaxUint64-track.delay {
+					return fmt.Errorf("track %d: leading empty edit cannot absorb the alignment delay", trackID)
+				}
+				continue
+			}
+			if entry.MediaTime < 0 {
+				return fmt.Errorf("track %d edit %d has unsupported media time %d",
+					trackID, i+1, entry.MediaTime)
+			}
+			if entry.MediaRateInteger != 1 || entry.MediaRateFraction != 0 {
+				return fmt.Errorf("track %d edit %d has unsupported media rate %d+%d/65536",
+					trackID, i+1, entry.MediaRateInteger, entry.MediaRateFraction)
+			}
+			if uint64(entry.MediaTime) < track.origin {
+				return fmt.Errorf("track %d edit %d media time %d is before decode origin %d",
+					trackID, i+1, entry.MediaTime, track.origin)
+			}
+		}
+	}
+	return nil
+}
+
+func (d *defragmenter) collectFragment(moof *MoofBox) error {
+	for _, traf := range moof.Trafs {
+		if traf.Tfhd == nil {
+			return fmt.Errorf("traf box in moof at %d lacks tfhd", moof.StartPos)
+		}
+		track, ok := d.byID[traf.Tfhd.TrackID]
+		if !ok {
+			return fmt.Errorf("moof at %d references track ID %d not present in moov",
+				moof.StartPos, traf.Tfhd.TrackID)
+		}
+		if !track.keep {
+			continue
+		}
+		if err := d.collectTraf(moof, traf, track); err != nil {
+			return fmt.Errorf("traf of track %d in moof at %d: %w", traf.Tfhd.TrackID, moof.StartPos, err)
+		}
+	}
+	return nil
+}
+
+func (d *defragmenter) collectTraf(moof *MoofBox, traf *TrafBox, track *defragTrack) error {
+	if traf.Senc != nil || traf.UUIDSenc != nil || traf.Saiz != nil || traf.Saio != nil {
+		return fmt.Errorf("encrypted (senc or saiz/saio) content cannot be defragmented")
+	}
+	tfhd := traf.Tfhd
+	if traf.Tfdt != nil {
+		declared := traf.Tfdt.BaseMediaDecodeTime()
+		switch {
+		case !track.started || len(track.samples) == 0:
+			track.started = true
+			track.origin = declared
+			track.endDts = declared
+		case declared < track.endDts:
+			return fmt.Errorf("tfdt %d is before the end %d of the previous samples", declared, track.endDts)
+		case declared > track.endDts:
+			// A forward tfdt gap extends the previous sample's duration.
+			gap := declared - track.endDts
+			last := &track.samples[len(track.samples)-1]
+			if gap > uint64(math.MaxUint32-last.dur) {
+				return fmt.Errorf("tfdt gap %d does not fit the previous sample duration", gap)
+			}
+			last.dur += uint32(gap)
+			track.endDts = declared
+		}
+	} else if !track.started {
+		track.started = true
+	}
+	baseOffset := int64(moof.StartPos)
+	switch {
+	case tfhd.HasBaseDataOffset():
+		if tfhd.BaseDataOffset > math.MaxInt64 {
+			return fmt.Errorf("base data offset %d too large", tfhd.BaseDataOffset)
+		}
+		baseOffset = int64(tfhd.BaseDataOffset)
+	case !tfhd.DefaultBaseIfMoof() && traf != moof.Trafs[0]:
+		// ISO/IEC 14496-12 Section 8.8.7: without base-data-offset or
+		// default-base-is-moof, the base offset of a traf that is not the
+		// first in its moof is the end of the previous traf's data, which
+		// is not derived here. Fail closed instead of misreading.
+		return fmt.Errorf("unsupported base data offset derivation: " +
+			"traf is neither first in its moof nor flagged with base-data-offset or default-base-is-moof")
+	}
+	sdi := tfhd.SampleDescriptionIndex
+	if !tfhd.HasSampleDescriptionIndex() || sdi == 0 {
+		sdi = 1
+		if track.trex != nil && track.trex.DefaultSampleDescriptionIndex != 0 {
+			sdi = track.trex.DefaultSampleDescriptionIndex
+		}
+	}
+	chunk := &defragChunk{track: track, sdi: sdi}
+	next := baseOffset
+	for _, trun := range traf.Truns {
+		trun.AddSampleDefaultValues(tfhd, track.trex)
+		runOffset := next
+		if trun.HasDataOffset() {
+			runOffset = baseOffset + int64(trun.DataOffset)
+		}
+		if runOffset < 0 {
+			return fmt.Errorf("trun data offset %d is before the file start", runOffset)
+		}
+		var runSize uint64
+		for _, s := range trun.Samples {
+			if uint64(s.Dur) > math.MaxUint64-track.endDts {
+				return fmt.Errorf("sample duration %d overflows the decode timeline at %d", s.Dur, track.endDts)
+			}
+			if uint64(s.Size) > math.MaxUint64-runSize {
+				return fmt.Errorf("sample size %d overflows the trun data size", s.Size)
+			}
+			// Sample.IsSync also requires sample_depends_on == 2, which many
+			// muxers leave at 0; only the explicit non-sync flag decides stss.
+			nonSync := DecodeSampleFlags(s.Flags).SampleIsNonSync
+			track.samples = append(track.samples, defragSample{
+				dur:     s.Dur,
+				size:    s.Size,
+				cts:     s.CompositionTimeOffset,
+				nonSync: nonSync,
+			})
+			track.endDts += uint64(s.Dur)
+			runSize += uint64(s.Size)
+		}
+		runStart := uint64(runOffset)
+		if runStart > d.fileSize || runSize > d.fileSize-runStart {
+			return fmt.Errorf("trun data at %d with %d bytes extends beyond the file end %d",
+				runOffset, runSize, d.fileSize)
+		}
+		chunk.addRange(runStart, runSize)
+		chunk.nrSamples += uint32(len(trun.Samples))
+		next = runOffset + int64(runSize)
+	}
+	if chunk.nrSamples > 0 {
+		track.chunks = append(track.chunks, chunk)
+		d.chunks = append(d.chunks, chunk)
+	}
+	return nil
+}
+
+func (d *defragmenter) writeProgressive(w io.Writer) error {
+	ftyp := NewFtyp("isom", 512, []string{"isom", "mp42"})
+	if d.ftyp != nil {
+		ftyp = progressiveFtyp(d.ftyp)
+	}
+	if err := d.rebuildMoov(); err != nil {
+		return err
+	}
+	payload := d.payloadSize
+	mdatHeaderSize := uint64(8)
+	if payload+8 > math.MaxUint32 {
+		mdatHeaderSize = 16
+	}
+	dataStart := ftyp.Size() + d.moov.Size() + mdatHeaderSize
+	if dataStart+payload > math.MaxUint32 {
+		d.switchToCo64()
+		// The moov grew when co64 replaced stco, so recompute dataStart.
+		dataStart = ftyp.Size() + d.moov.Size() + mdatHeaderSize
+	}
+	if err := d.assignChunkOffsets(dataStart); err != nil {
+		return err
+	}
+	if err := ftyp.Encode(w); err != nil {
+		return fmt.Errorf("could not encode ftyp: %w", err)
+	}
+	if err := d.moov.Encode(w); err != nil {
+		return fmt.Errorf("could not encode moov: %w", err)
+	}
+	if err := EncodeHeaderWithSize("mdat", payload+mdatHeaderSize, mdatHeaderSize == 16, w); err != nil {
+		return fmt.Errorf("could not encode mdat header: %w", err)
+	}
+	return d.copySampleData(w)
+}
+
+// fragmentFormatBrands are ftyp brands declaring a fragmented delivery
+// format (DASH segments, CMAF tracks/fragments/segments, Smooth Streaming,
+// PIFF, fragmented HLS), which a progressive file cannot conform to.
+var fragmentFormatBrands = map[string]bool{
+	"dash": true, "dsms": true, "msdh": true, "msix": true,
+	"sims": true, "lmsg": true, "cmfc": true, "cmf2": true,
+	"cmff": true, "cmfs": true, "isml": true, "piff": true,
+	"hlsf": true,
+}
+
+// progressiveFtyp rewrites the input ftyp for the progressive output:
+// fragment-format brands are dropped, a dropped major brand becomes isom,
+// and isom is ensured among the compatible brands. The structural version
+// brands iso2..iso6 declare ISOBMFF editions, not fragmentation, and stay.
+func progressiveFtyp(in *FtypBox) *FtypBox {
+	major := in.MajorBrand()
+	if fragmentFormatBrands[major] {
+		major = "isom"
+	}
+	inBrands := in.CompatibleBrands()
+	brands := make([]string, 0, len(inBrands)+1)
+	hasIsom := false
+	for _, brand := range inBrands {
+		if fragmentFormatBrands[brand] {
+			continue
+		}
+		if brand == "isom" {
+			hasIsom = true
+		}
+		brands = append(brands, brand)
+	}
+	if !hasIsom {
+		brands = append(brands, "isom")
+	}
+	return NewFtyp(major, in.MinorVersion(), brands)
+}
+
+// rebuildMoov drops the fragment structures and fills the sample tables of
+// the kept tracks, leaving all other moov content as decoded.
+func (d *defragmenter) rebuildMoov() error {
+	moov := d.moov
+	children := make([]Box, 0, len(moov.Children))
+	for _, child := range moov.Children {
+		switch box := child.(type) {
+		case *MvexBox:
+			continue
+		case *TrakBox:
+			if track, ok := d.byID[trakID(box)]; !ok || !track.keep {
+				continue
+			}
+		}
+		children = append(children, child)
+	}
+	moov.Children = children
+	moov.Mvex = nil
+	moov.Trak = nil
+	moov.Traks = nil
+	for _, child := range children {
+		if trak, ok := child.(*TrakBox); ok {
+			if moov.Trak == nil {
+				moov.Trak = trak
+			}
+			moov.Traks = append(moov.Traks, trak)
+		}
+	}
+	if len(moov.Traks) == 0 {
+		return fmt.Errorf("no tracks left to defragment")
+	}
+	var movieDur uint64
+	for _, track := range d.tracks {
+		if !track.keep {
+			continue
+		}
+		if err := fillSampleTables(track); err != nil {
+			return fmt.Errorf("sample tables of track %d: %w", track.trak.Tkhd.TrackID, err)
+		}
+		mediaDur := track.endDts - track.origin
+		rebaseTrackEdits(track, mediaDur, d.moov.Mvhd.Timescale)
+		mdhd := track.trak.Mdia.Mdhd
+		mdhd.Duration = mediaDur
+		if mediaDur > math.MaxUint32 {
+			mdhd.Version = 1
+		}
+		presDur := presentationDuration(track.trak, mediaDur, mdhd.Timescale, d.moov.Mvhd.Timescale)
+		track.trak.Tkhd.Duration = presDur
+		if presDur > math.MaxUint32 {
+			track.trak.Tkhd.Version = 1
+		}
+		if presDur > movieDur {
+			movieDur = presDur
+		}
+	}
+	d.moov.Mvhd.Duration = movieDur
+	if movieDur > math.MaxUint32 {
+		d.moov.Mvhd.Version = 1
+	}
+	return nil
+}
+
+// rebaseTrackEdits moves the track's edit list to the rebased media timeline
+// by shifting every nonempty media time down by the track's decode origin,
+// and records the track's alignment delay as an empty edit: merged into a
+// leading one, prepended, or as a synthesized edit list.
+func rebaseTrackEdits(track *defragTrack, mediaDur uint64, movieTs uint32) {
+	trak := track.trak
+	if trak.Edts != nil {
+		for _, elst := range trak.Edts.Elst {
+			for i := range elst.Entries {
+				entry := &elst.Entries[i]
+				if entry.MediaTime >= 0 {
+					entry.MediaTime -= int64(track.origin)
+				}
+			}
+		}
+	}
+	if track.delay > 0 {
+		emptyEdit := ElstEntry{SegmentDuration: track.delay, MediaTime: -1, MediaRateInteger: 1}
+		switch {
+		case trak.Edts == nil || len(trak.Edts.Elst) == 0:
+			elst := &ElstBox{Entries: []ElstEntry{
+				emptyEdit,
+				{SegmentDuration: rescaleDur(mediaDur, trak.Mdia.Mdhd.Timescale, movieTs),
+					MediaTime: 0, MediaRateInteger: 1},
+			}}
+			if trak.Edts == nil {
+				trak.insertEdts(&EdtsBox{})
+			}
+			trak.Edts.Elst = append(trak.Edts.Elst, elst)
+			trak.Edts.AddChild(elst)
+		case len(trak.Edts.Elst[0].Entries) > 0 && trak.Edts.Elst[0].Entries[0].MediaTime == -1:
+			trak.Edts.Elst[0].Entries[0].SegmentDuration += track.delay
+		default:
+			elst := trak.Edts.Elst[0]
+			elst.Entries = append([]ElstEntry{emptyEdit}, elst.Entries...)
+		}
+	}
+	if trak.Edts == nil {
+		return
+	}
+	// A final entry with segment_duration 0 means "rest of the media" in a
+	// fragmented file, whose mvhd duration is unknown (0). The progressive
+	// output has a real movie duration, so readers apply the edit literally
+	// and a zero-length final edit would hide the whole track. Resolve it the
+	// same way presentationDuration does.
+	if len(trak.Edts.Elst) > 0 {
+		elst := trak.Edts.Elst[0]
+		if n := len(elst.Entries); n > 0 {
+			last := &elst.Entries[n-1]
+			if last.SegmentDuration == 0 && last.MediaTime >= 0 && uint64(last.MediaTime) < mediaDur {
+				last.SegmentDuration = rescaleDur(mediaDur-uint64(last.MediaTime),
+					trak.Mdia.Mdhd.Timescale, movieTs)
+			}
+		}
+	}
+	for _, elst := range trak.Edts.Elst {
+		if elst.Version == 0 && elst.needs64Bits() {
+			elst.Version = 1
+		}
+	}
+}
+
+// presentationDuration returns the track presentation duration in movie
+// timescale: the total edit list duration when an edit list is present
+// (resolving a final zero segment duration against the media duration), and
+// the rescaled media duration otherwise.
+func presentationDuration(trak *TrakBox, mediaDur uint64, mediaTimescale, movieTimescale uint32) uint64 {
+	var elst *ElstBox
+	if trak.Edts != nil && len(trak.Edts.Elst) > 0 {
+		elst = trak.Edts.Elst[0]
+	}
+	if elst == nil || len(elst.Entries) == 0 {
+		return rescaleDur(mediaDur, mediaTimescale, movieTimescale)
+	}
+	var total uint64
+	for i, entry := range elst.Entries {
+		if entry.SegmentDuration == 0 && i == len(elst.Entries)-1 && entry.MediaTime >= 0 {
+			if uint64(entry.MediaTime) < mediaDur {
+				total += rescaleDur(mediaDur-uint64(entry.MediaTime), mediaTimescale, movieTimescale)
+			}
+			continue
+		}
+		total += entry.SegmentDuration
+	}
+	return total
+}
+
+// rescaleDur converts dur between timescales with rounding, without 64-bit
+// multiplication overflow for large durations.
+func rescaleDur(dur uint64, from, to uint32) uint64 {
+	if from == 0 || from == to {
+		return dur
+	}
+	quotient := dur / uint64(from)
+	remainder := dur % uint64(from)
+	return quotient*uint64(to) + (remainder*uint64(to)+uint64(from)/2)/uint64(from)
+}
+
+func trakID(trak *TrakBox) uint32 {
+	if trak.Tkhd == nil {
+		return 0
+	}
+	return trak.Tkhd.TrackID
+}
+
+func trackStbl(trak *TrakBox) *StblBox {
+	if trak.Mdia == nil || trak.Mdia.Minf == nil {
+		return nil
+	}
+	return trak.Mdia.Minf.Stbl
+}
+
+// fillSampleTables replaces the sample tables of the track's stbl box with
+// tables synthesized from the collected samples. The sample description box
+// (stsd) is kept as is.
+func fillSampleTables(track *defragTrack) error {
+	stbl := trackStbl(track.trak)
+	if stbl == nil || stbl.Stsd == nil {
+		return fmt.Errorf("no stbl or stsd box")
+	}
+	if uint64(len(track.samples)) > math.MaxUint32 {
+		return fmt.Errorf("%d samples do not fit a sample table", len(track.samples))
+	}
+	stts := buildStts(track.samples)
+	ctts, err := buildCtts(track.samples)
+	if err != nil {
+		return err
+	}
+	stsc, err := buildStsc(track.chunks)
+	if err != nil {
+		return err
+	}
+	stsz := buildStsz(track.samples)
+	stss := buildStss(track.samples)
+	stco := &StcoBox{ChunkOffset: make([]uint32, len(track.chunks))}
+
+	stbl.Stts = stts
+	stbl.Ctts = ctts
+	stbl.Stsc = stsc
+	stbl.Stsz = stsz
+	stbl.Stss = stss
+	stbl.Stco = stco
+	stbl.Co64 = nil
+	stbl.Sdtp = nil
+	stbl.Sbgp, stbl.Sbgps = nil, nil
+	stbl.Sgpd, stbl.Sgpds = nil, nil
+	stbl.Subs = nil
+	stbl.Saio = nil
+	stbl.Saiz = nil
+	children := []Box{stbl.Stsd, stts}
+	if ctts != nil {
+		children = append(children, ctts)
+	}
+	children = append(children, stsc, stsz)
+	if stss != nil {
+		children = append(children, stss)
+	}
+	children = append(children, stco)
+	stbl.Children = children
+	return nil
+}
+
+// buildStts run-length encodes the sample durations.
+func buildStts(samples []defragSample) *SttsBox {
+	stts := &SttsBox{}
+	for _, s := range samples {
+		if n := len(stts.SampleCount); n > 0 && stts.SampleTimeDelta[n-1] == s.dur {
+			stts.SampleCount[n-1]++
+			continue
+		}
+		stts.SampleCount = append(stts.SampleCount, 1)
+		stts.SampleTimeDelta = append(stts.SampleTimeDelta, s.dur)
+	}
+	return stts
+}
+
+// buildCtts run-length encodes the composition time offsets: nil when every
+// offset is zero, version 1 when some offset is negative.
+func buildCtts(samples []defragSample) (*CttsBox, error) {
+	ctts := &CttsBox{}
+	var counts []uint32
+	var offsets []int32
+	anyCts := false
+	for _, s := range samples {
+		if s.cts != 0 {
+			anyCts = true
+		}
+		if s.cts < 0 {
+			ctts.Version = 1
+		}
+		if n := len(offsets); n > 0 && offsets[n-1] == s.cts {
+			counts[n-1]++
+			continue
+		}
+		counts = append(counts, 1)
+		offsets = append(offsets, s.cts)
+	}
+	if !anyCts {
+		return nil, nil
+	}
+	if err := ctts.AddSampleCountsAndOffset(counts, offsets); err != nil {
+		return nil, err
+	}
+	return ctts, nil
+}
+
+// buildStsc run-length encodes the per-chunk sample counts and sample
+// description IDs, with one output chunk per input chunk.
+func buildStsc(chunks []*defragChunk) (*StscBox, error) {
+	stsc := &StscBox{}
+	var lastSdi uint32
+	for i, chunk := range chunks {
+		if n := len(stsc.Entries); n > 0 &&
+			stsc.Entries[n-1].SamplesPerChunk == chunk.nrSamples && lastSdi == chunk.sdi {
+			continue
+		}
+		if err := stsc.AddEntry(uint32(i+1), chunk.nrSamples, chunk.sdi); err != nil {
+			return nil, err
+		}
+		lastSdi = chunk.sdi
+	}
+	return stsc, nil
+}
+
+// buildStsz uses the compact uniform-size form when every sample has the
+// same nonzero size.
+func buildStsz(samples []defragSample) *StszBox {
+	stsz := &StszBox{SampleNumber: uint32(len(samples))}
+	uniform := len(samples) > 0
+	for _, s := range samples {
+		if s.size != samples[0].size || s.size == 0 {
+			uniform = false
+			break
+		}
+	}
+	if uniform {
+		stsz.SampleUniformSize = samples[0].size
+		return stsz
+	}
+	stsz.SampleSize = make([]uint32, len(samples))
+	for i, s := range samples {
+		stsz.SampleSize[i] = s.size
+	}
+	return stsz
+}
+
+// buildStss lists the sync samples: nil when every sample is sync, since a
+// missing stss means exactly that.
+func buildStss(samples []defragSample) *StssBox {
+	stss := &StssBox{}
+	for i, s := range samples {
+		if !s.nonSync {
+			stss.SampleNumber = append(stss.SampleNumber, uint32(i+1))
+		}
+	}
+	if len(stss.SampleNumber) == len(samples) {
+		return nil
+	}
+	return stss
+}
+
+// switchToCo64 replaces every stco box with a co64 box for 64-bit offsets.
+func (d *defragmenter) switchToCo64() {
+	for _, track := range d.tracks {
+		if !track.keep {
+			continue
+		}
+		stbl := trackStbl(track.trak)
+		co64 := &Co64Box{ChunkOffset: make([]uint64, len(track.chunks))}
+		for i, child := range stbl.Children {
+			if child == Box(stbl.Stco) {
+				stbl.Children[i] = co64
+			}
+		}
+		stbl.Stco = nil
+		stbl.Co64 = co64
+	}
+}
+
+func (d *defragmenter) assignChunkOffsets(dataStart uint64) error {
+	perTrackChunkNr := make(map[*defragTrack]int)
+	offset := dataStart
+	for _, chunk := range d.chunks {
+		chunk.offset = offset
+		offset += chunk.size
+		track := chunk.track
+		nr := perTrackChunkNr[track]
+		stbl := trackStbl(track.trak)
+		if stbl.Stco != nil {
+			if chunk.offset > math.MaxUint32 {
+				return fmt.Errorf("chunk offset %d does not fit stco", chunk.offset)
+			}
+			stbl.Stco.ChunkOffset[nr] = uint32(chunk.offset)
+		} else {
+			stbl.Co64.ChunkOffset[nr] = chunk.offset
+		}
+		perTrackChunkNr[track] = nr + 1
+	}
+	return nil
+}
+
+func (d *defragmenter) copySampleData(w io.Writer) error {
+	buf := make([]byte, 1024*1024)
+	for _, chunk := range d.chunks {
+		for _, r := range chunk.ranges {
+			if _, err := d.rs.Seek(int64(r.offset), io.SeekStart); err != nil {
+				return fmt.Errorf("could not seek to sample data at %d: %w", r.offset, err)
+			}
+			n, err := io.CopyBuffer(w, io.LimitReader(d.rs, int64(r.size)), buf)
+			if err != nil {
+				return fmt.Errorf("could not copy sample data at %d: %w", r.offset, err)
+			}
+			if uint64(n) != r.size {
+				return fmt.Errorf("sample data at %d truncated after %d of %d bytes", r.offset, n, r.size)
+			}
+		}
+	}
+	return nil
+}

--- a/mp4/defragmenter_test.go
+++ b/mp4/defragmenter_test.go
@@ -1,0 +1,1289 @@
+package mp4_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/mp4"
+	"github.com/go-test/deep"
+)
+
+const (
+	defragVideoTimescale = 15360
+	defragAudioTimescale = 44100
+)
+
+var defragVideoElstEntries = []mp4.ElstEntry{
+	{SegmentDuration: 600, MediaTime: 1024, MediaRateInteger: 1},
+	{SegmentDuration: 0, MediaTime: 2048, MediaRateInteger: 1},
+}
+
+// defragVideoElstWant is defragVideoElstEntries after defragmentation: the
+// final entry's zero segment duration (the fragmented-file "rest of the
+// media" idiom, where mvhd duration is unknown) is resolved against the real
+// media duration of the progressive output, since progressive readers apply
+// a zero-length final edit literally and would hide the track.
+var defragVideoElstWant = []mp4.ElstEntry{
+	{SegmentDuration: 600, MediaTime: 1024, MediaRateInteger: 1},
+	{SegmentDuration: 20, MediaTime: 2048, MediaRateInteger: 1},
+}
+
+func createDefragInit(t *testing.T) *mp4.InitSegment {
+	t.Helper()
+	init := mp4.CreateEmptyInit()
+	init.Moov.Mvhd.Timescale = 600
+	videoTrak := init.AddEmptyTrack(defragVideoTimescale, "video", "und")
+	sps, _ := hex.DecodeString(sps1nalu)
+	pps, _ := hex.DecodeString(pps1nalu)
+	if err := videoTrak.SetAVCDescriptor("avc1", [][]byte{sps}, [][]byte{pps}, true); err != nil {
+		t.Fatal(err)
+	}
+	edts := &mp4.EdtsBox{}
+	edts.AddChild(&mp4.ElstBox{Entries: append([]mp4.ElstEntry{}, defragVideoElstEntries...)})
+	videoTrak.AddChild(edts)
+	audioTrak := init.AddEmptyTrack(defragAudioTimescale, "audio", "eng")
+	if err := audioTrak.SetAACDescriptor(2, defragAudioTimescale); err != nil {
+		t.Fatal(err)
+	}
+	return init
+}
+
+func createDefragPlainAvInit(t *testing.T) *mp4.InitSegment {
+	t.Helper()
+	init := mp4.CreateEmptyInit()
+	init.Moov.Mvhd.Timescale = 600
+	init.AddEmptyTrack(defragVideoTimescale, "video", "und")
+	init.AddEmptyTrack(defragAudioTimescale, "audio", "und")
+	return init
+}
+
+func defragSyncFlags() uint32 {
+	return mp4.SampleFlags{SampleDependsOn: 2}.Encode()
+}
+
+func defragNonSyncFlags() uint32 {
+	return mp4.SampleFlags{SampleDependsOn: 1, SampleIsNonSync: true}.Encode()
+}
+
+func defragPayload(tag byte, size int) []byte {
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = tag + byte(i)
+	}
+	return payload
+}
+
+func addDefragFragment(t *testing.T, w *bytes.Buffer, seqNr, trackID uint32, samples []mp4.FullSample) {
+	t.Helper()
+	frag, err := mp4.CreateFragment(seqNr, trackID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range samples {
+		frag.AddFullSample(s)
+	}
+	if err := frag.Encode(w); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// defragment decodes data as a lazy-mdat mp4 file and defragments it,
+// keeping the given track IDs (all tracks when none are given).
+func defragment(t *testing.T, data []byte, trackIDs ...uint32) (*bytes.Buffer, error) {
+	t.Helper()
+	rs := bytes.NewReader(data)
+	f, err := mp4.DecodeFile(rs, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if len(trackIDs) == 0 {
+		err = mp4.Defragment(f, rs, &out)
+	} else {
+		err = mp4.DefragmentTracks(f, rs, &out, trackIDs...)
+	}
+	return &out, err
+}
+
+// writeDefragTestFile writes a fragmented file with a video and an audio
+// track and returns the file bytes and the expected per-track samples.
+func writeDefragTestFile(t *testing.T) (data []byte, videoSamples, audioSamples []mp4.FullSample) {
+	t.Helper()
+	var buf bytes.Buffer
+	init := createDefragInit(t)
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	videoSamples = []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 100, CompositionTimeOffset: 1024},
+			DecodeTime: 0, Data: defragPayload(1, 100)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 90, CompositionTimeOffset: -512},
+			DecodeTime: 512, Data: defragPayload(2, 90)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 80, CompositionTimeOffset: 512},
+			DecodeTime: 1024, Data: defragPayload(3, 80)},
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 110, CompositionTimeOffset: 0},
+			DecodeTime: 1536, Data: defragPayload(4, 110)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 70, CompositionTimeOffset: 0},
+			DecodeTime: 2048, Data: defragPayload(5, 70)},
+	}
+	audioSamples = []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1024, Size: 40}, DecodeTime: 0, Data: defragPayload(6, 40)},
+		{Sample: mp4.Sample{Dur: 1024, Size: 40}, DecodeTime: 1024, Data: defragPayload(7, 40)},
+		{Sample: mp4.Sample{Dur: 1024, Size: 40}, DecodeTime: 2048, Data: defragPayload(8, 40)},
+	}
+	addDefragFragment(t, &buf, 1, 1, videoSamples[:3])
+	addDefragFragment(t, &buf, 2, 2, audioSamples)
+	addDefragFragment(t, &buf, 3, 1, videoSamples[3:])
+	return buf.Bytes(), videoSamples, audioSamples
+}
+
+func decodeDefragOutput(t *testing.T, data []byte) *mp4.File {
+	t.Helper()
+	outFile, err := mp4.DecodeFile(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("could not decode defragmented output: %v", err)
+	}
+	if outFile.IsFragmented() {
+		t.Fatal("defragmented output is still fragmented")
+	}
+	return outFile
+}
+
+// readProgressiveSampleData returns the concatenated sample data of a track
+// in a progressive file, read chunk by chunk via the sample tables.
+func readProgressiveSampleData(t *testing.T, file *mp4.File, trackID uint32) []byte {
+	t.Helper()
+	var trak *mp4.TrakBox
+	for _, candidate := range file.Moov.Traks {
+		if candidate.Tkhd.TrackID == trackID {
+			trak = candidate
+		}
+	}
+	if trak == nil {
+		t.Fatalf("track %d not found", trackID)
+	}
+	nrSamples := trak.GetNrSamples()
+	if nrSamples == 0 {
+		return nil
+	}
+	ranges, err := trak.GetRangesForSampleInterval(1, nrSamples)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var data []byte
+	mdatStart := file.Mdat.PayloadAbsoluteOffset()
+	for _, r := range ranges {
+		if r.Offset < mdatStart || r.Offset+r.Size > mdatStart+uint64(len(file.Mdat.Data)) {
+			t.Fatalf("sample range [%d, %d) outside mdat", r.Offset, r.Offset+r.Size)
+		}
+		data = append(data, file.Mdat.Data[r.Offset-mdatStart:r.Offset-mdatStart+r.Size]...)
+	}
+	return data
+}
+
+func concatSampleData(samples []mp4.FullSample) []byte {
+	var data []byte
+	for _, s := range samples {
+		data = append(data, s.Data...)
+	}
+	return data
+}
+
+func TestDefragmentRoundTrip(t *testing.T) {
+	data, videoSamples, audioSamples := writeDefragTestFile(t)
+	out, err := defragment(t, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	if len(outFile.Children) != 3 {
+		t.Errorf("got %d top-level boxes, want ftyp + moov + mdat", len(outFile.Children))
+	}
+	moov := outFile.Moov
+	if moov.Mvex != nil {
+		t.Error("mvex not removed")
+	}
+	if moov.Mvhd.Timescale != 600 {
+		t.Errorf("movie timescale %d, want the original 600", moov.Mvhd.Timescale)
+	}
+	if len(moov.Traks) != 2 {
+		t.Fatalf("got %d tracks, want 2", len(moov.Traks))
+	}
+	videoTrak, audioTrak := moov.Traks[0], moov.Traks[1]
+	if videoTrak.Mdia.Mdhd.Timescale != defragVideoTimescale {
+		t.Errorf("video timescale %d, want the original %d", videoTrak.Mdia.Mdhd.Timescale, defragVideoTimescale)
+	}
+	if audioTrak.Mdia.Mdhd.Timescale != defragAudioTimescale {
+		t.Errorf("audio timescale %d, want the original %d", audioTrak.Mdia.Mdhd.Timescale, defragAudioTimescale)
+	}
+	if videoTrak.Edts == nil || len(videoTrak.Edts.Elst) != 1 {
+		t.Fatal("video elst not preserved")
+	}
+	if diff := deep.Equal(videoTrak.Edts.Elst[0].Entries, defragVideoElstWant); diff != nil {
+		t.Errorf("video elst entries changed: %v", diff)
+	}
+	if audioTrak.Edts != nil {
+		t.Error("audio track without elst got an edts box")
+	}
+
+	videoStbl := videoTrak.Mdia.Minf.Stbl
+	if diff := deep.Equal(videoStbl.Stts, &mp4.SttsBox{
+		SampleCount: []uint32{5}, SampleTimeDelta: []uint32{512},
+	}); diff != nil {
+		t.Errorf("video stts: %v", diff)
+	}
+	if videoStbl.Ctts == nil || videoStbl.Ctts.Version != 1 {
+		t.Fatalf("video ctts %v, want version 1 for negative offsets", videoStbl.Ctts)
+	}
+	for i, s := range videoSamples {
+		if got := videoStbl.Ctts.GetCompositionTimeOffset(uint32(i + 1)); got != s.CompositionTimeOffset {
+			t.Errorf("video sample %d composition offset %d, want %d", i+1, got, s.CompositionTimeOffset)
+		}
+	}
+	if videoStbl.Stss == nil || deep.Equal(videoStbl.Stss.SampleNumber, []uint32{1, 4}) != nil {
+		t.Errorf("video stss %v, want sync samples 1 and 4", videoStbl.Stss)
+	}
+	wantVideoSizes := []uint32{100, 90, 80, 110, 70}
+	for i, want := range wantVideoSizes {
+		if got := videoStbl.Stsz.GetSampleSize(i + 1); got != want {
+			t.Errorf("video sample %d size %d, want %d", i+1, got, want)
+		}
+	}
+	if len(videoStbl.Stco.ChunkOffset) != 2 {
+		t.Errorf("video has %d chunks, want one per fragment (2)", len(videoStbl.Stco.ChunkOffset))
+	}
+	if videoTrak.Mdia.Mdhd.Duration != 5*512 {
+		t.Errorf("video mdhd duration %d, want %d", videoTrak.Mdia.Mdhd.Duration, 5*512)
+	}
+	// elst-derived: 600 + rest of media from mediaTime 2048 (512 ticks -> 20)
+	if videoTrak.Tkhd.Duration != 620 {
+		t.Errorf("video tkhd duration %d, want 620", videoTrak.Tkhd.Duration)
+	}
+
+	audioStbl := audioTrak.Mdia.Minf.Stbl
+	if audioStbl.Ctts != nil {
+		t.Error("audio track without composition offsets got a ctts box")
+	}
+	if audioStbl.Stss != nil {
+		t.Error("audio track with only sync samples got an stss box")
+	}
+	if audioStbl.Stsz.SampleUniformSize != 40 || audioStbl.Stsz.SampleNumber != 3 {
+		t.Errorf("audio stsz uniform size %d over %d samples, want 40 over 3",
+			audioStbl.Stsz.SampleUniformSize, audioStbl.Stsz.SampleNumber)
+	}
+	if audioTrak.Mdia.Mdhd.Duration != 3*1024 {
+		t.Errorf("audio mdhd duration %d, want %d", audioTrak.Mdia.Mdhd.Duration, 3*1024)
+	}
+	// no elst: media duration rescaled to movie timescale (3*1024/44100*600)
+	if audioTrak.Tkhd.Duration != 42 {
+		t.Errorf("audio tkhd duration %d, want 42", audioTrak.Tkhd.Duration)
+	}
+	if moov.Mvhd.Duration != 620 {
+		t.Errorf("movie duration %d, want the longest track's 620", moov.Mvhd.Duration)
+	}
+
+	if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, concatSampleData(videoSamples)) {
+		t.Error("video sample data not byte-identical")
+	}
+	if got := readProgressiveSampleData(t, outFile, 2); !bytes.Equal(got, concatSampleData(audioSamples)) {
+		t.Error("audio sample data not byte-identical")
+	}
+}
+
+func TestDefragmentTracks(t *testing.T) {
+	data, videoSamples, _ := writeDefragTestFile(t)
+	out, err := defragment(t, data, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	if len(outFile.Moov.Traks) != 1 || outFile.Moov.Traks[0].Tkhd.TrackID != 1 {
+		t.Fatalf("got %d tracks, want only track 1", len(outFile.Moov.Traks))
+	}
+	videoData := concatSampleData(videoSamples)
+	if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, videoData) {
+		t.Error("video sample data not byte-identical")
+	}
+	if uint64(len(outFile.Mdat.Data)) != uint64(len(videoData)) {
+		t.Errorf("mdat has %d bytes, want only the %d video bytes", len(outFile.Mdat.Data), len(videoData))
+	}
+
+	if _, err := defragment(t, data, 5); err == nil ||
+		!strings.Contains(err.Error(), "track ID 5 not found") {
+		t.Errorf("unknown track ID error %v", err)
+	}
+	rs := bytes.NewReader(data)
+	f, err := mp4.DecodeFile(rs, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mp4.DefragmentTracks(f, rs, &bytes.Buffer{}); err == nil {
+		t.Error("no track IDs given must be an error")
+	}
+}
+
+func TestDefragmentTfdtGapExtendsPreviousSampleDuration(t *testing.T) {
+	var buf bytes.Buffer
+	init := createDefragInit(t)
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	first := []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 0, Data: defragPayload(1, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 512, Data: defragPayload(2, 10)},
+	}
+	second := []mp4.FullSample{
+		// 256 ticks after the end of the previous fragment.
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1280, Data: defragPayload(3, 10)},
+	}
+	addDefragFragment(t, &buf, 1, 1, first)
+	addDefragFragment(t, &buf, 2, 1, second)
+	out, err := defragment(t, buf.Bytes(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	stts := outFile.Moov.Trak.Mdia.Minf.Stbl.Stts
+	if diff := deep.Equal(stts, &mp4.SttsBox{
+		SampleCount:     []uint32{1, 1, 1},
+		SampleTimeDelta: []uint32{512, 768, 512},
+	}); diff != nil {
+		t.Errorf("stts with tfdt gap: %v", diff)
+	}
+	if dur := outFile.Moov.Trak.Mdia.Mdhd.Duration; dur != 1792 {
+		t.Errorf("media duration %d, want 1792 including the gap", dur)
+	}
+}
+
+func TestDefragmentBackwardsTfdtIsError(t *testing.T) {
+	tests := []struct {
+		name      string
+		videoTfdt []uint64
+		audio     bool
+	}{
+		{name: "backwards tfdt", videoTfdt: []uint64{0, 256}},
+		{name: "repeated overlap", videoTfdt: []uint64{0, 460, 907}},
+		{name: "video overlap with monotone audio", videoTfdt: []uint64{0, 256}, audio: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			init := createDefragPlainAvInit(t)
+			var buf bytes.Buffer
+			if err := init.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			seqNr := uint32(1)
+			for i, tfdt := range test.videoTfdt {
+				addDefragFragment(t, &buf, seqNr, 1, []mp4.FullSample{
+					{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10},
+						DecodeTime: tfdt, Data: defragPayload(byte(i+1), 10)},
+				})
+				seqNr++
+			}
+			if test.audio {
+				for i, tfdt := range []uint64{0, 1024} {
+					addDefragFragment(t, &buf, seqNr, 2, []mp4.FullSample{
+						{Sample: mp4.Sample{Dur: 1024, Size: 10}, DecodeTime: tfdt, Data: defragPayload(byte(i+10), 10)},
+					})
+					seqNr++
+				}
+			}
+			_, err := defragment(t, buf.Bytes())
+			if err == nil || !strings.Contains(err.Error(), "before the end") {
+				t.Errorf("overlapping tfdt error %v", err)
+			}
+		})
+	}
+}
+
+func TestDefragmentDecodeTimelineOverflowIsError(t *testing.T) {
+	var buf bytes.Buffer
+	init := createDefragPlainAvInit(t)
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 1, Size: 8}, DecodeTime: math.MaxUint64, Data: defragPayload(1, 8)},
+	})
+	out, err := defragment(t, buf.Bytes(), 1)
+	if err == nil || !strings.Contains(err.Error(), "overflows the decode timeline") {
+		t.Errorf("decode timeline overflow error %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("wrote %d bytes before rejecting input", out.Len())
+	}
+}
+
+func TestDefragmentTrunDataBeyondFileEndIsError(t *testing.T) {
+	var buf bytes.Buffer
+	init := createDefragInit(t)
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	// A moof declaring sample data without any mdat carrying it.
+	moof := &mp4.MoofBox{}
+	_ = moof.AddChild(mp4.CreateMfhd(1))
+	traf := &mp4.TrafBox{}
+	_ = moof.AddChild(traf)
+	_ = traf.AddChild(mp4.CreateTfhd(1))
+	_ = traf.AddChild(mp4.CreateTfdt(0))
+	trun := mp4.CreateTrun(0)
+	trun.AddSample(mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 1000})
+	_ = traf.AddChild(trun)
+	trun.DataOffset = int32(moof.Size() + 8)
+	if err := moof.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	_, err := defragment(t, buf.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "beyond the file end") {
+		t.Errorf("trun data beyond file end error %v", err)
+	}
+}
+
+func TestDefragmentEncryptedTrackIsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		addBoxes func(traf *mp4.TrafBox)
+	}{
+		{name: "senc", addBoxes: func(traf *mp4.TrafBox) {
+			_ = traf.AddChild(&mp4.SencBox{})
+		}},
+		{name: "senc-less saiz and saio", addBoxes: func(traf *mp4.TrafBox) {
+			_ = traf.AddChild(&mp4.SaizBox{DefaultSampleInfoSize: 8, SampleCount: 1})
+			_ = traf.AddChild(&mp4.SaioBox{Offset: []int64{0}})
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			init := createDefragInit(t)
+			if err := init.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			frag, err := mp4.CreateFragment(1, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			frag.AddFullSample(mp4.FullSample{
+				Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 0, Data: defragPayload(1, 10),
+			})
+			test.addBoxes(frag.Moof.Traf)
+			if err := frag.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			_, err = defragment(t, buf.Bytes())
+			if err == nil || !strings.Contains(err.Error(), "encrypted") {
+				t.Errorf("encrypted content error %v", err)
+			}
+		})
+	}
+}
+
+func TestDefragmentProgressiveInputIsError(t *testing.T) {
+	data, _, _ := writeDefragTestFile(t)
+	progressive, err := defragment(t, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = defragment(t, progressive.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "not fragmented") {
+		t.Errorf("progressive input error %v", err)
+	}
+}
+
+func TestDefragmentHybridInputIsError(t *testing.T) {
+	init := createDefragInit(t)
+	// A progressive prefix: the video sample tables already declare a sample.
+	stbl := init.Moov.Traks[0].Mdia.Minf.Stbl
+	stbl.Stsz.SampleNumber = 1
+	stbl.Stsz.SampleSize = []uint32{10}
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 2, []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1024, Size: 8}, DecodeTime: 0, Data: defragPayload(1, 8)},
+	})
+	_, err := defragment(t, buf.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "progressive samples") {
+		t.Errorf("hybrid input error %v", err)
+	}
+	// The hybrid track is accepted when it is not kept.
+	if _, err := defragment(t, buf.Bytes(), 2); err != nil {
+		t.Errorf("dropping the hybrid track: %v", err)
+	}
+}
+
+// TestDefragmentTrackWithoutSamplesIsError pins that a kept track without
+// samples is rejected: its 0-entry stts would classify the output as
+// fragmented on decode. Dropping the track via track selection works.
+func TestDefragmentTrackWithoutSamplesIsError(t *testing.T) {
+	var buf bytes.Buffer
+	init := createDefragInit(t)
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	initOnly := append([]byte{}, buf.Bytes()...)
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 0, Data: defragPayload(1, 10)},
+	})
+	_, err := defragment(t, buf.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "track 2 has no samples") {
+		t.Errorf("fragment-less audio track error %v", err)
+	}
+	if _, err := defragment(t, buf.Bytes(), 1); err != nil {
+		t.Errorf("dropping the fragment-less track: %v", err)
+	}
+	_, err = defragment(t, initOnly)
+	if err == nil || !strings.Contains(err.Error(), "has no samples") {
+		t.Errorf("init-only input error %v", err)
+	}
+}
+
+func TestDefragmentDefaultsAndFirstSampleFlags(t *testing.T) {
+	var buf bytes.Buffer
+	init := createDefragInit(t)
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	moof := &mp4.MoofBox{}
+	_ = moof.AddChild(mp4.CreateMfhd(1))
+	traf := &mp4.TrafBox{}
+	_ = moof.AddChild(traf)
+	tfhd := mp4.CreateTfhd(1)
+	tfhd.Flags |= 0x08 | 0x10 | 0x20 // default duration, size and flags present
+	tfhd.DefaultSampleDuration = 512
+	tfhd.DefaultSampleSize = 25
+	tfhd.DefaultSampleFlags = defragNonSyncFlags()
+	_ = traf.AddChild(tfhd)
+	_ = traf.AddChild(mp4.CreateTfdt(0))
+	trun := &mp4.TrunBox{Flags: mp4.TrunDataOffsetPresentFlag}
+	trun.SetFirstSampleFlags(defragSyncFlags())
+	trun.AddSamples(make([]mp4.Sample, 3))
+	_ = traf.AddChild(trun)
+	secondTrun := &mp4.TrunBox{} // no data offset: continues after the first trun
+	secondTrun.AddSamples(make([]mp4.Sample, 2))
+	_ = traf.AddChild(secondTrun)
+	trun.DataOffset = int32(moof.Size() + 8)
+	if err := moof.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	payload := defragPayload(1, 5*25)
+	mdat := &mp4.MdatBox{Data: payload}
+	if err := mdat.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := defragment(t, buf.Bytes(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	stbl := outFile.Moov.Trak.Mdia.Minf.Stbl
+	if diff := deep.Equal(stbl.Stts, &mp4.SttsBox{
+		SampleCount: []uint32{5}, SampleTimeDelta: []uint32{512},
+	}); diff != nil {
+		t.Errorf("stts from tfhd defaults: %v", diff)
+	}
+	if stbl.Stsz.SampleUniformSize != 25 || stbl.Stsz.SampleNumber != 5 {
+		t.Errorf("stsz uniform size %d over %d samples, want 25 over 5",
+			stbl.Stsz.SampleUniformSize, stbl.Stsz.SampleNumber)
+	}
+	if stbl.Stss == nil || deep.Equal(stbl.Stss.SampleNumber, []uint32{1}) != nil {
+		t.Errorf("stss %v, want only sample 1 sync via first-sample flags", stbl.Stss)
+	}
+	if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, payload) {
+		t.Error("sample data not byte-identical")
+	}
+}
+
+func TestDefragmentMissingMvhdIsError(t *testing.T) {
+	init := createDefragPlainAvInit(t)
+	moov := init.Moov
+	moov.Mvhd = nil
+	children := make([]mp4.Box, 0, len(moov.Children))
+	for _, child := range moov.Children {
+		if _, isMvhd := child.(*mp4.MvhdBox); isMvhd {
+			continue
+		}
+		children = append(children, child)
+	}
+	moov.Children = children
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 8}, DecodeTime: 0, Data: defragPayload(1, 8)},
+	})
+	_, err := defragment(t, buf.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "lacks mvhd") {
+		t.Errorf("missing mvhd error %v", err)
+	}
+}
+
+func TestDefragmentCommonNonzeroOriginRebase(t *testing.T) {
+	init := createDefragPlainAvInit(t)
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	// Both tracks start one second in, so no cross-track delay is needed.
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10},
+			DecodeTime: defragVideoTimescale, Data: defragPayload(1, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10},
+			DecodeTime: defragVideoTimescale + 512, Data: defragPayload(2, 10)},
+	})
+	addDefragFragment(t, &buf, 2, 2, []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1024, Size: 10}, DecodeTime: defragAudioTimescale, Data: defragPayload(3, 10)},
+		{Sample: mp4.Sample{Dur: 1024, Size: 10}, DecodeTime: defragAudioTimescale + 1024, Data: defragPayload(4, 10)},
+	})
+	out, err := defragment(t, buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	if dur := outFile.Moov.Traks[0].Mdia.Mdhd.Duration; dur != 2*512 {
+		t.Errorf("video media duration %d, want %d (origin rebased away)", dur, 2*512)
+	}
+	if dur := outFile.Moov.Traks[1].Mdia.Mdhd.Duration; dur != 2*1024 {
+		t.Errorf("audio media duration %d, want %d (origin rebased away)", dur, 2*1024)
+	}
+	for i, trak := range outFile.Moov.Traks {
+		if trak.Edts != nil {
+			t.Errorf("track %d with a shared origin got an edts box", i+1)
+		}
+	}
+}
+
+func TestDefragmentElstWithNonzeroOriginRebasesExactly(t *testing.T) {
+	init := createDefragInit(t)
+	elst := init.Moov.Traks[0].Edts.Children[0].(*mp4.ElstBox)
+	elst.Entries = []mp4.ElstEntry{
+		{SegmentDuration: 77, MediaTime: -1, MediaRateInteger: 9, MediaRateFraction: 11},
+		{SegmentDuration: 600, MediaTime: 2048, MediaRateInteger: 1},
+		{SegmentDuration: 0, MediaTime: 2560, MediaRateInteger: 1},
+	}
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	samples := []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1024, Data: defragPayload(1, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1536, Data: defragPayload(2, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 2048, Data: defragPayload(3, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 2560, Data: defragPayload(4, 10)},
+	}
+	addDefragFragment(t, &buf, 1, 1, samples[:2])
+	addDefragFragment(t, &buf, 2, 1, samples[2:])
+
+	out, err := defragment(t, buf.Bytes(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	trak := outFile.Moov.Traks[0]
+	if diff := deep.Equal(trak.Mdia.Minf.Stbl.Stts, &mp4.SttsBox{
+		SampleCount: []uint32{4}, SampleTimeDelta: []uint32{512},
+	}); diff != nil {
+		t.Errorf("stts after tfdt rebase: %v", diff)
+	}
+	if trak.Mdia.Mdhd.Duration != 2048 {
+		t.Errorf("media duration %d, want 2048", trak.Mdia.Mdhd.Duration)
+	}
+	wantElst := []mp4.ElstEntry{
+		{SegmentDuration: 77, MediaTime: -1, MediaRateInteger: 9, MediaRateFraction: 11},
+		{SegmentDuration: 600, MediaTime: 1024, MediaRateInteger: 1},
+		{SegmentDuration: 20, MediaTime: 1536, MediaRateInteger: 1},
+	}
+	if diff := deep.Equal(trak.Edts.Elst[0].Entries, wantElst); diff != nil {
+		t.Errorf("rebased elst: %v", diff)
+	}
+	if trak.Tkhd.Duration != 697 {
+		t.Errorf("presentation duration %d, want 697", trak.Tkhd.Duration)
+	}
+	if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, concatSampleData(samples)) {
+		t.Error("sample data not byte-identical")
+	}
+}
+
+func TestDefragmentMultiTrackNonzeroOriginsRebaseInTrackTicks(t *testing.T) {
+	init := createDefragPlainAvInit(t)
+	for i, trak := range init.Moov.Traks {
+		edts := &mp4.EdtsBox{}
+		origin := []int64{512, 1470}[i]
+		edts.AddChild(&mp4.ElstBox{Entries: []mp4.ElstEntry{
+			{SegmentDuration: 20, MediaTime: -1, MediaRateInteger: 0},
+			{SegmentDuration: 0, MediaTime: origin * 3, MediaRateInteger: 1},
+		}})
+		trak.AddChild(edts)
+	}
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	// 512/15360 and 1470/44100 are the same origin (1/30 s) in seconds.
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 512, Data: defragPayload(1, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1024, Data: defragPayload(2, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1536, Data: defragPayload(3, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 2048, Data: defragPayload(4, 10)},
+	})
+	addDefragFragment(t, &buf, 2, 2, []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1470, Size: 10}, DecodeTime: 1470, Data: defragPayload(5, 10)},
+		{Sample: mp4.Sample{Dur: 1470, Size: 10}, DecodeTime: 2940, Data: defragPayload(6, 10)},
+		{Sample: mp4.Sample{Dur: 1470, Size: 10}, DecodeTime: 4410, Data: defragPayload(7, 10)},
+		{Sample: mp4.Sample{Dur: 1470, Size: 10}, DecodeTime: 5880, Data: defragPayload(8, 10)},
+	})
+	out, err := defragment(t, buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	video, audio := outFile.Moov.Traks[0], outFile.Moov.Traks[1]
+	if got := len(video.Edts.Elst[0].Entries); got != 2 {
+		t.Errorf("video has %d elst entries, want the original 2", got)
+	}
+	if got := video.Edts.Elst[0].Entries[1].MediaTime; got != 1024 {
+		t.Errorf("video media time %d, want 1024", got)
+	}
+	if got := audio.Edts.Elst[0].Entries[1].MediaTime; got != 2940 {
+		t.Errorf("audio media time %d, want 2940", got)
+	}
+	if video.Edts.Elst[0].Entries[0].SegmentDuration != 20 || audio.Edts.Elst[0].Entries[0].SegmentDuration != 20 {
+		t.Error("empty edit changed despite equal origins")
+	}
+}
+
+func TestDefragmentDifferingOriginsAlignedWithEmptyEdit(t *testing.T) {
+	init := createDefragPlainAvInit(t)
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 0, Data: defragPayload(1, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 512, Data: defragPayload(2, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1024, Data: defragPayload(3, 10)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1536, Data: defragPayload(4, 10)},
+	})
+	// The audio starts 1024/44100 s after the video.
+	addDefragFragment(t, &buf, 2, 2, []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1024, Size: 10}, DecodeTime: 1024, Data: defragPayload(5, 10)},
+		{Sample: mp4.Sample{Dur: 1024, Size: 10}, DecodeTime: 2048, Data: defragPayload(6, 10)},
+	})
+	out, err := defragment(t, buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	video, audio := outFile.Moov.Traks[0], outFile.Moov.Traks[1]
+	if video.Edts != nil {
+		t.Error("earliest track got an edts box")
+	}
+	if audio.Edts == nil || len(audio.Edts.Elst) != 1 {
+		t.Fatal("audio track got no synthesized elst")
+	}
+	// 1024/44100 s is 13.93 movie ticks, rounded to a 14-tick empty edit,
+	// followed by the whole media: 2048/44100 s = 27.86 -> 28 movie ticks.
+	wantElst := []mp4.ElstEntry{
+		{SegmentDuration: 14, MediaTime: -1, MediaRateInteger: 1},
+		{SegmentDuration: 28, MediaTime: 0, MediaRateInteger: 1},
+	}
+	if diff := deep.Equal(audio.Edts.Elst[0].Entries, wantElst); diff != nil {
+		t.Errorf("synthesized audio elst: %v", diff)
+	}
+	if audio.Edts.Elst[0].Version != 0 {
+		t.Errorf("audio elst version %d, want 0", audio.Edts.Elst[0].Version)
+	}
+	if audio.Mdia.Mdhd.Duration != 2048 {
+		t.Errorf("audio media duration %d, want 2048 (origin rebased away)", audio.Mdia.Mdhd.Duration)
+	}
+	if audio.Tkhd.Duration != 42 {
+		t.Errorf("audio presentation duration %d, want 14+28", audio.Tkhd.Duration)
+	}
+	if video.Tkhd.Duration != 80 || outFile.Moov.Mvhd.Duration != 80 {
+		t.Errorf("video/movie durations %d/%d, want 80/80",
+			video.Tkhd.Duration, outFile.Moov.Mvhd.Duration)
+	}
+}
+
+func TestDefragmentDifferingOriginsMergeIntoExistingElst(t *testing.T) {
+	tests := []struct {
+		name     string
+		entries  []mp4.ElstEntry
+		wantElst []mp4.ElstEntry
+		wantTkhd uint64
+	}{
+		{
+			name:    "prepended empty edit",
+			entries: []mp4.ElstEntry{{SegmentDuration: 600, MediaTime: 2048, MediaRateInteger: 1}},
+			wantElst: []mp4.ElstEntry{
+				{SegmentDuration: 14, MediaTime: -1, MediaRateInteger: 1},
+				{SegmentDuration: 600, MediaTime: 1024, MediaRateInteger: 1},
+			},
+			wantTkhd: 614,
+		},
+		{
+			name: "merged into leading empty edit",
+			entries: []mp4.ElstEntry{
+				{SegmentDuration: 20, MediaTime: -1, MediaRateInteger: 9, MediaRateFraction: 11},
+				{SegmentDuration: 600, MediaTime: 2048, MediaRateInteger: 1},
+			},
+			wantElst: []mp4.ElstEntry{
+				{SegmentDuration: 34, MediaTime: -1, MediaRateInteger: 9, MediaRateFraction: 11},
+				{SegmentDuration: 600, MediaTime: 1024, MediaRateInteger: 1},
+			},
+			wantTkhd: 634,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			init := createDefragPlainAvInit(t)
+			edts := &mp4.EdtsBox{}
+			edts.AddChild(&mp4.ElstBox{Entries: test.entries})
+			init.Moov.Traks[1].AddChild(edts)
+			var buf bytes.Buffer
+			if err := init.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+				{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 0, Data: defragPayload(1, 10)},
+			})
+			addDefragFragment(t, &buf, 2, 2, []mp4.FullSample{
+				{Sample: mp4.Sample{Dur: 1024, Size: 10}, DecodeTime: 1024, Data: defragPayload(2, 10)},
+			})
+			out, err := defragment(t, buf.Bytes())
+			if err != nil {
+				t.Fatal(err)
+			}
+			outFile := decodeDefragOutput(t, out.Bytes())
+			audio := outFile.Moov.Traks[1]
+			if diff := deep.Equal(audio.Edts.Elst[0].Entries, test.wantElst); diff != nil {
+				t.Errorf("aligned audio elst: %v", diff)
+			}
+			if audio.Tkhd.Duration != test.wantTkhd {
+				t.Errorf("audio presentation duration %d, want %d", audio.Tkhd.Duration, test.wantTkhd)
+			}
+		})
+	}
+}
+
+func TestDefragmentUnsafeElstOriginRebaseFailsClosed(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   mp4.ElstEntry
+		wantErr string
+	}{
+		{name: "before origin",
+			entry:   mp4.ElstEntry{MediaTime: 1023, MediaRateInteger: 1},
+			wantErr: "before decode origin"},
+		{name: "negative but not empty",
+			entry:   mp4.ElstEntry{MediaTime: -2, MediaRateInteger: 1},
+			wantErr: "unsupported media time"},
+		{name: "integer rate",
+			entry:   mp4.ElstEntry{MediaTime: 1024, MediaRateInteger: 2},
+			wantErr: "unsupported media rate"},
+		{name: "fractional rate",
+			entry:   mp4.ElstEntry{MediaTime: 1024, MediaRateInteger: 1, MediaRateFraction: 1},
+			wantErr: "unsupported media rate"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			init := createDefragInit(t)
+			init.Moov.Traks[0].Edts.Children[0].(*mp4.ElstBox).Entries = []mp4.ElstEntry{test.entry}
+			var buf bytes.Buffer
+			if err := init.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+				{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1024, Data: defragPayload(1, 10)},
+			})
+			out, err := defragment(t, buf.Bytes(), 1)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("error %v, want %q", err, test.wantErr)
+			}
+			if out.Len() != 0 {
+				t.Errorf("wrote %d bytes before rejecting input", out.Len())
+			}
+		})
+	}
+}
+
+// TestDefragmentSecondTrafWithoutBaseOffsetModeFailsClosed pins that a traf
+// that is not the first in its moof and carries neither base-data-offset nor
+// default-base-is-moof is rejected: per ISO/IEC 14496-12 Section 8.8.7 its
+// base offset is the end of the previous traf's data, which the defragmenter
+// does not derive. Interpreting it against the moof start would misread the
+// payload silently.
+func TestDefragmentSecondTrafWithoutBaseOffsetModeFailsClosed(t *testing.T) {
+	init := createDefragPlainAvInit(t)
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	frag, err := mp4.CreateMultiTrackFragment(1, []uint32{1, 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	videoSample := mp4.FullSample{
+		Sample:     mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10},
+		DecodeTime: 0,
+		Data:       defragPayload(1, 10),
+	}
+	if err := frag.AddFullSampleToTrack(videoSample, 1); err != nil {
+		t.Fatal(err)
+	}
+	audioSample := mp4.FullSample{
+		Sample:     mp4.Sample{Dur: 1024, Size: 10},
+		DecodeTime: 0,
+		Data:       defragPayload(2, 10),
+	}
+	if err := frag.AddFullSampleToTrack(audioSample, 2); err != nil {
+		t.Fatal(err)
+	}
+	frag.Moof.Trafs[1].Tfhd.Flags &^= mp4.TfhdDefaultBaseIsMoofFlag
+	if err := frag.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	_, err = defragment(t, buf.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "unsupported base data offset derivation") {
+		t.Errorf("second traf without a base offset mode gave %v, "+
+			"want an unsupported base data offset derivation error", err)
+	}
+}
+
+func TestDefragmentPayloadExceedingFileSizeIsError(t *testing.T) {
+	var buf bytes.Buffer
+	init := createDefragInit(t)
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	const sampleSize = 3000
+	moofStart := uint64(buf.Len())
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: sampleSize},
+			DecodeTime: 0, Data: defragPayload(1, sampleSize)},
+	})
+	// The first fragment's payload starts after its moof and the mdat header.
+	payloadStart := uint64(buf.Len()) - sampleSize
+	if payloadStart <= moofStart {
+		t.Fatal("unexpected fragment layout")
+	}
+	// Many moof-only fragments re-declare the same payload bytes with
+	// monotone decode times: the total declared payload exceeds the file.
+	for seqNr := uint32(2); seqNr <= 4; seqNr++ {
+		moof := &mp4.MoofBox{}
+		_ = moof.AddChild(mp4.CreateMfhd(seqNr))
+		traf := &mp4.TrafBox{}
+		_ = moof.AddChild(traf)
+		tfhd := mp4.CreateTfhd(1)
+		tfhd.Flags |= 0x01 // base-data-offset present
+		tfhd.BaseDataOffset = payloadStart
+		_ = traf.AddChild(tfhd)
+		_ = traf.AddChild(mp4.CreateTfdt(uint64(seqNr-1) * 512))
+		trun := mp4.CreateTrun(0)
+		trun.Flags &^= mp4.TrunDataOffsetPresentFlag
+		trun.AddSample(mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: sampleSize})
+		_ = traf.AddChild(trun)
+		if err := moof.Encode(&buf); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := defragment(t, buf.Bytes(), 1)
+	if err == nil || !strings.Contains(err.Error(), "exceeds the") {
+		t.Errorf("payload amplification error %v", err)
+	}
+}
+
+func TestDefragmentUnsupportedElstAtZeroOriginIsError(t *testing.T) {
+	init := createDefragInit(t)
+	init.Moov.Traks[0].Edts.Children[0].(*mp4.ElstBox).Entries = []mp4.ElstEntry{
+		{SegmentDuration: 600, MediaTime: 0, MediaRateInteger: 2},
+	}
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 0, Data: defragPayload(1, 10)},
+	})
+	_, err := defragment(t, buf.Bytes(), 1)
+	if err == nil || !strings.Contains(err.Error(), "unsupported media rate") {
+		t.Errorf("rate-2 edit at origin 0 gave %v, want an unsupported media rate error", err)
+	}
+}
+
+// TestDefragmentTrivialElst pins the identity definition: one entry from
+// media time 0 at rate 1.0 whose segment duration is zero or the full
+// presentation length is dropped, while a trimming duration is kept.
+func TestDefragmentTrivialElst(t *testing.T) {
+	writeSingleVideoTrack := func(t *testing.T, entries []mp4.ElstEntry, nrSamples int) []byte {
+		t.Helper()
+		init := createDefragInit(t)
+		init.Moov.Traks[0].Edts.Children[0].(*mp4.ElstBox).Entries = entries
+		var buf bytes.Buffer
+		if err := init.Encode(&buf); err != nil {
+			t.Fatal(err)
+		}
+		samples := make([]mp4.FullSample, 0, nrSamples)
+		for i := 0; i < nrSamples; i++ {
+			flags := defragNonSyncFlags()
+			if i == 0 {
+				flags = defragSyncFlags()
+			}
+			samples = append(samples, mp4.FullSample{
+				Sample:     mp4.Sample{Flags: flags, Dur: 512, Size: 10},
+				DecodeTime: 1024 + uint64(i)*512, Data: defragPayload(byte(i+1), 10),
+			})
+		}
+		addDefragFragment(t, &buf, 1, 1, samples)
+		return buf.Bytes()
+	}
+	t.Run("zero segment duration is dropped", func(t *testing.T) {
+		data := writeSingleVideoTrack(t, []mp4.ElstEntry{
+			{SegmentDuration: 0, MediaTime: 0, MediaRateInteger: 1},
+		}, 1)
+		out, err := defragment(t, data, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		trak := decodeDefragOutput(t, out.Bytes()).Moov.Traks[0]
+		if trak.Edts != nil {
+			t.Error("identity elst must be dropped")
+		}
+		if trak.Mdia.Mdhd.Duration != 512 || trak.Tkhd.Duration != 20 {
+			t.Errorf("durations %d/%d, want 512 media and 20 movie ticks",
+				trak.Mdia.Mdhd.Duration, trak.Tkhd.Duration)
+		}
+	})
+	t.Run("full presentation length is dropped", func(t *testing.T) {
+		// 4 samples of 512 ticks at 15360 rescale to 80 movie ticks.
+		data := writeSingleVideoTrack(t, []mp4.ElstEntry{
+			{SegmentDuration: 80, MediaTime: 0, MediaRateInteger: 1},
+		}, 4)
+		out, err := defragment(t, data, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		trak := decodeDefragOutput(t, out.Bytes()).Moov.Traks[0]
+		if trak.Edts != nil {
+			t.Error("full-length identity elst must be dropped")
+		}
+		if trak.Tkhd.Duration != 80 {
+			t.Errorf("presentation duration %d, want 80", trak.Tkhd.Duration)
+		}
+	})
+	t.Run("trimming segment duration fails the origin shift", func(t *testing.T) {
+		// A trim of the 80-tick presentation to 40 ticks is not an identity
+		// edit; its media time 0 is before the 1024-tick origin.
+		data := writeSingleVideoTrack(t, []mp4.ElstEntry{
+			{SegmentDuration: 40, MediaTime: 0, MediaRateInteger: 1},
+		}, 4)
+		_, err := defragment(t, data, 1)
+		if err == nil || !strings.Contains(err.Error(), "before decode origin") {
+			t.Errorf("trimming elst at nonzero origin gave %v, want a fail-closed error", err)
+		}
+	})
+	t.Run("trimming elst at origin 0 is preserved", func(t *testing.T) {
+		init := createDefragInit(t)
+		trim := []mp4.ElstEntry{{SegmentDuration: 40, MediaTime: 0, MediaRateInteger: 1}}
+		init.Moov.Traks[0].Edts.Children[0].(*mp4.ElstBox).Entries = append([]mp4.ElstEntry{}, trim...)
+		var buf bytes.Buffer
+		if err := init.Encode(&buf); err != nil {
+			t.Fatal(err)
+		}
+		samples := make([]mp4.FullSample, 0, 4)
+		for i := 0; i < 4; i++ {
+			flags := defragNonSyncFlags()
+			if i == 0 {
+				flags = defragSyncFlags()
+			}
+			samples = append(samples, mp4.FullSample{
+				Sample:     mp4.Sample{Flags: flags, Dur: 512, Size: 10},
+				DecodeTime: uint64(i) * 512, Data: defragPayload(byte(i+1), 10),
+			})
+		}
+		addDefragFragment(t, &buf, 1, 1, samples)
+		out, err := defragment(t, buf.Bytes(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		trak := decodeDefragOutput(t, out.Bytes()).Moov.Traks[0]
+		if diff := deep.Equal(trak.Edts.Elst[0].Entries, trim); diff != nil {
+			t.Errorf("trimming elst changed: %v", diff)
+		}
+		if trak.Tkhd.Duration != 40 || trak.Mdia.Mdhd.Duration != 2048 {
+			t.Errorf("durations %d/%d, want the 40-tick trim over 2048 media ticks",
+				trak.Tkhd.Duration, trak.Mdia.Mdhd.Duration)
+		}
+	})
+	t.Run("identity elst with differing origins gets the empty edit", func(t *testing.T) {
+		init := createDefragPlainAvInit(t)
+		edts := &mp4.EdtsBox{}
+		// 2048 audio ticks at 44100 rescale to 28 movie ticks: identity.
+		edts.AddChild(&mp4.ElstBox{Entries: []mp4.ElstEntry{
+			{SegmentDuration: 28, MediaTime: 0, MediaRateInteger: 1},
+		}})
+		init.Moov.Traks[1].AddChild(edts)
+		var buf bytes.Buffer
+		if err := init.Encode(&buf); err != nil {
+			t.Fatal(err)
+		}
+		addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+			{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 0, Data: defragPayload(1, 10)},
+		})
+		addDefragFragment(t, &buf, 2, 2, []mp4.FullSample{
+			{Sample: mp4.Sample{Dur: 1024, Size: 10}, DecodeTime: 1024, Data: defragPayload(2, 10)},
+			{Sample: mp4.Sample{Dur: 1024, Size: 10}, DecodeTime: 2048, Data: defragPayload(3, 10)},
+		})
+		out, err := defragment(t, buf.Bytes())
+		if err != nil {
+			t.Fatal(err)
+		}
+		outFile := decodeDefragOutput(t, out.Bytes())
+		wantElst := []mp4.ElstEntry{
+			{SegmentDuration: 14, MediaTime: -1, MediaRateInteger: 1},
+			{SegmentDuration: 28, MediaTime: 0, MediaRateInteger: 1},
+		}
+		if diff := deep.Equal(outFile.Moov.Traks[1].Edts.Elst[0].Entries, wantElst); diff != nil {
+			t.Errorf("synthesized elst after identity drop: %v", diff)
+		}
+	})
+}
+
+func TestDefragmentFtypBrands(t *testing.T) {
+	tests := []struct {
+		name       string
+		inFtyp     *mp4.FtypBox
+		wantMajor  string
+		wantMinor  uint32
+		wantBrands []string
+	}{
+		{name: "fragment-format brands dropped",
+			inFtyp:    mp4.NewFtyp("dash", 0, []string{"iso6", "cmfc", "dsms", "lmsg", "dash"}),
+			wantMajor: "isom", wantMinor: 0, wantBrands: []string{"iso6", "isom"}},
+		{name: "progressive brands untouched",
+			inFtyp:    mp4.NewFtyp("isom", 512, []string{"isom", "iso2", "avc1", "mp41"}),
+			wantMajor: "isom", wantMinor: 512, wantBrands: []string{"isom", "iso2", "avc1", "mp41"}},
+		{name: "missing ftyp gets the plain default",
+			inFtyp:    nil,
+			wantMajor: "isom", wantMinor: 512, wantBrands: []string{"isom", "mp42"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			init := createDefragInit(t)
+			var buf bytes.Buffer
+			if test.inFtyp != nil {
+				if err := test.inFtyp.Encode(&buf); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := init.Moov.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+				{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10},
+					DecodeTime: 0, Data: defragPayload(1, 10)},
+			})
+			out, err := defragment(t, buf.Bytes(), 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			outFtyp := decodeDefragOutput(t, out.Bytes()).Ftyp
+			if outFtyp.MajorBrand() != test.wantMajor || outFtyp.MinorVersion() != test.wantMinor {
+				t.Errorf("ftyp %s/%d, want %s/%d",
+					outFtyp.MajorBrand(), outFtyp.MinorVersion(), test.wantMajor, test.wantMinor)
+			}
+			if diff := deep.Equal(outFtyp.CompatibleBrands(), test.wantBrands); diff != nil {
+				t.Errorf("compatible brands: %v", diff)
+			}
+		})
+	}
+}
+
+func TestDefragmentZeroMovieTimescaleIsError(t *testing.T) {
+	init := createDefragPlainAvInit(t)
+	init.Moov.Mvhd.Timescale = 0
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 0, Data: defragPayload(1, 10)},
+	})
+	_, err := defragment(t, buf.Bytes(), 1)
+	if err == nil || !strings.Contains(err.Error(), "zero movie timescale") {
+		t.Errorf("zero movie timescale gave %v, want a fail-closed error", err)
+	}
+}
+func TestDefragmentResolvesFinalZeroSegmentDurationEdit(t *testing.T) {
+	// A final elst entry with segment_duration 0 is the fragmented-file idiom
+	// for "rest of the media" (mvhd duration is 0 there). The progressive
+	// output carries a real movie duration, and readers such as ffmpeg's mov
+	// demuxer apply the edit literally, so an unresolved zero-length final
+	// edit hides the whole track. The written entry must get the remaining
+	// media duration in movie timescale. Entries that do not use the idiom
+	// pass through unchanged.
+	cases := []struct {
+		name    string
+		entries []mp4.ElstEntry
+		want    []mp4.ElstEntry
+	}{
+		{
+			name:    "zero final duration resolves to remaining media",
+			entries: []mp4.ElstEntry{{SegmentDuration: 0, MediaTime: 512, MediaRateInteger: 1}},
+			// media 2048@15360 from media time 512 -> 1536 ticks = 60 @600.
+			want: []mp4.ElstEntry{{SegmentDuration: 60, MediaTime: 512, MediaRateInteger: 1}},
+		},
+		{
+			name:    "explicit durations pass through",
+			entries: []mp4.ElstEntry{{SegmentDuration: 30, MediaTime: 512, MediaRateInteger: 1}},
+			want:    []mp4.ElstEntry{{SegmentDuration: 30, MediaTime: 512, MediaRateInteger: 1}},
+		},
+		{
+			name: "zero-duration empty edit is not the idiom",
+			entries: []mp4.ElstEntry{
+				{SegmentDuration: 600, MediaTime: 0, MediaRateInteger: 1},
+				{SegmentDuration: 0, MediaTime: -1, MediaRateInteger: 1},
+			},
+			want: []mp4.ElstEntry{
+				{SegmentDuration: 600, MediaTime: 0, MediaRateInteger: 1},
+				{SegmentDuration: 0, MediaTime: -1, MediaRateInteger: 1},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			init := createDefragInit(t)
+			elst := init.Moov.Traks[0].Edts.Children[0].(*mp4.ElstBox)
+			elst.Entries = append([]mp4.ElstEntry{}, c.entries...)
+			var buf bytes.Buffer
+			if err := init.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+				{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 1024, Size: 10},
+					DecodeTime: 0, Data: defragPayload(1, 10)},
+				{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 1024, Size: 10},
+					DecodeTime: 1024, Data: defragPayload(2, 10)},
+			})
+			out, err := defragment(t, buf.Bytes(), 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			outFile := decodeDefragOutput(t, out.Bytes())
+			trak := outFile.Moov.Traks[0]
+			if trak.Edts == nil || len(trak.Edts.Elst) != 1 {
+				t.Fatal("elst not preserved")
+			}
+			if diff := deep.Equal(trak.Edts.Elst[0].Entries, c.want); diff != nil {
+				t.Errorf("elst entries: %v", diff)
+			}
+		})
+	}
+}

--- a/mp4/elst.go
+++ b/mp4/elst.go
@@ -3,6 +3,7 @@ package mp4
 import (
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/Eyevinn/mp4ff/bits"
 )
@@ -80,6 +81,18 @@ func DecodeElstSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 		return nil, fmt.Errorf("unknown version for elst")
 	}
 	return b, sr.AccError()
+}
+
+// needs64Bits tells whether some entry only fits the version 1 (64-bit)
+// field widths.
+func (b *ElstBox) needs64Bits() bool {
+	for _, entry := range b.Entries {
+		if entry.SegmentDuration > math.MaxUint32 ||
+			entry.MediaTime > math.MaxInt32 || entry.MediaTime < math.MinInt32 {
+			return true
+		}
+	}
+	return false
 }
 
 // Type - box type

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -29,6 +29,23 @@ func NewTrakBox() *TrakBox {
 	return &TrakBox{}
 }
 
+// insertEdts adds edts right after tkhd, matching the conventional box
+// order, unlike the appending AddChild.
+func (t *TrakBox) insertEdts(edts *EdtsBox) {
+	t.Edts = edts
+	for i, child := range t.Children {
+		if _, ok := child.(*TkhdBox); ok {
+			children := make([]Box, 0, len(t.Children)+1)
+			children = append(children, t.Children[:i+1]...)
+			children = append(children, edts)
+			children = append(children, t.Children[i+1:]...)
+			t.Children = children
+			return
+		}
+	}
+	t.Children = append(t.Children, edts)
+}
+
 // AddChild - Add a child box
 func (t *TrakBox) AddChild(child Box) {
 	switch box := child.(type) {


### PR DESCRIPTION
Implements #548, following the approach discussed there. Follow-ups: #560 (overlap resolution), #561 (progressive-prefix input).

## Problem

There is no way to convert a fragmented file to a progressive one (#162,
#311, #548): the moov of the progressive file needs the metadata of every
sample, so all moofs must be read before anything can be written.

## Fix

`mp4.Defragment(f *File, rs io.ReadSeeker, w io.Writer)` and
`mp4.DefragmentTracks(f, rs, w, trackIDs...)`, plus a thin
`cmd/mp4ff-defragment` CLI (cloned from the mp4ff-crop skeleton, `-t` for
track selection). Two passes: sample metadata is collected from all moofs
(lazy mdat, payloads never materialized), the progressive sample tables
(stts/ctts/stsc/stsz/stss/stco/co64) are synthesized, the moov is written,
then the sample byte ranges are copied verbatim. Each traf becomes one chunk,
so the input interleaving is kept.

Timeline handling as discussed in #548: each track is rebased by its own
first tfdt, existing elst media times shift by the same amount, and differing
start offsets between tracks are absorbed with an empty edit in movie
timescale on the later track (merged into its elst or synthesized), worst
case half a movie tick of rounding. A trivial identity edit list (single
entry, media time 0, rate 1.0, whole-presentation or zero duration) is
dropped rather than rejected; a trailing zero-duration edit ("rest of the
media", legal in fragmented files) is resolved to the real remaining
duration so progressive readers do not apply it literally. A forward tfdt
gap extends the previous sample; a backward tfdt is an error.

Edit lists are validated for every kept track whatever its start time.
Fail-closed rather than silently wrong: rate != 1 and unshiftable media
times, encrypted tracks (senc, or saiz/saio without senc), zero movie or
media timescales, kept tracks without samples (init-only input), declared
payload exceeding the input size, and files that already carry progressive
samples are rejected with clear errors. Fragment-format brands (dash, dsms,
msdh, msix, sims, lmsg, cmfc, cmf2, cmff, cmfs, isml, piff, hlsf) are
dropped from the output ftyp with isom ensured; structural iso2..iso6 brands
are kept.

## Tests

Exact elst outputs are pinned for differing origins with no/existing/leading
empty edits, equal origins, identity and trimming edits, and the trailing
zero-duration resolution; exact ftyp brands pinned for dash-major, isom-major
and missing-ftyp inputs; conversion round-trips verified sample-by-sample
against re-decoded output; all fragmented testdata files convert and
re-decode as progressive; error paths cover encryption, backward tfdt, zero
timescales, truncation, amplification, hybrid input, unsupported edits at
any origin, and sample-less tracks. `go test ./...`, `go vet`, `gofmt`,
`golangci-lint` pass.