### PR TITLE
feat(mp4): defragment hybrid files with a progressive part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   starting later than the earliest one keeps its presentation alignment
   through an empty edit; a trivial identity edit list is dropped.
   Fragment-format brands (dash, cmfc, isml, and friends) are removed from
-  the output ftyp. Encrypted content, unsupported edit lists, zero
+  the output ftyp. Per-sample encryption auxiliary information (senc or
+  saiz/saio; constant-IV full-sample encryption without such data passes
+  through losslessly), unsupported edit lists, zero
   timescales, truncated byte ranges, and payloads larger than the input
   file are rejected
 - `mp4.Defragment` and `mp4.DefragmentTracks` resolve overlapping fragments:
@@ -53,6 +55,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   time ranges that no surviving later fragment declares again, and
   overlapping files whose fragments use absolute base data offsets are
   rejected
+- `mp4.Defragment` and `mp4.DefragmentTracks` accept hybrid files that carry
+  progressive samples in the moov before the first fragment: the progressive
+  samples come first with their chunk structure preserved (also when stco
+  offsets are not monotone), and the fragment samples are appended.
+  Fragments may supersede progressive samples under the same
+  later-declarer-wins and coverage rules as fragment overlaps, and hostile
+  sample tables are validated before any count-proportional allocation
+- `SttsBox.SampleDurations`, `CttsBox.CompositionTimeOffsets`, and
+  `StssBox.SampleIsSync` expand a whole sample table into one value per
+  sample, validating the entries against the declared sample count
 - `mp4ff-defragment` command line tool exposing the defragmentation with
   optional track selection
 

--- a/mp4/ctts.go
+++ b/mp4/ctts.go
@@ -134,6 +134,38 @@ func (b *CttsBox) AddSampleCountsAndOffset(counts []uint32, offsets []int32) err
 	return nil
 }
 
+// CompositionTimeOffsets returns the offset of each of nrSamples samples,
+// validating that the entries cover exactly that many samples. A box
+// without entries covers no samples.
+func (b *CttsBox) CompositionTimeOffsets(nrSamples uint32) ([]int32, error) {
+	ctss := make([]int32, nrSamples)
+	if len(b.EndSampleNr) < 2 {
+		if nrSamples == 0 {
+			return ctss, nil
+		}
+		return nil, fmt.Errorf("ctts covers 0 samples, not the %d declared", nrSamples)
+	}
+	if len(b.SampleOffset) != len(b.EndSampleNr)-1 {
+		return nil, fmt.Errorf("ctts has %d offsets for %d entries", len(b.SampleOffset), len(b.EndSampleNr)-1)
+	}
+	if b.EndSampleNr[len(b.EndSampleNr)-1] != nrSamples {
+		return nil, fmt.Errorf("ctts covers %d samples, not the %d declared",
+			b.EndSampleNr[len(b.EndSampleNr)-1], nrSamples)
+	}
+	for i := 0; i < b.NrSampleCount(); i++ {
+		// The decoded EndSampleNr accumulation can wrap uint32, so the final
+		// entry alone proves nothing about the intermediate ones.
+		if b.EndSampleNr[i] > b.EndSampleNr[i+1] || b.EndSampleNr[i+1] > nrSamples {
+			return nil, fmt.Errorf("ctts entry %d covers samples (%d, %d], outside the %d declared samples",
+				i+1, b.EndSampleNr[i], b.EndSampleNr[i+1], nrSamples)
+		}
+		for nr := b.EndSampleNr[i]; nr < b.EndSampleNr[i+1]; nr++ {
+			ctss[nr] = b.SampleOffset[i]
+		}
+	}
+	return ctss, nil
+}
+
 // GetCompositionTimeOffset - composition time offset for (one-based) sampleNr in track timescale.
 // Returns 0 for a sampleNr beyond the samples covered by this box.
 func (b *CttsBox) GetCompositionTimeOffset(sampleNr uint32) int32 {

--- a/mp4/ctts_test.go
+++ b/mp4/ctts_test.go
@@ -78,3 +78,37 @@ func TestGetCompositionTimeOffsetOutsideBox(t *testing.T) {
 		t.Errorf("decoded empty ctts: got cto %d instead of 0", cto)
 	}
 }
