### PR TITLE
fix(mp4): GetSampleData panicked when startSampleNr > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carried a wrong sample_depends_on value. Note that entries built with the
   broken constructor re-encode byte-identically; only newly constructed
   entries change
+- `TrakBox.GetSampleData` indexed its result slice with the absolute sample
+  number instead of the offset within the requested interval, panicking with
+  index out of range for any interval not starting at sample 1
 
 ## [0.56.0] - 2026-08-22
 

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -127,7 +127,7 @@ func (t *TrakBox) GetSampleData(startSampleNr, endSampleNr uint32) ([]Sample, er
 		if ctts != nil {
 			cto = ctts.GetCompositionTimeOffset(nr)
 		}
-		samples[nr-1] = Sample{
+		samples[nr-startSampleNr] = Sample{
 			Flags:                 createSampleFlagsFromProgressiveBoxes(stss, sdtp, nr),
 			Dur:                   stts.GetDur(nr),
 			Size:                  stbl.Stsz.GetSampleSize(int(nr)),

--- a/mp4/trak_test.go
+++ b/mp4/trak_test.go
@@ -34,6 +34,25 @@ func TestTrakSampleFunctions(t *testing.T) {
 	if len(first2Samples) != 2 {
 		t.Fatalf("expected 2 samples, got %d", len(first2Samples))
 	}
+	// An interval not starting at sample 1 must yield the same samples as
+	// the corresponding tail of a from-the-start interval (this used to
+	// panic on samples[nr-1] indexing past the result slice).
+	first4Samples, err := trak.GetSampleData(1, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	samples2to4, err := trak.GetSampleData(2, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples2to4) != 3 {
+		t.Fatalf("expected 3 samples, got %d", len(samples2to4))
+	}
+	for i, s := range samples2to4 {
+		if s != first4Samples[i+1] {
+			t.Errorf("sample %d differs: got %+v, want %+v", i+2, s, first4Samples[i+1])
+		}
+	}
 	ranges, err := trak.GetRangesForSampleInterval(1, 2)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

`TrakBox.GetSampleData` sizes its result slice to the requested interval but indexes it with the absolute sample number:

```go
samples := make([]Sample, endSampleNr-startSampleNr+1)
...
samples[nr-1] = Sample{...}
```

For any interval not starting at sample 1 this writes past the end of the slice and panics with index out of range (e.g. `GetSampleData(2, 4)` makes a 3-element slice and writes indexes 1–3).

## Fix

Index by the offset within the interval: `samples[nr-startSampleNr]`.

## Test

Extends `TestTrakSampleFunctions` with a `GetSampleData(2, 4)` call, asserting it returns the same samples as the corresponding tail of `GetSampleData(1, 4)`. Panics on the previous code, passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)