### PR TITLE
fix(mp4): error instead of panic when trun sample sizes exceed mdat data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `TrunBox.GetFullSamples` returns an error when the trun-declared sample
+  sizes point outside the mdat data (a truncated or corrupt file), instead
+  of panicking with index out of range. Signature change:
+  `GetFullSamples(...) []FullSample` → `GetFullSamples(...) ([]FullSample, error)`.
+  `Fragment.GetFullSamples` (unchanged signature) propagates the error
+
 ### Fixed
 
 - `NewSdtpEntry` packed the `sampleDependedOn` argument into both two-bit
@@ -17,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TrakBox.GetSampleData` indexed its result slice with the absolute sample
   number instead of the offset within the requested interval, panicking with
   index out of range for any interval not starting at sample 1
+- `TrunBox.GetSampleInterval` (and thereby `Fragment.GetSampleInterval`)
+  returns an error instead of panicking when the requested interval points
+  outside the mdat data
 
 ## [0.56.0] - 2026-08-22
 

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -185,7 +185,11 @@ func (f *Fragment) GetFullSamples(trex *TrexBox) ([]FullSample, error) {
 		} else {
 			offsetInMdat = 0
 		}
-		samples = append(samples, trun.GetFullSamples(uint32(offsetInMdat), baseTime, mdat)...)
+		trunSamples, err := trun.GetFullSamples(uint32(offsetInMdat), baseTime, mdat)
+		if err != nil {
+			return nil, err
+		}
+		samples = append(samples, trunSamples...)
 		baseTime += totalDur // Next trun start after this
 	}
 

--- a/mp4/fragment_test.go
+++ b/mp4/fragment_test.go
@@ -62,3 +62,27 @@ func TestFragmentSampleIntervals(t *testing.T) {
 	}
 	sampleItvl.Reset()
 }
+
+func TestFragmentGetFullSamplesTruncatedMdat(t *testing.T) {
+	frag, err := mp4.CreateFragment(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := mp4.FullSample{
+		Sample: mp4.Sample{
+			Flags: mp4.SyncSampleFlags,
+			Dur:   1024,
+			Size:  4,
+		},
+		DecodeTime: 0,
+		Data:       []byte{0, 1, 2, 3},
+	}
+	frag.AddFullSample(fs)
+	// Simulate a truncated file: the trun declares more sample bytes
+	// than the mdat carries.
+	frag.Mdat.Data = frag.Mdat.Data[:2]
+
+	if _, err := frag.GetFullSamples(nil); err == nil {
+		t.Error("expected error when mdat is truncated, got nil")
+	}
+}

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -363,12 +363,18 @@ func (t *TrunBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 // offsetInMdat is offset in mdat data (data normally starts 8 or 16 bytes after start of mdat box)
 // baseDecodeTime is decodeTime in tfdt in track timescale (timescale in mfhd)
 // To fill missing individual values from tfhd and trex defaults, call trun.AddSampleDefaultValues() before this call
-func (t *TrunBox) GetFullSamples(offsetInMdat uint32, baseDecodeTime uint64, mdat *MdatBox) []FullSample {
+// An error is returned if the sample sizes point outside the mdat data (e.g. a truncated file).
+func (t *TrunBox) GetFullSamples(offsetInMdat uint32, baseDecodeTime uint64, mdat *MdatBox) ([]FullSample, error) {
 	samples := make([]FullSample, 0, t.SampleCount())
 	var accDur uint64 = 0
-	for _, s := range t.Samples {
+	for nr, s := range t.Samples {
 		dTime := baseDecodeTime + accDur
 
+		end := uint64(offsetInMdat) + uint64(s.Size)
+		if end > uint64(len(mdat.Data)) {
+			return nil, fmt.Errorf("sample %d range %d-%d is outside mdat data (size %d)",
+				nr+1, offsetInMdat, end, len(mdat.Data))
+		}
 		newSample := FullSample{
 			Sample:     s,
 			DecodeTime: dTime,
@@ -378,7 +384,7 @@ func (t *TrunBox) GetFullSamples(offsetInMdat uint32, baseDecodeTime uint64, mda
 		accDur += uint64(s.Dur)
 		offsetInMdat += s.Size
 	}
-	return samples
+	return samples, nil
 }
 
 // GetSamples - get all trun sample data
@@ -428,6 +434,11 @@ func (t *TrunBox) GetSampleInterval(startSampleNr, endSampleNr uint32, baseDecod
 	si.OffsetInMdat = offsetInMdat
 	si.Size = size
 	if mdat != nil && !mdat.IsLazy() {
+		end := uint64(si.OffsetInMdat) + uint64(si.Size)
+		if end > uint64(len(mdat.Data)) {
+			return SampleInterval{}, fmt.Errorf("sample interval range %d-%d is outside mdat data (size %d)",
+				si.OffsetInMdat, end, len(mdat.Data))
+		}
 		si.Data = mdat.Data[si.OffsetInMdat : si.OffsetInMdat+si.Size]
 	}
 	return si, nil

--- a/mp4/trun_test.go
+++ b/mp4/trun_test.go
@@ -197,3 +197,35 @@ func TestCommonDuration(t *testing.T) {
 		}
 	}
 }
+
+func TestGetFullSamplesTruncatedMdat(t *testing.T) {
+	trun := mp4.CreateTrun(0)
+	trun.AddSamples([]mp4.Sample{
+		{Flags: mp4.SyncSampleFlags, Dur: 1024, Size: 4},
+		{Flags: mp4.NonSyncSampleFlags, Dur: 1024, Size: 4},
+	})
+	mdat := &mp4.MdatBox{Data: []byte{0, 1, 2, 3, 4, 5}} // 6 bytes, but 8 declared
+
+	if _, err := trun.GetFullSamples(0, 0, mdat); err == nil {
+		t.Error("expected error when sample sizes point outside mdat data, got nil")
+	}
+	if _, err := trun.GetSampleInterval(1, 2, 0, mdat, 0); err == nil {
+		t.Error("expected error when sample interval points outside mdat data, got nil")
+	}
+
+	mdat.Data = []byte{0, 1, 2, 3, 4, 5, 6, 7}
+	samples, err := trun.GetFullSamples(0, 0, mdat)
+	if err != nil {
+		t.Fatalf("unexpected error with complete mdat: %v", err)
+	}
+	if len(samples) != 2 {
+		t.Errorf("expected 2 samples, got %d", len(samples))
+	}
+	si, err := trun.GetSampleInterval(1, 2, 0, mdat, 0)
+	if err != nil {
+		t.Fatalf("unexpected error with complete mdat: %v", err)
+	}
+	if len(si.Data) != 8 {
+		t.Errorf("expected 8 bytes of interval data, got %d", len(si.Data))
+	}
+}


### PR DESCRIPTION
## Summary

A truncated (or corrupt) fragmented file whose `moof` decodes cleanly but whose `mdat` carries fewer bytes than the trun-declared sample sizes makes both mdat slice sites panic with index out of range instead of returning an error:

- `TrunBox.GetFullSamples`: `mdat.Data[offsetInMdat : offsetInMdat+s.Size]`
- `TrunBox.GetSampleInterval`: `mdat.Data[si.OffsetInMdat : si.OffsetInMdat+si.Size]`

`Fragment.GetFullSamples` checks the trun's *start* offset against the mdat size (`offset in mdata beyond size`) but nothing checks that the declared sample sizes stay inside it. Found by fuzzing a fragmented-mp4 parser built on `Fragment.GetFullSamples` — a truncated real file reproduces it directly through `DecodeFile` + `GetFullSamples`.

## Fix

Bounds-check (in uint64, so a large size cannot wrap) before each slice and return an error naming the offending range.

`TrunBox.GetSampleInterval` already returns an error, so that one is non-breaking. `TrunBox.GetFullSamples` did not — this PR changes its signature to `([]FullSample, error)`, leaning on the README's pre-1.0 stability note. `Fragment.GetFullSamples` and `Fragment.GetSampleInterval` keep their signatures and propagate the error. If you'd rather keep the `TrunBox.GetFullSamples` signature I can rework it to validate the total trun size in `Fragment.GetFullSamples` instead — but the exported method itself would then keep the panic for direct callers.

## Tests

- `TestGetFullSamplesTruncatedMdat` (trun-level): both methods error on a short mdat and still succeed on a complete one.
- `TestFragmentGetFullSamplesTruncatedMdat` (fragment-level): a built fragment with a truncated `Mdat.Data` errors instead of panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)