+
+func TestCttsCompositionTimeOffsets(t *testing.T) {
+	ctts := &mp4.CttsBox{}
+	if err := ctts.AddSampleCountsAndOffset([]uint32{2, 1}, []int32{100, -200}); err != nil {
+		t.Fatal(err)
+	}
+	offsets, err := ctts.CompositionTimeOffsets(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []int32{100, 100, -200}
+	for i := range want {
+		if offsets[i] != want[i] {
+			t.Errorf("offset %d is %d, want %d", i, offsets[i], want[i])
+		}
+	}
+	if _, err := ctts.CompositionTimeOffsets(2); err == nil {
+		t.Error("entries covering more samples than declared must be an error")
+	}
+	empty := &mp4.CttsBox{}
+	if offsets, err := empty.CompositionTimeOffsets(0); err != nil || len(offsets) != 0 {
+		t.Errorf("empty box with 0 samples gave %v, %v", offsets, err)
+	}
+	if _, err := empty.CompositionTimeOffsets(3); err == nil {
+		t.Error("an empty box covering declared samples must be an error")
+	}
+}
+
+func TestCttsCompositionTimeOffsetsMismatchedSlices(t *testing.T) {
+	ctts := &mp4.CttsBox{EndSampleNr: []uint32{0, 3}, SampleOffset: []int32{100, 200}}
+	if _, err := ctts.CompositionTimeOffsets(3); err == nil {
+		t.Error("mismatched ctts slices must be an error, not a panic")
+	}
+}

--- a/mp4/defragmenter.go
+++ b/mp4/defragmenter.go
@@ -13,7 +13,10 @@ import (
 //
 // Sample data is copied byte-verbatim while progressive sample tables
 // (stts, ctts, stsc, stsz, stss, stco/co64) are synthesized from the
-// fragment metadata, with each traf becoming one chunk. Every track is
+// fragment metadata, with each traf becoming one chunk. Progressive samples
+// that the moov already describes (a progressive part before the first
+// fragment) come first with their chunk structure preserved, and the
+// fragment samples are appended. Every track is
 // rebased so that its first tfdt becomes media time zero: edit-list media
 // times shift along, and a track starting later than the earliest one keeps
 // its presentation alignment through an empty edit (with at most half a
@@ -22,11 +25,14 @@ import (
 // A fragment whose tfdt re-declares an earlier decode time supersedes the
 // earlier samples (a retransmission): the fragment appearing later in the
 // file wins, and the superseded samples are dropped at sample granularity,
-// whether or not the re-sent bytes are identical. Every abandoned time
-// range must be declared again by surviving fragments, so no declared
-// content is ever silently dropped; overlaps that cannot be resolved
-// exactly are rejected, as are encrypted content and edits that cannot be
-// shifted.
+// whether or not the re-sent bytes are identical. Progressive samples can
+// be superseded the same way. Every abandoned time range must be declared
+// again by surviving fragments, so no declared content is ever silently
+// dropped; overlaps that cannot be resolved exactly are rejected, as are
+// per-sample encryption auxiliary information (senc or saiz/saio, which the
+// progressive sample tables cannot carry) and edits that cannot be shifted.
+// Full-sample encryption with a constant IV has no such auxiliary data and
+// passes through losslessly, keeping the sinf of the sample description.
 func Defragment(f *File, rs io.ReadSeeker, w io.Writer) error {
 	d, err := newDefragmenter(f, rs, nil)
 	if err != nil {
@@ -69,6 +75,7 @@ type defragChunk struct {
 	nrSamples uint32
 	size      uint64
 	ranges    []defragRange // input byte ranges, coalesced
+	srcOffset uint64        // input chunk offset, for cross-track ordering
 	offset    uint64        // output chunk offset, assigned before writing
 	dead      bool          // every sample dropped by overlap resolution
 }
@@ -95,7 +102,7 @@ type defragTrack struct {
 	origin       uint64           // decode time of the first sample
 	endDts       uint64           // decode time just after the last sample
 	delay        uint64           // presentation delay relative to the earliest track, in movie ticks
-	frags        []*defragFragRec // one record per collected traf
+	frags        []*defragFragRec // one record per collected traf, plus the progressive part
 	live         []*defragFragRec // the records with kept > 0, in collection order
 	extendedDurs []paddedDur      // durations before gap padding, by increasing sample index
 }
@@ -196,14 +203,8 @@ func newDefragmenter(f *File, rs io.ReadSeeker, keptTrackIDs []uint32) (*defragm
 			track.keep = true
 		}
 	}
-	for _, track := range d.tracks {
-		if !track.keep {
-			continue
-		}
-		if stbl := trackStbl(track.trak); stbl != nil && stbl.Stsz != nil && stbl.Stsz.GetNrSamples() > 0 {
-			return nil, fmt.Errorf("track %d already carries progressive samples, "+
-				"only purely fragmented input is supported", track.trak.Tkhd.TrackID)
-		}
+	if err := d.collectProgressivePart(); err != nil {
+		return nil, err
 	}
 	for _, seg := range f.Segments {
 		for _, frag := range seg.Fragments {
@@ -236,6 +237,190 @@ func newDefragmenter(f *File, rs io.ReadSeeker, keptTrackIDs []uint32) (*defragm
 		return nil, err
 	}
 	return d, nil
+}
+
+// collectProgressivePart gathers the samples that the moov sample tables
+// already describe (nonempty for files with a progressive part before the
+// first fragment). Per-track chunk order follows the sample tables, and the
+// tracks' chunk runs are interleaved by their input file position. The
+// progressive part counts as each track's earliest declaration, so a later
+// fragment may supersede it but never the reverse.
+func (d *defragmenter) collectProgressivePart() error {
+	var perTrack [][]*defragChunk
+	for _, track := range d.tracks {
+		if !track.keep {
+			continue
+		}
+		trackChunks, err := progressiveChunks(track, d.fileSize)
+		if err != nil {
+			return fmt.Errorf("progressive samples of track %d: %w", track.trak.Tkhd.TrackID, err)
+		}
+		if len(trackChunks) == 0 {
+			continue
+		}
+		track.chunks = trackChunks
+		// The progressive part takes part in overlap resolution like a
+		// fragment: its declared range must survive or be re-declared.
+		track.addFragRec(&defragFragRec{
+			end:   track.endDts,
+			total: len(track.samples),
+			kept:  len(track.samples),
+		})
+		perTrack = append(perTrack, trackChunks)
+	}
+	// Merge the runs by their head chunk's offset. Within a track the sample
+	// table order always stands, since stco offsets need not be monotone.
+	for {
+		best := -1
+		for i, run := range perTrack {
+			if len(run) == 0 {
+				continue
+			}
+			if best < 0 || run[0].srcOffset < perTrack[best][0].srcOffset {
+				best = i
+			}
+		}
+		if best < 0 {
+			return nil
+		}
+		d.chunks = append(d.chunks, perTrack[best][0])
+		perTrack[best] = perTrack[best][1:]
+	}
+}
+
+func progressiveChunks(track *defragTrack, fileSize uint64) ([]*defragChunk, error) {
+	stbl := trackStbl(track.trak)
+	if stbl == nil {
+		return nil, nil
+	}
+	if stbl.Stsz == nil || stbl.Stsz.GetNrSamples() == 0 {
+		// stsz carries the only sample count mp4ff reads, so chunks declared
+		// without it would be dropped silently.
+		nrChunks := 0
+		if stbl.Stco != nil {
+			nrChunks += len(stbl.Stco.ChunkOffset)
+		}
+		if stbl.Co64 != nil {
+			nrChunks += len(stbl.Co64.ChunkOffset)
+		}
+		if nrChunks > 0 {
+			return nil, fmt.Errorf("%d chunks declared but stsz declares no samples (stz2 is not supported)", nrChunks)
+		}
+		return nil, nil
+	}
+	if stbl.Saiz != nil || stbl.Saio != nil {
+		return nil, fmt.Errorf("per-sample encryption auxiliary information (saiz/saio) " +
+			"cannot be carried into the progressive sample tables")
+	}
+	nrSamples := stbl.Stsz.GetNrSamples()
+	// A table-backed stsz is inherently bounded by its own box size, but a
+	// uniform-size stsz declares its count in a fixed-size box, and the
+	// per-sample expansions below allocate proportionally to the count. Bound
+	// it by what the file can physically hold before allocating anything.
+	if uint64(nrSamples) > uint64(len(stbl.Stsz.SampleSize)) {
+		uniform := stbl.Stsz.SampleUniformSize
+		if uniform == 0 || uint64(nrSamples)*uint64(uniform) > fileSize {
+			return nil, fmt.Errorf("stsz declares %d samples of uniform size %d, more than the %d bytes of the file",
+				nrSamples, uniform, fileSize)
+		}
+	}
+	if stbl.Stts == nil || stbl.Stsc == nil || (stbl.Stco == nil && stbl.Co64 == nil) {
+		return nil, fmt.Errorf("stsz declares %d samples but stts, stsc or stco/co64 is missing", nrSamples)
+	}
+	durs, err := stbl.Stts.SampleDurations(nrSamples)
+	if err != nil {
+		return nil, err
+	}
+	ctss := make([]int32, nrSamples)
+	if stbl.Ctts != nil {
+		if ctss, err = stbl.Ctts.CompositionTimeOffsets(nrSamples); err != nil {
+			return nil, err
+		}
+	}
+	sync := make([]bool, nrSamples)
+	if stbl.Stss == nil {
+		for i := range sync {
+			sync[i] = true // no stss means every sample is sync
+		}
+	} else if sync, err = stbl.Stss.SampleIsSync(nrSamples); err != nil {
+		return nil, err
+	}
+	track.samples = make([]defragSample, nrSamples)
+	for i := uint32(0); i < nrSamples; i++ {
+		track.samples[i] = defragSample{
+			dur:     durs[i],
+			size:    stbl.Stsz.GetSampleSize(int(i + 1)),
+			cts:     ctss[i],
+			nonSync: !sync[i],
+		}
+		if uint64(durs[i]) > math.MaxUint64-track.endDts {
+			return nil, fmt.Errorf("sample %d duration overflows the decode timeline", i+1)
+		}
+		track.endDts += uint64(durs[i])
+	}
+	track.started = true
+
+	var chunkOffsets []uint64
+	if stbl.Stco != nil {
+		chunkOffsets = make([]uint64, len(stbl.Stco.ChunkOffset))
+		for i, offset := range stbl.Stco.ChunkOffset {
+			chunkOffsets[i] = uint64(offset)
+		}
+	} else {
+		chunkOffsets = stbl.Co64.ChunkOffset
+	}
+	chunks := make([]*defragChunk, 0, len(chunkOffsets))
+	stsc := stbl.Stsc
+	sampleNr := uint32(0) // zero-based
+	entryNr := 0
+	for chunkNr := 1; chunkNr <= len(chunkOffsets); chunkNr++ {
+		for entryNr+1 < len(stsc.Entries) && stsc.Entries[entryNr+1].FirstChunk <= uint32(chunkNr) {
+			entryNr++
+		}
+		if len(stsc.Entries) == 0 || stsc.Entries[0].FirstChunk > uint32(chunkNr) {
+			return nil, fmt.Errorf("no stsc entry for chunk %d", chunkNr)
+		}
+		nrInChunk := stsc.Entries[entryNr].SamplesPerChunk
+		if nrInChunk == 0 || nrInChunk > nrSamples-sampleNr {
+			return nil, fmt.Errorf("stsc chunk %d declares %d samples, but %d remain",
+				chunkNr, nrInChunk, nrSamples-sampleNr)
+		}
+		chunk := &defragChunk{
+			track:     track,
+			sdi:       stscEntrySDI(stsc, entryNr),
+			nrSamples: nrInChunk,
+			srcOffset: chunkOffsets[chunkNr-1],
+		}
+		var chunkSize uint64
+		for i := uint32(0); i < nrInChunk; i++ {
+			chunkSize += uint64(track.samples[sampleNr+i].size)
+		}
+		if chunkOffsets[chunkNr-1] > fileSize || chunkSize > fileSize-chunkOffsets[chunkNr-1] {
+			return nil, fmt.Errorf("chunk %d at %d with %d bytes extends beyond the file end %d",
+				chunkNr, chunkOffsets[chunkNr-1], chunkSize, fileSize)
+		}
+		chunk.addRange(chunkOffsets[chunkNr-1], chunkSize)
+		sampleNr += nrInChunk
+		chunks = append(chunks, chunk)
+	}
+	if sampleNr != nrSamples {
+		return nil, fmt.Errorf("chunks cover %d samples, stsz declares %d", sampleNr, nrSamples)
+	}
+	return chunks, nil
+}
+
+// stscEntrySDI returns the sample description ID of the 0-based stsc entry,
+// reading the decoded fields directly: GetSampleDescriptionID indexes
+// entries despite its chunk-number parameter name, and returns 0 for an
+// absent ID where the spec default 1 is wanted (matching the tfhd treatment).
+func stscEntrySDI(stsc *StscBox, entryNr int) uint32 {
+	if stsc.singleSampleDescriptionID != 0 {
+		return stsc.singleSampleDescriptionID
+	}
+	if entryNr < len(stsc.SampleDescriptionID) {
+		return stsc.SampleDescriptionID[entryNr]
+	}
+	return 1
 }
 
 // computeTrackAlignment gives every kept track with samples a presentation

--- a/mp4/defragmenter_test.go
+++ b/mp4/defragmenter_test.go
@@ -496,12 +496,240 @@ func TestDefragmentProgressiveInputIsError(t *testing.T) {
 	}
 }
 
-func TestDefragmentHybridInputIsError(t *testing.T) {
-	init := createDefragInit(t)
-	// A progressive prefix: the video sample tables already declare a sample.
+func TestDefragmentHybridFile(t *testing.T) {
+	data, videoSamples, audioSamples := writeDefragTestFile(t)
+	progressive, err := defragment(t, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hybrid := bytes.NewBuffer(append([]byte{}, progressive.Bytes()...))
+	extra := []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 60, CompositionTimeOffset: 512},
+			DecodeTime: 5 * 512, Data: defragPayload(9, 60)},
+		{Sample: mp4.Sample{Flags: defragNonSyncFlags(), Dur: 512, Size: 50},
+			DecodeTime: 6 * 512, Data: defragPayload(10, 50)},
+	}
+	addDefragFragment(t, hybrid, 1, 1, extra)
+	out, err := defragment(t, hybrid.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	videoTrak := outFile.Moov.Traks[0]
+	if nr := videoTrak.GetNrSamples(); nr != 7 {
+		t.Fatalf("video has %d samples, want the 5 progressive + 2 fragment samples", nr)
+	}
+	if diff := deep.Equal(videoTrak.Mdia.Minf.Stbl.Stss.SampleNumber, []uint32{1, 4, 6}); diff != nil {
+		t.Errorf("hybrid stss: %v", diff)
+	}
+	if dur := videoTrak.Mdia.Mdhd.Duration; dur != 7*512 {
+		t.Errorf("video media duration %d, want %d", dur, 7*512)
+	}
+	want := append(concatSampleData(videoSamples), concatSampleData(extra)...)
+	if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, want) {
+		t.Error("hybrid video sample data not byte-identical")
+	}
+	if got := readProgressiveSampleData(t, outFile, 2); !bytes.Equal(got, concatSampleData(audioSamples)) {
+		t.Error("hybrid audio sample data not byte-identical")
+	}
+}
+
+// writeDefragHybridPrefixFile writes ftyp + moov declaring a 4-sample video
+// prefix in two chunks (with descending stco offsets when swapChunkBytes is
+// set), the mdat carrying the prefix payload, and one 2-sample audio
+// fragment at audioDts. It returns the file and the video sample-order bytes.
+func writeDefragHybridPrefixFile(t *testing.T, swapChunkBytes bool, audioDts uint64) (data, videoPayload []byte) {
+	t.Helper()
+	init := createDefragPlainAvInit(t)
 	stbl := init.Moov.Traks[0].Mdia.Minf.Stbl
-	stbl.Stsz.SampleNumber = 1
-	stbl.Stsz.SampleSize = []uint32{10}
+	stbl.Stts.SampleCount = []uint32{4}
+	stbl.Stts.SampleTimeDelta = []uint32{512}
+	stbl.Stsz.SampleNumber = 4
+	stbl.Stsz.SampleSize = []uint32{10, 20, 30, 40}
+	if err := stbl.Stsc.AddEntry(1, 2, 1); err != nil {
+		t.Fatal(err)
+	}
+	stbl.Stco.ChunkOffset = []uint32{0, 0} // fixed-width placeholders, set below
+	var measure bytes.Buffer
+	if err := init.Encode(&measure); err != nil {
+		t.Fatal(err)
+	}
+	payloadStart := uint32(measure.Len()) + 8 // after the mdat header
+	chunk1 := append(defragPayload(1, 10), defragPayload(2, 20)...)
+	chunk2 := append(defragPayload(3, 30), defragPayload(4, 40)...)
+	var filePayload []byte
+	if swapChunkBytes {
+		// Chunk 2's bytes precede chunk 1's in the file: descending stco.
+		stbl.Stco.ChunkOffset = []uint32{payloadStart + uint32(len(chunk2)), payloadStart}
+		filePayload = append(append([]byte{}, chunk2...), chunk1...)
+	} else {
+		stbl.Stco.ChunkOffset = []uint32{payloadStart, payloadStart + uint32(len(chunk1))}
+		filePayload = append(append([]byte{}, chunk1...), chunk2...)
+	}
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	mdat := &mp4.MdatBox{Data: filePayload}
+	if err := mdat.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 2, []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1024, Size: 12}, DecodeTime: audioDts, Data: defragPayload(9, 12)},
+		{Sample: mp4.Sample{Dur: 1024, Size: 12}, DecodeTime: audioDts + 1024, Data: defragPayload(10, 12)},
+	})
+	return buf.Bytes(), append(append([]byte{}, chunk1...), chunk2...)
+}
+
+// TestDefragmentNonMonotonicStcoKeepsSampleMapping pins that a progressive
+// prefix whose stco offsets are not monotone keeps its sample-to-chunk
+// mapping: the chunk order of the sample tables stands, so every sample
+// lands byte-correct in the output.
+func TestDefragmentNonMonotonicStcoKeepsSampleMapping(t *testing.T) {
+	data, videoPayload := writeDefragHybridPrefixFile(t, true, 0)
+	out, err := defragment(t, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, videoPayload) {
+		t.Error("video sample bytes corrupted by non-monotone chunk offsets")
+	}
+	stbl := outFile.Moov.Traks[0].Mdia.Minf.Stbl
+	wantSizes := []uint32{10, 20, 30, 40}
+	for i, want := range wantSizes {
+		if got := stbl.Stsz.GetSampleSize(i + 1); got != want {
+			t.Errorf("sample %d size %d, want %d", i+1, got, want)
+		}
+	}
+	if len(stbl.Stco.ChunkOffset) != 2 {
+		t.Errorf("video has %d chunks, want the original 2", len(stbl.Stco.ChunkOffset))
+	}
+}
+
+// TestDefragmentHybridTrackAlignsFragmentOnlyTrack pins that a track with a
+// progressive prefix starts at decode time zero and anchors the empty-edit
+// alignment of a fragment-only track with a nonzero origin.
+func TestDefragmentHybridTrackAlignsFragmentOnlyTrack(t *testing.T) {
+	data, videoPayload := writeDefragHybridPrefixFile(t, false, 1024)
+	out, err := defragment(t, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	video, audio := outFile.Moov.Traks[0], outFile.Moov.Traks[1]
+	if video.Edts != nil {
+		t.Error("hybrid track starting at zero got an edts box")
+	}
+	// 1024/44100 s is 13.93 -> 14 movie ticks; media 2048/44100 s -> 28.
+	wantElst := []mp4.ElstEntry{
+		{SegmentDuration: 14, MediaTime: -1, MediaRateInteger: 1},
+		{SegmentDuration: 28, MediaTime: 0, MediaRateInteger: 1},
+	}
+	if audio.Edts == nil || len(audio.Edts.Elst) != 1 {
+		t.Fatal("fragment-only audio track got no synthesized elst")
+	}
+	if diff := deep.Equal(audio.Edts.Elst[0].Entries, wantElst); diff != nil {
+		t.Errorf("audio elst: %v", diff)
+	}
+	if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, videoPayload) {
+		t.Error("hybrid video sample data not byte-identical")
+	}
+}
+
+// TestDefragmentFragmentSupersedesProgressiveSamples pins that a fragment
+// re-declaring decode times of the progressive prefix wins like any
+// retransmission, under the same coverage and sample-boundary rules.
+func TestDefragmentFragmentSupersedesProgressiveSamples(t *testing.T) {
+	data, videoPayload := writeDefragHybridPrefixFile(t, false, 0)
+	t.Run("covered supersession resolves", func(t *testing.T) {
+		// The prefix covers [0, 2048); this fragment re-declares [1024, 2048).
+		hybrid := bytes.NewBuffer(append([]byte{}, data...))
+		fragSamples := defragSampleRun(1024, 2, 101, 10)
+		addDefragFragment(t, hybrid, 2, 1, fragSamples)
+		out, err := defragment(t, hybrid.Bytes())
+		if err != nil {
+			t.Fatal(err)
+		}
+		outFile := decodeDefragOutput(t, out.Bytes())
+		// Prefix samples 1-2 (10+20 bytes) survive, samples 3-4 are superseded.
+		wantData := append(append([]byte{}, videoPayload[:30]...), concatSampleData(fragSamples)...)
+		if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, wantData) {
+			t.Error("video sample data must be the prefix head plus the superseding fragment")
+		}
+		if dur := outFile.Moov.Traks[0].Mdia.Mdhd.Duration; dur != 4*512 {
+			t.Errorf("video media duration %d, want %d", dur, 4*512)
+		}
+	})
+	t.Run("uncovered supersession is an error", func(t *testing.T) {
+		// [1024, 1536) is re-declared, but the prefix extended to 2048.
+		hybrid := bytes.NewBuffer(append([]byte{}, data...))
+		addDefragFragment(t, hybrid, 2, 1, defragSampleRun(1024, 1, 101, 10))
+		out, err := defragment(t, hybrid.Bytes())
+		if err == nil || !strings.Contains(err.Error(), "never re-declared") {
+			t.Errorf("uncovered supersession gave %v, want a coverage error", err)
+		}
+		if out.Len() != 0 {
+			t.Errorf("wrote %d bytes before rejecting input", out.Len())
+		}
+	})
+	t.Run("cut inside a progressive sample is an error", func(t *testing.T) {
+		hybrid := bytes.NewBuffer(append([]byte{}, data...))
+		addDefragFragment(t, hybrid, 2, 1, defragSampleRun(700, 3, 101, 10))
+		_, err := defragment(t, hybrid.Bytes())
+		if err == nil || !strings.Contains(err.Error(), "inside sample") {
+			t.Errorf("mid-sample supersession gave %v, want a sample-granularity error", err)
+		}
+	})
+}
+
+// TestDefragmentHostileProgressiveTablesAreErrors pins that compact sample
+// tables are validated against the declared sample count before expansion.
+func TestDefragmentHostileProgressiveTablesAreErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(stbl *mp4.StblBox)
+		wantErr string
+	}{
+		{name: "stts covering too many samples", mutate: func(stbl *mp4.StblBox) {
+			stbl.Stsz.SampleNumber = 3
+			stbl.Stsz.SampleSize = []uint32{10, 10, 10}
+			stbl.Stts.SampleCount = []uint32{2, 2}
+			stbl.Stts.SampleTimeDelta = []uint32{512, 512}
+			if err := stbl.Stsc.AddEntry(1, 3, 1); err != nil {
+				t.Fatal(err)
+			}
+			stbl.Stco.ChunkOffset = []uint32{8}
+		}, wantErr: "stts covers more than"},
+		{name: "stsc chunk declaring too many samples", mutate: func(stbl *mp4.StblBox) {
+			stbl.Stsz.SampleNumber = 3
+			stbl.Stsz.SampleSize = []uint32{10, 10, 10}
+			stbl.Stts.SampleCount = []uint32{3}
+			stbl.Stts.SampleTimeDelta = []uint32{512}
+			if err := stbl.Stsc.AddEntry(1, 5, 1); err != nil {
+				t.Fatal(err)
+			}
+			stbl.Stco.ChunkOffset = []uint32{8}
+		}, wantErr: "but 3 remain"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := writeDefragHostilePrefixFile(t, test.mutate)
+			_, err := defragment(t, data)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("hostile tables gave %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+// writeDefragHostilePrefixFile writes a fragmented file whose video sample
+// tables have been mutated into a hostile shape, followed by one valid audio
+// fragment so that the file classifies as fragmented.
+func writeDefragHostilePrefixFile(t *testing.T, mutate func(stbl *mp4.StblBox)) []byte {
+	t.Helper()
+	init := createDefragInit(t)
+	mutate(init.Moov.Traks[0].Mdia.Minf.Stbl)
 	var buf bytes.Buffer
 	if err := init.Encode(&buf); err != nil {
 		t.Fatal(err)
@@ -509,13 +737,41 @@ func TestDefragmentHybridInputIsError(t *testing.T) {
 	addDefragFragment(t, &buf, 1, 2, []mp4.FullSample{
 		{Sample: mp4.Sample{Dur: 1024, Size: 8}, DecodeTime: 0, Data: defragPayload(1, 8)},
 	})
-	_, err := defragment(t, buf.Bytes())
-	if err == nil || !strings.Contains(err.Error(), "progressive samples") {
-		t.Errorf("hybrid input error %v", err)
+	return buf.Bytes()
+}
+
+func TestDefragmentHugeDeclaredSampleCountIsError(t *testing.T) {
+	data := writeDefragHostilePrefixFile(t, func(stbl *mp4.StblBox) {
+		stbl.Stsz.SampleUniformSize = 20
+		stbl.Stsz.SampleNumber = math.MaxUint32
+	})
+	_, err := defragment(t, data)
+	if err == nil || !strings.Contains(err.Error(), "more than the") {
+		t.Errorf("huge declared sample count error %v", err)
 	}
-	// The hybrid track is accepted when it is not kept.
-	if _, err := defragment(t, buf.Bytes(), 2); err != nil {
-		t.Errorf("dropping the hybrid track: %v", err)
+}
+
+// The crafted ctts counts {5, 4294967294} wrap the uint32 accumulation in
+// mp4ff's decoder to EndSampleNr [0, 5, 3]: the final entry matches the
+// 3-sample stsz while the intermediate one overshoots it.
+func TestDefragmentCttsOverflowIsError(t *testing.T) {
+	data := writeDefragHostilePrefixFile(t, func(stbl *mp4.StblBox) {
+		stbl.Stsz.SampleNumber = 3
+		stbl.Stsz.SampleSize = []uint32{10, 10, 10}
+		stbl.Stts.SampleCount = []uint32{3}
+		stbl.Stts.SampleTimeDelta = []uint32{512}
+		stbl.AddChild(&mp4.CttsBox{
+			EndSampleNr:  []uint32{0, 5, 3},
+			SampleOffset: []int32{100, 200},
+		})
+		if err := stbl.Stsc.AddEntry(1, 3, 1); err != nil {
+			t.Fatal(err)
+		}
+		stbl.Stco.ChunkOffset = []uint32{8}
+	})
+	_, err := defragment(t, data)
+	if err == nil || !strings.Contains(err.Error(), "ctts entry") {
+		t.Errorf("overflowing ctts error %v", err)
 	}
 }
 
@@ -1779,5 +2035,135 @@ func TestDefragmentBoundaryCutInPaddingKeepsCutoff(t *testing.T) {
 	}
 	if out.Len() != 0 {
 		t.Errorf("wrote %d bytes before rejecting input", out.Len())
+	}
+}
+
+// TestDefragmentHybridTrackUnsupportedElstIsError pins that edit lists are
+// validated for a progressive-prefix track too, whose origin is always 0.
+func TestDefragmentHybridTrackUnsupportedElstIsError(t *testing.T) {
+	init := createDefragInit(t)
+	init.Moov.Traks[0].Edts.Children[0].(*mp4.ElstBox).Entries = []mp4.ElstEntry{
+		{SegmentDuration: 600, MediaTime: 0, MediaRateInteger: 2},
+	}
+	stbl := init.Moov.Traks[0].Mdia.Minf.Stbl
+	stbl.Stts.SampleCount = []uint32{1}
+	stbl.Stts.SampleTimeDelta = []uint32{512}
+	stbl.Stsz.SampleNumber = 1
+	stbl.Stsz.SampleSize = []uint32{10}
+	if err := stbl.Stsc.AddEntry(1, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	stbl.Stco.ChunkOffset = []uint32{8}
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 2, []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1024, Size: 8}, DecodeTime: 0, Data: defragPayload(1, 8)},
+	})
+	_, err := defragment(t, buf.Bytes(), 1)
+	if err == nil || !strings.Contains(err.Error(), "unsupported media rate") {
+		t.Errorf("rate-2 edit on a hybrid track gave %v, want an unsupported media rate error", err)
+	}
+}
+
+// TestDefragmentChunksWithoutStszIsError pins that a progressive part whose
+// chunks are declared without an stsz (the unsupported stz2 shape) errors
+// instead of silently dropping the samples.
+func TestDefragmentChunksWithoutStszIsError(t *testing.T) {
+	init := createDefragInit(t)
+	stbl := init.Moov.Traks[0].Mdia.Minf.Stbl
+	// Two progressive samples declared by stts/stsc/stco but not stsz.
+	stbl.Stts.SampleCount = []uint32{2}
+	stbl.Stts.SampleTimeDelta = []uint32{512}
+	if err := stbl.Stsc.AddEntry(1, 2, 1); err != nil {
+		t.Fatal(err)
+	}
+	stbl.Stco.ChunkOffset = []uint32{8}
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 1, []mp4.FullSample{
+		{Sample: mp4.Sample{Flags: defragSyncFlags(), Dur: 512, Size: 10}, DecodeTime: 1024, Data: defragPayload(1, 10)},
+	})
+	out, err := defragment(t, buf.Bytes(), 1)
+	if err == nil || !strings.Contains(err.Error(), "stz2 is not supported") {
+		t.Fatalf("chunks without stsz gave %v, want an stz2 error", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("wrote %d bytes before rejecting input", out.Len())
+	}
+}
+
+// TestDefragmentProgressiveSaizSaioIsError pins that per-sample encryption
+// auxiliary information on the progressive part rejects, also when the
+// fragments belong to another track so the traf check never fires.
+func TestDefragmentProgressiveSaizSaioIsError(t *testing.T) {
+	init := createDefragInit(t)
+	stbl := init.Moov.Traks[0].Mdia.Minf.Stbl
+	stbl.Stts.SampleCount = []uint32{1}
+	stbl.Stts.SampleTimeDelta = []uint32{512}
+	stbl.Stsz.SampleNumber = 1
+	stbl.Stsz.SampleSize = []uint32{10}
+	if err := stbl.Stsc.AddEntry(1, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	stbl.Stco.ChunkOffset = []uint32{8}
+	stbl.AddChild(&mp4.SaizBox{DefaultSampleInfoSize: 8, SampleCount: 1})
+	stbl.AddChild(&mp4.SaioBox{Offset: []int64{0}})
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	addDefragFragment(t, &buf, 1, 2, []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1024, Size: 8}, DecodeTime: 0, Data: defragPayload(1, 8)},
+	})
+	_, err := defragment(t, buf.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "auxiliary information") {
+		t.Errorf("progressive saiz/saio gave %v, want a fail-closed error", err)
+	}
+}
+
+// TestDefragmentConstantIVEncryptionPassesThrough pins that full-sample
+// encryption with a constant IV, which has no senc/saiz/saio, converts
+// losslessly with the sinf kept in the sample description.
+func TestDefragmentConstantIVEncryptionPassesThrough(t *testing.T) {
+	init := mp4.CreateEmptyInit()
+	init.Moov.Mvhd.Timescale = 600
+	trak := init.AddEmptyTrack(defragAudioTimescale, "audio", "en")
+	if err := trak.SetAACDescriptor(2, defragAudioTimescale); err != nil {
+		t.Fatal(err)
+	}
+	key, _ := hex.DecodeString("00112233445566778899aabbccddeeff")
+	iv, _ := hex.DecodeString("11223344556677889900aabbccddeeff")
+	kidUUID, _ := mp4.NewUUIDFromString("00112233445566778899aabbccddeeff")
+	if _, err := mp4.InitProtect(init, key, iv, "cbcs", kidUUID, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	samples := []mp4.FullSample{
+		{Sample: mp4.Sample{Dur: 1024, Size: 16}, DecodeTime: 0, Data: defragPayload(1, 16)},
+		{Sample: mp4.Sample{Dur: 1024, Size: 16}, DecodeTime: 1024, Data: defragPayload(2, 16)},
+	}
+	addDefragFragment(t, &buf, 1, 1, samples)
+	out, err := defragment(t, buf.Bytes(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outFile := decodeDefragOutput(t, out.Bytes())
+	entry := outFile.Moov.Traks[0].Mdia.Minf.Stbl.Stsd.Children[0]
+	enca, ok := entry.(*mp4.AudioSampleEntryBox)
+	if !ok || enca.Type() != "enca" || enca.Sinf == nil {
+		t.Fatalf("sample entry %s lost its protection, want enca with sinf", entry.Type())
+	}
+	if enca.Sinf.Schm == nil || enca.Sinf.Schm.SchemeType != "cbcs" {
+		t.Error("sinf lost its cbcs scheme")
+	}
+	if got := readProgressiveSampleData(t, outFile, 1); !bytes.Equal(got, concatSampleData(samples)) {
+		t.Error("encrypted sample data not byte-identical")
 	}
 }

--- a/mp4/stss.go
+++ b/mp4/stss.go
@@ -75,6 +75,19 @@ func (b *StssBox) expectedSize(entryCount uint32) uint64 {
 	return uint64(boxHeaderSize + 8 + uint64(entryCount)*4)
 }
 
+// SampleIsSync returns for each of nrSamples samples whether it is a sync
+// sample, validating that no entry lies outside that count.
+func (b *StssBox) SampleIsSync(nrSamples uint32) ([]bool, error) {
+	sync := make([]bool, nrSamples)
+	for _, nr := range b.SampleNumber {
+		if nr < 1 || nr > nrSamples {
+			return nil, fmt.Errorf("stss entry %d outside the %d declared samples", nr, nrSamples)
+		}
+		sync[nr-1] = true
+	}
+	return sync, nil
+}
+
 // IsSyncSample - check if sample (one-based) sampleNr is a sync sample
 func (b *StssBox) IsSyncSample(sampleNr uint32) (isSync bool) {
 	// Based on a binary search algorithm from the Go standard library code.

--- a/mp4/stss_test.go
+++ b/mp4/stss_test.go
@@ -74,3 +74,20 @@ func TestStssNoSamples(t *testing.T) {
 		}
 	}
 }
+
+func TestStssSampleIsSync(t *testing.T) {
+	stss := &mp4.StssBox{SampleNumber: []uint32{1, 3}}
+	sync, err := stss.SampleIsSync(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []bool{true, false, true}
+	for i := range want {
+		if sync[i] != want[i] {
+			t.Errorf("sample %d sync %v, want %v", i+1, sync[i], want[i])
+		}
+	}
+	if _, err := stss.SampleIsSync(2); err == nil {
+		t.Error("an entry outside the declared samples must be an error")
+	}
+}

--- a/mp4/stts.go
+++ b/mp4/stts.go
@@ -126,6 +126,27 @@ func (b *SttsBox) GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32, er
 	return decTime, dur, nil
 }
 
+// SampleDurations returns the duration of each of nrSamples samples,
+// validating that the entries cover exactly that many samples.
+func (b *SttsBox) SampleDurations(nrSamples uint32) ([]uint32, error) {
+	if len(b.SampleTimeDelta) != len(b.SampleCount) {
+		return nil, fmt.Errorf("stts has %d durations for %d entries", len(b.SampleTimeDelta), len(b.SampleCount))
+	}
+	durs := make([]uint32, 0, nrSamples)
+	for i := range b.SampleCount {
+		if uint64(len(durs))+uint64(b.SampleCount[i]) > uint64(nrSamples) {
+			return nil, fmt.Errorf("stts covers more than the %d declared samples", nrSamples)
+		}
+		for j := uint32(0); j < b.SampleCount[i]; j++ {
+			durs = append(durs, b.SampleTimeDelta[i])
+		}
+	}
+	if uint32(len(durs)) != nrSamples {
+		return nil, fmt.Errorf("stts covers %d samples, not the %d declared", len(durs), nrSamples)
+	}
+	return durs, nil
+}
+
 // GetDur - get dur for a specific sample
 func (b *SttsBox) GetDur(sampleNr uint32) (dur uint32) {
 	if sampleNr == 0 {

--- a/mp4/stts_test.go
+++ b/mp4/stts_test.go
@@ -117,3 +117,33 @@ func TestSttsEmptyBox(t *testing.T) {
 		t.Error("expected error from GetSampleNrAtTime on stts without entries, got none")
 	}
 }
+
+func TestSttsSampleDurations(t *testing.T) {
+	stts := &mp4.SttsBox{
+		SampleCount:     []uint32{2, 1},
+		SampleTimeDelta: []uint32{10, 14},
+	}
+	durs, err := stts.SampleDurations(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []uint32{10, 10, 14}
+	for i := range want {
+		if durs[i] != want[i] {
+			t.Errorf("duration %d is %d, want %d", i, durs[i], want[i])
+		}
+	}
+	if _, err := stts.SampleDurations(2); err == nil {
+		t.Error("entries covering more samples than declared must be an error")
+	}
+	if _, err := stts.SampleDurations(4); err == nil {
+		t.Error("entries covering fewer samples than declared must be an error")
+	}
+}
+
+func TestSttsSampleDurationsMismatchedSlices(t *testing.T) {
+	stts := &mp4.SttsBox{SampleCount: []uint32{2, 1}, SampleTimeDelta: []uint32{10}}
+	if _, err := stts.SampleDurations(3); err == nil {
+		t.Error("mismatched stts slices must be an error, not a panic")
+	}
+}


### PR DESCRIPTION
## Problem

Hybrid files carry a progressive part in the moov sample tables followed by
fragments (a recorder that finalizes periodically, or a progressive file
extended by appending fragments). #557 rejects them; converting requires
dropping the hybrid track via track selection.

## Fix

The moov sample tables are expanded into the same sample list the fragments
feed (stts/ctts/stsc/stsz/stss/stco/co64, with hostile-table guards so
declared counts a file cannot physically hold error out before any
count-proportional allocation). Per-track chunk order follows the sample
tables unconditionally; across tracks, chunk runs are interleaved by input
file position, so non-monotonic chunk offsets (legal, if unusual) cannot
corrupt the sample-to-bytes mapping.

The progressive part counts as each track's earliest declaration and flows
through the overlap machinery from #560 unchanged: a later fragment may
supersede progressive samples under the same later-declarer-wins and
no-silently-dropped-ranges rules, and mid-sample cuts reject. A hybrid track
starts at decode time 0 by construction and anchors the cross-track
alignment of #557 for later-starting fragment-only tracks. Purely
progressive input (no fragments) still rejects as not fragmented.

## Tests

Hybrid round-trips with multi-entry stsc, sync-sample subsets, and negative
composition offsets; non-monotonic chunk offsets round-trip byte-correct;
fragments superseding progressive samples (covered resolves, uncovered and
mid-sample reject); hybrid track anchoring a fragment-only track's empty
edit; hostile stts/stsc/stsz/ctts tables. All fragmented testdata files
convert byte-identically to #560 output. `go test ./...`, `go vet`, `gofmt`,
`golangci-lint` pass.


