### PR TITLE
fix(mp4): NewSdtpEntry dropped sampleDependsOn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `NewSdtpEntry` packed the `sampleDependedOn` argument into both two-bit
+  dependency fields and dropped `sampleDependsOn`, so every entry it built
+  carried a wrong sample_depends_on value. Note that entries built with the
+  broken constructor re-encode byte-identically; only newly constructed
+  entries change
+
 ## [0.56.0] - 2026-08-22
 
 ### Added

--- a/mp4/sdtp.go
+++ b/mp4/sdtp.go
@@ -26,7 +26,7 @@ type SdtpEntry uint8
 
 // NewSdtpEntry - make new SdtpEntry from 2-bit parameters
 func NewSdtpEntry(isLeading, sampleDependsOn, sampleDependedOn, hasRedundancy uint8) SdtpEntry {
-	return SdtpEntry(isLeading<<6 | sampleDependedOn<<4 | sampleDependedOn<<2 | hasRedundancy)
+	return SdtpEntry(isLeading<<6 | sampleDependsOn<<4 | sampleDependedOn<<2 | hasRedundancy)
 }
 
 // IsLeading (bits 0-1)

--- a/mp4/sdtp_test.go
+++ b/mp4/sdtp_test.go
@@ -6,6 +6,37 @@ import (
 	"github.com/Eyevinn/mp4ff/mp4"
 )
 
+func TestNewSdtpEntry(t *testing.T) {
+	cases := []struct {
+		isLeading, dependsOn, dependedOn, hasRedundancy uint8
+	}{
+		{0, 0, 0, 0},
+		{1, 2, 1, 1},
+		{2, 1, 2, 0}, // typical non-disposable non-I-picture
+		{3, 2, 0, 3},
+		{0, 1, 0, 0},
+	}
+	for _, c := range cases {
+		entry := mp4.NewSdtpEntry(c.isLeading, c.dependsOn, c.dependedOn, c.hasRedundancy)
+		if got := entry.IsLeading(); got != c.isLeading {
+			t.Errorf("NewSdtpEntry(%d,%d,%d,%d).IsLeading() = %d, want %d",
+				c.isLeading, c.dependsOn, c.dependedOn, c.hasRedundancy, got, c.isLeading)
+		}
+		if got := entry.SampleDependsOn(); got != c.dependsOn {
+			t.Errorf("NewSdtpEntry(%d,%d,%d,%d).SampleDependsOn() = %d, want %d",
+				c.isLeading, c.dependsOn, c.dependedOn, c.hasRedundancy, got, c.dependsOn)
+		}
+		if got := entry.SampleIsDependedOn(); got != c.dependedOn {
+			t.Errorf("NewSdtpEntry(%d,%d,%d,%d).SampleIsDependedOn() = %d, want %d",
+				c.isLeading, c.dependsOn, c.dependedOn, c.hasRedundancy, got, c.dependedOn)
+		}
+		if got := entry.SampleHasRedundancy(); got != c.hasRedundancy {
+			t.Errorf("NewSdtpEntry(%d,%d,%d,%d).SampleHasRedundancy() = %d, want %d",
+				c.isLeading, c.dependsOn, c.dependedOn, c.hasRedundancy, got, c.hasRedundancy)
+		}
+	}
+}
+
 func TestSdtp(t *testing.T) {
 	entries := []mp4.SdtpEntry{
 		mp4.NewSdtpEntry(0, 2, 0, 0),


### PR DESCRIPTION
## Summary

`NewSdtpEntry` packs the `sampleDependedOn` argument into **both** two-bit dependency fields (bits 5–4 and 3–2) and never uses `sampleDependsOn`:

```go
return SdtpEntry(isLeading<<6 | sampleDependedOn<<4 | sampleDependedOn<<2 | hasRedundancy)
```

So every entry built with the constructor carries a wrong `sample_depends_on` value (and, whenever the two arguments differ, a wrong entry byte overall). The decode accessors (`SampleDependsOn`/`SampleIsDependedOn`) are correct — only construction is affected.

Found while writing tests for a packager that mirrors `sdtp` entries into fragment sample flags: hand-packed expected values disagreed with the constructor's output.

## Fix

One token: `sampleDependedOn<<4` → `sampleDependsOn<<4`.

## Test

Adds `TestNewSdtpEntry`, which round-trips all four constructor arguments through their accessors. The existing `TestSdtp` only round-tripped encode/decode, which cannot see the swapped field (a wrongly-built entry re-encodes byte-identically). The new test fails on the previous code and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)