### PR TITLE
fix: error instead of panic for out-of-bounds sample tables and nalu lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mp4ff-crop` panicked on a file whose ctts, stts, stsc or stsz does not
   cover all samples of the track, and reported only the last of several
   cropping errors
+- `CryptSampleCenc`, `DecryptSampleCbcs` and `EncryptSampleCbcs` panicked for
+  subsample patterns whose byte counts reach outside the sample. Nothing ties
+  the senc byte counts to the actual sample sizes, and big counts could also
+  wrap in uint32. They now return an error
+- `DecryptFragment` and `DecryptFragmentWithKeys` panicked when the senc box
+  held subsample information for a different number of samples than the trun
+  declares
 
 ## [0.56.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DecryptFragment` and `DecryptFragmentWithKeys` panicked when the senc box
   held subsample information for a different number of samples than the trun
   declares
+- The nalu scanning functions in the `avc` and `hevc` packages trusted the
+  4-byte nalu length fields of a sample, so a bad length field made them slice
+  outside the sample and panic. A length field close to 2^32 also wrapped when
+  added to the position, which defeated the check in `avc.GetNalusFromSample`
+  and in `GetAVCProtectRanges`/`GetHEVCProtectRanges`. Affected are
+  `FindNaluTypes`, `FindNaluTypesUpToFirstVideoNALU`/`...Nalu`,
+  `ContainsNaluType`, `IsIDRSample`, `IsRAPSample`, `HasParameterSets`,
+  `GetParameterSets`, `GetNalusFromSample` and `ConvertSampleToByteStream`
+- `avc.ContainsNaluType` (and thereby `avc.IsIDRSample`) lacked the guard
+  against samples shorter than 4 bytes that the other scanning functions have,
+  so the loop limit underflowed and the first read went outside the sample
 
 ## [0.56.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TrunBox.GetSampleInterval` (and thereby `Fragment.GetSampleInterval`)
   returns an error instead of panicking when the requested interval points
   outside the mdat data
+- `File.CopySampleData` returns an error instead of panicking when a chunk
+  offset or sample size in the sample tables points outside the mdat data.
+  This is the progressive-file counterpart of the fragmented `trun` case
+- `MdatBox.ReadData` and `MdatBox.CopyData` rejected valid ranges ending at
+  the very end of the mdat payload, so reading the last sample (or the full
+  payload) failed with "invalid range provided". They now also reject a start
+  before the mdat payload, which previously underflowed and panicked
+- `mp4ff-nallister`, `mp4ff-pslister` and `mp4ff-subslister` panicked instead
+  of reporting an error on a progressive file with sample tables pointing
+  outside the mdat data
 
 ## [0.56.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of panicking with index out of range. Signature change:
   `GetFullSamples(...) []FullSample` → `GetFullSamples(...) ([]FullSample, error)`.
   `Fragment.GetFullSamples` (unchanged signature) propagates the error
+- `StscBox.GetChunk` returns an error instead of panicking for chunk numbers
+  that no stsc entry covers. Signature change:
+  `GetChunk(chunkNr uint32) Chunk` → `GetChunk(chunkNr uint32) (Chunk, error)`
 
 ### Fixed
 
@@ -38,6 +41,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mp4ff-nallister`, `mp4ff-pslister` and `mp4ff-subslister` panicked instead
   of reporting an error on a progressive file with sample tables pointing
   outside the mdat data
+- `CttsBox.GetCompositionTimeOffset` panicked for a sample beyond the entries
+  of the box, which a file with a ctts and stsz that disagree on the sample
+  count triggers. Such a sample now gets composition time offset 0
+- `TrakBox.GetSampleData` panicked for an sdtp with fewer entries than the
+  track has samples. The sample flags from a missing sdtp entry are now left
+  at their default
+- `StscBox.GetContainingChunks` and `StscBox.ChunkNrFromSampleNr` panicked
+  with index out of range for an stsc without entries (which is valid, and
+  what init segments have) and divided by zero for an entry with
+  samplesPerChunk == 0. Both now return an error
+- `StscBox.GetSampleDescriptionID` and `StszBox.GetSampleSize` indexed outside
+  their tables for out-of-range chunk and sample numbers
+- `StszBox.GetTotalSampleSize` validated the sample interval against
+  `SampleNumber` but indexed `SampleSize`, so a box where the two disagree
+  panicked
+- `mp4ff-crop` panicked on a file whose ctts, stts, stsc or stsz does not
+  cover all samples of the track, and reported only the last of several
+  cropping errors
 
 ## [0.56.0] - 2026-08-22
 

--- a/avc/annexb.go
+++ b/avc/annexb.go
@@ -166,8 +166,12 @@ func getStartCodePositions(stream []byte) (scNalus []scNalu, minStartCodeLength 
 func ConvertSampleToByteStream(sample []byte) []byte {
 	sampleLength := uint32(len(sample))
 	var pos uint32 = 0
-	for pos < sampleLength {
+	for pos+4 <= sampleLength {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
+		// uint64 arithmetic so that a length field close to 2^32 cannot wrap
+		if uint64(pos)+4+uint64(naluLength) > uint64(sampleLength) {
+			break // bad nalu length field: leave the rest as is
+		}
 		startCode := []byte{0, 0, 0, 1}
 		copy(sample[pos:pos+4], startCode)
 		pos += naluLength + 4

--- a/avc/avc.go
+++ b/avc/avc.go
@@ -59,6 +59,14 @@ func GetNaluType(naluHeader byte) NaluType {
 	return NaluType(naluHeader & 0x1f)
 }
 
+// naluFits reports whether a nalu of naluLength bytes starting at pos fits
+// inside a sample of sampleLength bytes. The length fields come from the
+// sample itself, so they must be checked before use. The arithmetic is done in
+// uint64 so that a length field close to 2^32 cannot wrap.
+func naluFits(pos, naluLength uint32, sampleLength int) bool {
+	return naluLength > 0 && uint64(pos)+uint64(naluLength) <= uint64(sampleLength)
+}
+
 // FindNaluTypes - find list of NAL unit types in sample
 func FindNaluTypes(sample []byte) []NaluType {
 	length := len(sample)
@@ -67,9 +75,12 @@ func FindNaluTypes(sample []byte) []NaluType {
 	}
 	naluList := make([]NaluType, 0, 2)
 	var pos uint32 = 0
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
+		if !naluFits(pos, naluLength, length) {
+			break // bad nalu length field: stop scanning
+		}
 		naluType := GetNaluType(sample[pos])
 		naluList = append(naluList, naluType)
 		pos += naluLength
@@ -85,9 +96,12 @@ func FindNaluTypesUpToFirstVideoNALU(sample []byte) []NaluType {
 	}
 	naluList := make([]NaluType, 0)
 	var pos uint32 = 0
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
+		if !naluFits(pos, naluLength, length) {
+			break // bad nalu length field: stop scanning
+		}
 		naluType := GetNaluType(sample[pos])
 		naluList = append(naluList, naluType)
 		pos += naluLength
@@ -107,9 +121,12 @@ func IsIDRSample(sample []byte) bool {
 func ContainsNaluType(sample []byte, specificNalType NaluType) bool {
 	var pos uint32 = 0
 	length := len(sample)
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
+		if !naluFits(pos, naluLength, length) {
+			break // bad nalu length field: stop scanning
+		}
 		naluType := GetNaluType(sample[pos])
 		if naluType == specificNalType {
 			return true
@@ -143,9 +160,12 @@ func GetParameterSets(sample []byte) (sps [][]byte, pps [][]byte) {
 	sampleLength := uint32(len(sample))
 	var pos uint32 = 0
 naluLoop:
-	for pos < sampleLength {
+	for pos+4 < sampleLength {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
+		if !naluFits(pos, naluLength, len(sample)) {
+			break // bad nalu length field: stop scanning
+		}
 		naluHdr := sample[pos]
 		switch naluType := GetNaluType(naluHdr); {
 		case naluType == NALU_SPS:

--- a/avc/badnalu_test.go
+++ b/avc/badnalu_test.go
@@ -1,0 +1,72 @@
+package avc_test
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/avc"
+)
+
+// TestScanBadSamples checks that the sample scanning functions handle samples
+// that are too short to hold a length field and length fields that reach
+// outside the sample, instead of panicking. Length fields close to 2^32 also
+// must not wrap when added to the position.
+func TestScanBadSamples(t *testing.T) {
+	samples := map[string][]byte{
+		"empty":                  {},
+		"one byte":               {0x67},
+		"three bytes":            {0, 0, 0},
+		"length field only":      {0, 0, 0, 4},
+		"length beyond sample":   {0, 0, 0x10, 0, 0x67, 0x42, 0x00},
+		"length wrapping uint32": {0xff, 0xff, 0xff, 0xff, 0x67, 0, 0, 0},
+		"zero length":            {0, 0, 0, 0, 0x67, 0, 0, 0},
+	}
+	for desc, sample := range samples {
+		t.Run(desc, func(t *testing.T) {
+			// A copy per call, since ConvertSampleToByteStream works in place.
+			cp := func() []byte {
+				out := make([]byte, len(sample))
+				copy(out, sample)
+				return out
+			}
+			_ = avc.FindNaluTypes(cp())
+			_ = avc.FindNaluTypesUpToFirstVideoNALU(cp())
+			_ = avc.ContainsNaluType(cp(), avc.NALU_IDR)
+			_ = avc.IsIDRSample(cp())
+			_ = avc.HasParameterSets(cp())
+			_, _ = avc.GetParameterSets(cp())
+			_, _ = avc.GetNalusFromSample(cp())
+			_ = avc.ConvertSampleToByteStream(cp())
+		})
+	}
+}
+
+// TestGetNalusFromSampleBadLength checks that a length field that wraps in
+// uint32 is reported instead of slicing outside the sample.
+func TestGetNalusFromSampleBadLength(t *testing.T) {
+	if _, err := avc.GetNalusFromSample([]byte{0xff, 0xff, 0xff, 0xff, 0x67, 0, 0, 0}); err == nil {
+		t.Error("expected error for nalu length wrapping uint32, got nil")
+	}
+	if _, err := avc.GetNalusFromSample([]byte{0, 0, 0x10, 0, 0x67, 0, 0, 0}); err == nil {
+		t.Error("expected error for nalu length beyond sample, got nil")
+	}
+}
+
+// TestGetParameterSetsBadLength checks that a bad length field stops the scan
+// rather than returning parameter sets read from outside the sample.
+func TestGetParameterSetsBadLength(t *testing.T) {
+	// A valid SPS nalu followed by a nalu whose length field is far too big.
+	sample := []byte{
+		0, 0, 0, 3, 0x67, 0x42, 0x00, // SPS of 3 bytes
+		0xff, 0xff, 0xff, 0xff, 0x68, // PPS with a bogus length
+	}
+	spss, ppss := avc.GetParameterSets(sample)
+	if len(spss) != 1 {
+		t.Fatalf("got %d SPS instead of 1", len(spss))
+	}
+	if len(spss[0]) != 3 {
+		t.Errorf("got SPS of %d bytes instead of 3", len(spss[0]))
+	}
+	if len(ppss) != 0 {
+		t.Errorf("got %d PPS from a bogus length field, expected 0", len(ppss))
+	}
+}

--- a/avc/nalus.go
+++ b/avc/nalus.go
@@ -13,10 +13,11 @@ func GetNalusFromSample(sample []byte) ([][]byte, error) {
 	}
 	naluList := make([][]byte, 0, 2)
 	var pos uint32 = 0
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
-		if int(pos+naluLength) > len(sample) {
+		// uint64 arithmetic so that a length field close to 2^32 cannot wrap
+		if uint64(pos)+uint64(naluLength) > uint64(length) {
 			return nil, fmt.Errorf("NALU length fields are bad. Not video?")
 		}
 		naluList = append(naluList, sample[pos:pos+naluLength])

--- a/cmd/mp4ff-crop/main.go
+++ b/cmd/mp4ff-crop/main.go
@@ -247,7 +247,10 @@ func findTrakEnds(traks []*mp4.TrakBox, endTime, endTimescale uint64) (map[uint3
 		if err != nil {
 			return nil, err
 		}
-		chunk := stsc.GetChunk(uint32(chunkNr))
+		chunk, err := stsc.GetChunk(uint32(chunkNr))
+		if err != nil {
+			return nil, fmt.Errorf("stsc GetChunk: %w", err)
+		}
 		to.lastChunk = chunk
 	}
 	return tos, nil
@@ -292,7 +295,10 @@ func fillTrakOutsAndByteRanges(traks []*mp4.TrakBox, tos map[uint32]*trakOut, by
 			currentOutOffset = firstOffset
 		}
 		to := tos[trakIDMin]
-		chunk := stblMin.Stsc.GetChunk(to.nextInChunkNr)
+		chunk, err := stblMin.Stsc.GetChunk(to.nextInChunkNr)
+		if err != nil {
+			return 0, fmt.Errorf("stsc GetChunk: %w", err)
+		}
 		lastSampleInChunk := chunk.StartSampleNr + chunk.NrSamples - 1
 		sampleNrStart := chunk.StartSampleNr
 		sampleNrEnd := minUint32(lastSampleInChunk, to.lastSampleNr)
@@ -407,15 +413,15 @@ func cropStblChildren(traks []*mp4.TrakBox, trakOuts map[uint32]*trakOut) (err e
 		for _, ch := range stbl.Children {
 			switch ch.Type() {
 			case "stts":
-				cropStts(ch.(*mp4.SttsBox), to.lastSampleNr)
+				err = cropStts(ch.(*mp4.SttsBox), to.lastSampleNr)
 			case "stss":
 				cropStss(ch.(*mp4.StssBox), to.lastSampleNr)
 			case "ctts":
-				cropCtts(ch.(*mp4.CttsBox), to.lastSampleNr)
+				err = cropCtts(ch.(*mp4.CttsBox), to.lastSampleNr)
 			case "stsc":
 				err = cropStsc(ch.(*mp4.StscBox), to.lastSampleNr)
 			case "stsz":
-				cropStsz(ch.(*mp4.StszBox), to.lastSampleNr)
+				err = cropStsz(ch.(*mp4.StszBox), to.lastSampleNr)
 			case "sdtp":
 				cropSdtp(ch.(*mp4.SdtpBox), to.lastSampleNr)
 			case "stco":
@@ -423,12 +429,18 @@ func cropStblChildren(traks []*mp4.TrakBox, trakOuts map[uint32]*trakOut) (err e
 			case "co64":
 				updateCo64(ch.(*mp4.Co64Box), to.chunkOffsets)
 			}
+			if err != nil {
+				return fmt.Errorf("track %d %s: %w", trakID, ch.Type(), err)
+			}
 		}
 	}
-	return err
+	return nil
 }
 
-func cropStts(b *mp4.SttsBox, lastSampleNr uint32) {
+func cropStts(b *mp4.SttsBox, lastSampleNr uint32) error {
+	if len(b.SampleCount) == 0 {
+		return fmt.Errorf("no stts entries")
+	}
 	var countedSamples uint32 = 0
 	lastEntry := -1
 	for i := 0; i < len(b.SampleCount); i++ {
@@ -447,6 +459,7 @@ func cropStts(b *mp4.SttsBox, lastSampleNr uint32) {
 
 	b.SampleCount = b.SampleCount[:lastEntry+1]
 	b.SampleTimeDelta = b.SampleTimeDelta[:lastEntry+1]
+	return nil
 }
 
 func cropStss(b *mp4.StssBox, lastSampleNr uint32) {
@@ -461,17 +474,27 @@ func cropStss(b *mp4.StssBox, lastSampleNr uint32) {
 	b.SampleNumber = b.SampleNumber[:nrEntriesToKeep]
 }
 
-func cropCtts(b *mp4.CttsBox, lastSampleNr uint32) {
+func cropCtts(b *mp4.CttsBox, lastSampleNr uint32) error {
 	lastIdx := sort.Search(len(b.EndSampleNr), func(i int) bool { return b.EndSampleNr[i] >= lastSampleNr })
+	if lastIdx == 0 || lastIdx >= len(b.EndSampleNr) {
+		return fmt.Errorf("ctts does not cover sample %d", lastSampleNr)
+	}
 	// Finally cut down the endSampleNr for this index
 	b.EndSampleNr[lastIdx] = lastSampleNr
 	b.EndSampleNr = b.EndSampleNr[:lastIdx+1]
 	b.SampleOffset = b.SampleOffset[:lastIdx]
+	return nil
 }
 
 func cropStsc(b *mp4.StscBox, lastSampleNr uint32) error {
 	entryIdx := b.FindEntryNrForSampleNr(lastSampleNr, 0)
+	if entryIdx >= uint32(len(b.Entries)) {
+		return fmt.Errorf("no stsc entry for sample %d among %d entries", lastSampleNr, len(b.Entries))
+	}
 	lastEntry := b.Entries[entryIdx]
+	if lastEntry.SamplesPerChunk == 0 {
+		return fmt.Errorf("stsc entry %d has samplesPerChunk == 0", entryIdx+1)
+	}
 	b.Entries = b.Entries[:entryIdx+1]
 	if len(b.SampleDescriptionID) > 0 {
 		b.Entries = b.Entries[:entryIdx+1]
@@ -489,11 +512,15 @@ func cropStsc(b *mp4.StscBox, lastSampleNr uint32) error {
 	return nil
 }
 
-func cropStsz(b *mp4.StszBox, lastSampleNr uint32) {
+func cropStsz(b *mp4.StszBox, lastSampleNr uint32) error {
 	if b.SampleUniformSize == 0 {
+		if int(lastSampleNr) > len(b.SampleSize) {
+			return fmt.Errorf("stsz has %d sizes, but sample %d is needed", len(b.SampleSize), lastSampleNr)
+		}
 		b.SampleSize = b.SampleSize[:lastSampleNr]
 	}
 	b.SampleNumber = lastSampleNr
+	return nil
 }
 
 func cropSdtp(b *mp4.SdtpBox, lastSampleNr uint32) {

--- a/cmd/mp4ff-crop/main_test.go
+++ b/cmd/mp4ff-crop/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/binary"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -68,5 +70,39 @@ func TestCroppedFileDuration(t *testing.T) {
 	moovTimescale := decCropped.Moov.Mvhd.Timescale
 	if uint64(cropDur)*uint64(moovTimescale) != moovDur*1000 {
 		t.Errorf("got %d/%dms instead of %dms", moovDur, moovTimescale, cropDur)
+	}
+}
+
+// TestTruncatedCtts checks that a ctts box that does not cover all samples of
+// the track gives an error instead of a panic while cropping.
+func TestTruncatedCtts(t *testing.T) {
+	raw, err := os.ReadFile("../../mp4/testdata/bbb_prog_10s.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cut the first ctts down to a single entry and pad the rest with a free box.
+	cttsPos := bytes.Index(raw, []byte("ctts"))
+	if cttsPos < 0 {
+		t.Fatal("no ctts box found")
+	}
+	sizePos := cttsPos - 4
+	oldSize := binary.BigEndian.Uint32(raw[sizePos : sizePos+4])
+	const newSize = 8 + 4 + 4 + 8 // header + versionAndFlags + entryCount + one entry
+	if oldSize <= newSize+8 {
+		t.Fatalf("ctts box of size %d is too small to truncate", oldSize)
+	}
+	binary.BigEndian.PutUint32(raw[sizePos:sizePos+4], newSize)
+	binary.BigEndian.PutUint32(raw[cttsPos+8:cttsPos+12], 1) // entryCount
+	freePos := sizePos + newSize
+	binary.BigEndian.PutUint32(raw[freePos:freePos+4], oldSize-newSize)
+	copy(raw[freePos+4:freePos+8], []byte("free"))
+
+	inFile := filepath.Join(t.TempDir(), "short_ctts.mp4")
+	if err := os.WriteFile(inFile, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outFile := filepath.Join(t.TempDir(), "out.mp4")
+	if err := run([]string{appName, "-d", "2", inFile, outFile}, &bytes.Buffer{}); err == nil {
+		t.Error("expected error for ctts not covering all samples, got nil")
 	}
 }

--- a/cmd/mp4ff-crop/stblcrop_test.go
+++ b/cmd/mp4ff-crop/stblcrop_test.go
@@ -33,7 +33,9 @@ func TestSttsCrop(t *testing.T) {
 		}
 		copy(stts.SampleCount, c.sttsIn.SampleCount)
 		copy(stts.SampleTimeDelta, c.sttsIn.SampleTimeDelta)
-		cropStts(&stts, c.lastSampleNr)
+		if err := cropStts(&stts, c.lastSampleNr); err != nil {
+			t.Fatal(err)
+		}
 		if len(stts.SampleCount) != len(c.expectedSampleCounts) {
 			t.Errorf("Expected %d sampleCounts, got %d", len(c.expectedSampleCounts), len(stts.SampleCount))
 		}

--- a/cmd/mp4ff-decrypt/main_test.go
+++ b/cmd/mp4ff-decrypt/main_test.go
@@ -387,3 +387,51 @@ func BenchmarkDecodeCenc(b *testing.B) {
 		}
 	}
 }
+
+// TestBadSubSamplePattern checks that a senc box whose subsample byte counts
+// reach outside the sample data gives an error instead of a panic.
+func TestBadSubSamplePattern(t *testing.T) {
+	fd, err := os.Open("../../mp4/testdata/prog_8s_enc_dashinit.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fd.Close()
+	f, err := mp4.DecodeFile(fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make the first protected byte range of the first sample far too big.
+	var senc *mp4.SencBox
+	for _, seg := range f.Segments {
+		for _, frag := range seg.Fragments {
+			if s := frag.Moof.Traf.Senc; s != nil && len(s.SubSamples) > 0 {
+				senc = s
+				break
+			}
+		}
+	}
+	if senc == nil {
+		t.Fatal("no senc box with subsample patterns found")
+	}
+	if len(senc.SubSamples[0]) == 0 {
+		t.Fatal("first senc sample has no subsample patterns")
+	}
+	senc.SubSamples[0][0].BytesOfProtectedData = 1 << 28
+
+	inFile := path.Join(t.TempDir(), "bad_senc.mp4")
+	ofd, err := os.Create(inFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Encode(ofd); err != nil {
+		ofd.Close()
+		t.Fatal(err)
+	}
+	ofd.Close()
+
+	outFile := path.Join(t.TempDir(), "out.mp4")
+	args := []string{"mp4ff-decrypt", "-key", "00112233445566778899aabbccddeeff", inFile, outFile}
+	if err := run(args); err == nil {
+		t.Error("expected error for subsample data outside sample, got nil")
+	}
+}

--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -186,7 +186,6 @@ func parseProgressiveMp4(w io.Writer, f *mp4.File, maxNrSamples int, codec strin
 	}
 	nrSamples := stbl.Stsz.SampleNumber
 	mdat := f.Mdat
-	mdatPayloadStart := mdat.PayloadAbsoluteOffset()
 
 	for sampleNr := 1; sampleNr <= int(nrSamples); sampleNr++ {
 		chunkNr, sampleNrAtChunkStart, err := stbl.Stsc.ChunkNrFromSampleNr(sampleNr)
@@ -207,8 +206,10 @@ func parseProgressiveMp4(w io.Writer, f *mp4.File, maxNrSamples int, codec strin
 			cto = int64(stbl.Ctts.GetCompositionTimeOffset(uint32(sampleNr)))
 		}
 		// Next find sample bytes as slice in mdat
-		offsetInMdatData := uint64(offset) - mdatPayloadStart
-		sample := mdat.Data[offsetInMdatData : offsetInMdatData+uint64(size)]
+		sample, err := mdat.ReadData(offset, int64(size), nil)
+		if err != nil {
+			return fmt.Errorf("sample %d: %w", sampleNr, err)
+		}
 		nalus, err := avc.GetNalusFromSample(sample)
 		if err != nil {
 			return err

--- a/cmd/mp4ff-nallister/main_test.go
+++ b/cmd/mp4ff-nallister/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/binary"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/avc"
@@ -106,5 +108,33 @@ func MakeByteStream(t *testing.T, inFile, outFile string) {
 	err = os.WriteFile(outFile, byteStream, 0644)
 	if err != nil {
 		t.Fatalf("could not write file %s: %s", outFile, err)
+	}
+}
+
+// TestBadChunkOffsets checks that a progressive file whose chunk offsets point
+// outside the mdat data gives an error instead of a panic.
+func TestBadChunkOffsets(t *testing.T) {
+	raw, err := os.ReadFile("testdata/h264.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Move every chunk offset in the first stco far beyond the end of the file.
+	stcoPos := bytes.Index(raw, []byte("stco"))
+	if stcoPos < 0 {
+		t.Fatal("no stco box found")
+	}
+	entryCount := binary.BigEndian.Uint32(raw[stcoPos+8 : stcoPos+12])
+	for e := 0; e < int(entryCount); e++ {
+		p := stcoPos + 12 + e*4
+		offset := binary.BigEndian.Uint32(raw[p : p+4])
+		binary.BigEndian.PutUint32(raw[p:p+4], offset+1<<28)
+	}
+	badFile := filepath.Join(t.TempDir(), "bad_stco.mp4")
+	if err := os.WriteFile(badFile, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := run([]string{appName, badFile}, &bytes.Buffer{}); err == nil {
+		t.Error("expected error for chunk offsets outside mdat, got nil")
 	}
 }

--- a/cmd/mp4ff-pslister/main.go
+++ b/cmd/mp4ff-pslister/main.go
@@ -241,9 +241,10 @@ func parseMp4File(w io.Writer, r io.Reader, codec string, verbose bool) error {
 			size := stbl.Stsz.GetSampleSize(1)
 			// Next find bytes as slice in mdat
 			mdat := parsedMp4.Mdat
-			mdatPayloadStart := mdat.PayloadAbsoluteOffset()
-			offsetInMdatData := uint64(offset) - mdatPayloadStart
-			sampleData := mdat.Data[offsetInMdatData : offsetInMdatData+uint64(size)]
+			sampleData, err := mdat.ReadData(offset, int64(size), nil)
+			if err != nil {
+				return fmt.Errorf("read sample 1: %w", err)
+			}
 			switch codec {
 			case "avc":
 				spsNalus, ppsNalus := avc.GetParameterSets(sampleData)

--- a/cmd/mp4ff-subslister/main.go
+++ b/cmd/mp4ff-subslister/main.go
@@ -135,7 +135,6 @@ func parseProgressiveMp4(f *mp4.File, w io.Writer, trackID uint32, maxNrSamples 
 	stbl := subsTrak.trak.Mdia.Minf.Stbl
 	nrSamples := stbl.Stsz.SampleNumber
 	mdat := f.Mdat
-	mdatPayloadStart := mdat.PayloadAbsoluteOffset()
 	for sampleNr := 1; sampleNr <= int(nrSamples); sampleNr++ {
 		chunkNr, sampleNrAtChunkStart, err := stbl.Stsc.ChunkNrFromSampleNr(sampleNr)
 		if err != nil {
@@ -154,8 +153,10 @@ func parseProgressiveMp4(f *mp4.File, w io.Writer, trackID uint32, maxNrSamples 
 		decTime, dur := stbl.Stts.GetDecodeTime(uint32(sampleNr))
 		// Skip checking compositionTimeOffset since not uset for subtitles
 		// Next find sample bytes as slice in mdat
-		offsetInMdatData := uint64(offset) - mdatPayloadStart
-		sample := mdat.Data[offsetInMdatData : offsetInMdatData+uint64(size)]
+		sample, err := mdat.ReadData(offset, int64(size), nil)
+		if err != nil {
+			return fmt.Errorf("sample %d: %w", sampleNr, err)
+		}
 		switch subsTrak.variant {
 		case "wvtt":
 			err = printWvttSample(w, sample, sampleNr, int64(decTime), dur)

--- a/examples/segmenter/segmenter.go
+++ b/examples/segmenter/segmenter.go
@@ -140,7 +140,6 @@ func (s *Segmenter) GetFullSamplesForInterval(mp4f *mp4.File, tr *Track, startSa
 	stbl := tr.inTrak.Mdia.Minf.Stbl
 	samples := make([]mp4.FullSample, 0, endSampleNr-startSampleNr+1)
 	mdat := mp4f.Mdat
-	mdatPayloadStart := mdat.PayloadAbsoluteOffset()
 	for sampleNr := startSampleNr; sampleNr <= endSampleNr; sampleNr++ {
 		chunkNr, sampleNrAtChunkStart, err := stbl.Stsc.ChunkNrFromSampleNr(int(sampleNr))
 		if err != nil {
@@ -162,21 +161,10 @@ func (s *Segmenter) GetFullSamplesForInterval(mp4f *mp4.File, tr *Track, startSa
 		if stbl.Ctts != nil {
 			cto = stbl.Ctts.GetCompositionTimeOffset(sampleNr)
 		}
-		var sampleData []byte
 		// Next find bytes as slice in mdat
-		if mdat.GetLazyDataSize() > 0 {
-			_, err := rs.Seek(offset, io.SeekStart)
-			if err != nil {
-				return nil, err
-			}
-			sampleData = make([]byte, size)
-			_, err = io.ReadFull(rs, sampleData)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			offsetInMdatData := uint64(offset) - mdatPayloadStart
-			sampleData = mdat.Data[offsetInMdatData : offsetInMdatData+uint64(size)]
+		sampleData, err := mdat.ReadData(offset, int64(size), rs)
+		if err != nil {
+			return nil, fmt.Errorf("sample %d: %w", sampleNr, err)
 		}
 
 		//presTime := uint64(int64(decTime) + int64(cto))

--- a/hevc/badnalu_test.go
+++ b/hevc/badnalu_test.go
@@ -1,0 +1,54 @@
+package hevc_test
+
+import (
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/hevc"
+)
+
+// TestScanBadSamples checks that the sample scanning functions handle samples
+// that are too short to hold a length field and length fields that reach
+// outside the sample, instead of panicking. Length fields close to 2^32 also
+// must not wrap when added to the position.
+func TestScanBadSamples(t *testing.T) {
+	samples := map[string][]byte{
+		"empty":                  {},
+		"one byte":               {0x40},
+		"three bytes":            {0, 0, 0},
+		"length field only":      {0, 0, 0, 4},
+		"length beyond sample":   {0, 0, 0x10, 0, 0x40, 0x01, 0x00},
+		"length wrapping uint32": {0xff, 0xff, 0xff, 0xff, 0x40, 0, 0, 0},
+		"zero length":            {0, 0, 0, 0, 0x40, 0, 0, 0},
+	}
+	for desc, sample := range samples {
+		t.Run(desc, func(t *testing.T) {
+			_ = hevc.FindNaluTypes(sample)
+			_ = hevc.FindNaluTypesUpToFirstVideoNalu(sample)
+			_ = hevc.ContainsNaluType(sample, hevc.NALU_IDR_W_RADL)
+			_ = hevc.IsRAPSample(sample)
+			_ = hevc.IsIDRSample(sample)
+			_ = hevc.HasParameterSets(sample)
+			_, _, _ = hevc.GetParameterSets(sample)
+		})
+	}
+}
+
+// TestGetParameterSetsBadLength checks that a bad length field stops the scan
+// rather than returning parameter sets read from outside the sample.
+func TestGetParameterSetsBadLength(t *testing.T) {
+	// A valid VPS nalu followed by a nalu whose length field is far too big.
+	sample := []byte{
+		0, 0, 0, 3, 0x40, 0x01, 0x00, // VPS of 3 bytes
+		0xff, 0xff, 0xff, 0xff, 0x42, // SPS with a bogus length
+	}
+	vpss, spss, ppss := hevc.GetParameterSets(sample)
+	if len(vpss) != 1 {
+		t.Fatalf("got %d VPS instead of 1", len(vpss))
+	}
+	if len(vpss[0]) != 3 {
+		t.Errorf("got VPS of %d bytes instead of 3", len(vpss[0]))
+	}
+	if len(spss) != 0 || len(ppss) != 0 {
+		t.Errorf("got %d SPS and %d PPS from a bogus length field, expected 0", len(spss), len(ppss))
+	}
+}

--- a/hevc/hevc.go
+++ b/hevc/hevc.go
@@ -145,6 +145,14 @@ func SplitNalusByLayerID(sample []byte, lengthSize int) map[byte][][]byte {
 	return result
 }
 
+// naluFits reports whether a nalu of naluLength bytes starting at pos fits
+// inside a sample of sampleLength bytes. The length fields come from the
+// sample itself, so they must be checked before use. The arithmetic is done in
+// uint64 so that a length field close to 2^32 cannot wrap.
+func naluFits(pos, naluLength uint32, sampleLength int) bool {
+	return naluLength > 0 && uint64(pos)+uint64(naluLength) <= uint64(sampleLength)
+}
+
 // FindNaluTypes - find list of nalu types in sample
 func FindNaluTypes(sample []byte) []NaluType {
 	naluList := make([]NaluType, 0)
@@ -153,9 +161,12 @@ func FindNaluTypes(sample []byte) []NaluType {
 		return naluList
 	}
 	var pos uint32 = 0
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
+		if !naluFits(pos, naluLength, length) {
+			break // bad nalu length field: stop scanning
+		}
 		naluType := GetNaluType(sample[pos])
 		naluList = append(naluList, naluType)
 		pos += naluLength
@@ -171,9 +182,12 @@ func FindNaluTypesUpToFirstVideoNalu(sample []byte) []NaluType {
 		return naluList
 	}
 	var pos uint32 = 0
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
+		if !naluFits(pos, naluLength, length) {
+			break // bad nalu length field: stop scanning
+		}
 		naluType := GetNaluType(sample[pos])
 		naluList = append(naluList, naluType)
 		pos += naluLength
@@ -196,9 +210,12 @@ func ContainsNaluType(sample []byte, specificNaluType NaluType) bool {
 	if length < 4 {
 		return false
 	}
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
+		if !naluFits(pos, naluLength, length) {
+			break // bad nalu length field: stop scanning
+		}
 		naluType := GetNaluType(sample[pos])
 		if naluType == specificNaluType {
 			return true
@@ -253,9 +270,12 @@ func GetParameterSets(sample []byte) (vps, sps, pps [][]byte) {
 	sampleLength := uint32(len(sample))
 	var pos uint32 = 0
 naluLoop:
-	for pos < sampleLength {
+	for pos+4 < sampleLength {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
+		if !naluFits(pos, naluLength, len(sample)) {
+			break // bad nalu length field: stop scanning
+		}
 		switch naluType := GetNaluType(sample[pos]); {
 		case naluType == NALU_VPS:
 			vps = append(vps, sample[pos:pos+naluLength])

--- a/mp4/crypto.go
+++ b/mp4/crypto.go
@@ -35,10 +35,11 @@ func GetAVCProtectRanges(spsMap map[uint32]*avc.SPS, ppsMap map[uint32]*avc.PPS,
 	var pos uint32 = 0
 	clearStart := uint32(0)
 	clearEnd := uint32(0)
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
-		if int(pos+naluLength) > len(sample) {
+		// uint64 arithmetic so that a length field close to 2^32 cannot wrap
+		if uint64(pos)+uint64(naluLength) > uint64(len(sample)) {
 			return nil, fmt.Errorf("NALU length fields are bad")
 		}
 		naluType := avc.GetNaluType(sample[pos])
@@ -97,10 +98,11 @@ func GetHEVCProtectRanges(spsMap map[uint32]*hevc.SPS, ppsMap map[uint32]*hevc.P
 	var pos uint32 = 0
 	clearStart := uint32(0)
 	clearEnd := uint32(0)
-	for pos < uint32(length-4) {
+	for pos+4 < uint32(length) {
 		naluLength := binary.BigEndian.Uint32(sample[pos : pos+4])
 		pos += 4
-		if int(pos+naluLength) > len(sample) {
+		// uint64 arithmetic so that a length field close to 2^32 cannot wrap
+		if uint64(pos)+uint64(naluLength) > uint64(len(sample)) {
 			return nil, fmt.Errorf("NALU length fields are bad")
 		}
 		naluType := hevc.GetNaluType(sample[pos])

--- a/mp4/crypto.go
+++ b/mp4/crypto.go
@@ -224,21 +224,34 @@ func CryptSampleCenc(sample []byte, key []byte, iv []byte, subSamplePatterns []S
 	if len(subSamplePatterns) != 0 {
 		var pos uint32 = 0
 		for j := 0; j < len(subSamplePatterns); j++ {
-			ss := subSamplePatterns[j]
-			nrClear := uint32(ss.BytesOfClearData)
-			if nrClear > 0 {
-				pos += nrClear
+			start, end, err := subSampleRange(len(sample), pos, j, subSamplePatterns[j])
+			if err != nil {
+				return err
 			}
-			nrEnc := ss.BytesOfProtectedData
-			if nrEnc > 0 {
-				stream.XORKeyStream(sample[pos:pos+nrEnc], sample[pos:pos+nrEnc])
-				pos += nrEnc
+			if end > start {
+				stream.XORKeyStream(sample[start:end], sample[start:end])
 			}
+			pos = end
 		}
 	} else {
 		stream.XORKeyStream(sample, sample)
 	}
 	return nil
+}
+
+// subSampleRange returns the protected byte range [start, end) of the
+// subsample pattern nr (zero-based) starting at pos in sample. An error is
+// returned if the pattern reaches outside the sample, since the byte counts
+// come from a senc box that nothing ties to the actual sample sizes.
+func subSampleRange(sampleLen int, pos uint32, nr int, ss SubSamplePattern) (start, end uint32, err error) {
+	// uint64 arithmetic so that big byte counts cannot wrap
+	startPos := uint64(pos) + uint64(ss.BytesOfClearData)
+	endPos := startPos + uint64(ss.BytesOfProtectedData)
+	if endPos > uint64(sampleLen) {
+		return 0, 0, fmt.Errorf("subsample %d range %d-%d is outside sample of size %d",
+			nr+1, startPos, endPos, sampleLen)
+	}
+	return uint32(startPos), uint32(endPos), nil
 }
 
 // DecryptSampleCenc does in-place decryption of cbcs-schema encrypted sample.
@@ -260,17 +273,17 @@ func cryptSampleCbcs(dir cryptoDir, sample []byte, key []byte, iv []byte, subSam
 	var pos uint32 = 0
 	if len(subSamplePatterns) != 0 {
 		for j := 0; j < len(subSamplePatterns); j++ {
-			ss := subSamplePatterns[j]
-			nrClear := uint32(ss.BytesOfClearData)
-			pos += nrClear
-			if ss.BytesOfProtectedData > 0 {
-				err := cbcsCrypt(dir, sample[pos:pos+ss.BytesOfProtectedData], key,
-					iv, nrInCryptBlock, nrInSkipBlock)
+			start, end, err := subSampleRange(len(sample), pos, j, subSamplePatterns[j])
+			if err != nil {
+				return err
+			}
+			if end > start {
+				err = cbcsCrypt(dir, sample[start:end], key, iv, nrInCryptBlock, nrInSkipBlock)
 				if err != nil {
 					return err
 				}
 			}
-			pos += ss.BytesOfProtectedData
+			pos = end
 		}
 	} else { // Full encryption as used for audio
 		err := cbcsCrypt(dir, sample, key, iv, nrInCryptBlock, nrInSkipBlock)
@@ -1050,6 +1063,14 @@ func decryptSamplesInPlace(schemeType string, samples []FullSample, key []byte, 
 	iv := make([]byte, 16)
 	if tenc.DefaultConstantIV != nil {
 		copy(iv, tenc.DefaultConstantIV)
+	}
+
+	// Subsample information must cover exactly the samples to decrypt. Using
+	// it for the wrong sample would decrypt the wrong byte ranges, and a senc
+	// with fewer entries than samples used to panic.
+	if senc != nil && len(senc.SubSamples) != 0 && len(senc.SubSamples) != len(samples) {
+		return fmt.Errorf("senc has subsample information for %d samples, but %d samples to decrypt",
+			len(senc.SubSamples), len(samples))
 	}
 
 	for i := range samples {

--- a/mp4/crypto_test.go
+++ b/mp4/crypto_test.go
@@ -885,3 +885,22 @@ func TestDecryptFragmentSencSampleCountMismatch(t *testing.T) {
 		t.Error("expected error for senc subsample count mismatch, got nil")
 	}
 }
+
+// TestProtectRangesBadNaluLength checks that a nalu length field that wraps in
+// uint32 is reported instead of slicing outside the sample.
+func TestProtectRangesBadNaluLength(t *testing.T) {
+	samples := map[string][]byte{
+		"length wrapping uint32": {0xff, 0xff, 0xff, 0xff, 0x65, 0, 0, 0},
+		"length beyond sample":   {0, 0, 0x10, 0, 0x65, 0, 0, 0},
+	}
+	for desc, sample := range samples {
+		t.Run(desc, func(t *testing.T) {
+			if _, err := mp4.GetAVCProtectRanges(nil, nil, sample, "cenc"); err == nil {
+				t.Error("GetAVCProtectRanges: expected error, got nil")
+			}
+			if _, err := mp4.GetHEVCProtectRanges(nil, nil, sample, "cenc"); err == nil {
+				t.Error("GetHEVCProtectRanges: expected error, got nil")
+			}
+		})
+	}
+}

--- a/mp4/crypto_test.go
+++ b/mp4/crypto_test.go
@@ -777,3 +777,111 @@ func TestEncryptFragmentNoAuxInfoOmitsBoxes(t *testing.T) {
 			traf.Senc != nil, traf.Saiz != nil, traf.Saio != nil)
 	}
 }
+
+// TestCryptSampleBadSubSamplePatterns checks that subsample byte counts
+// reaching outside the sample give an error instead of a panic. The counts
+// come from a senc box, which nothing ties to the actual sample sizes.
+func TestCryptSampleBadSubSamplePatterns(t *testing.T) {
+	key := make([]byte, 16)
+	iv := make([]byte, 16)
+	tenc := &mp4.TencBox{DefaultCryptByteBlock: 1, DefaultSkipByteBlock: 9}
+	cases := []struct {
+		desc     string
+		patterns []mp4.SubSamplePattern
+		wantErr  bool
+	}{
+		{
+			desc:     "protected data past end",
+			patterns: []mp4.SubSamplePattern{{BytesOfClearData: 2, BytesOfProtectedData: 1000}},
+			wantErr:  true,
+		},
+		{
+			desc:     "clear data past end",
+			patterns: []mp4.SubSamplePattern{{BytesOfClearData: 1000, BytesOfProtectedData: 1}},
+			wantErr:  true,
+		},
+		{
+			desc:     "byte counts wrapping uint32",
+			patterns: []mp4.SubSamplePattern{{BytesOfClearData: 4, BytesOfProtectedData: 0xfffffffc}},
+			wantErr:  true,
+		},
+		{
+			desc: "second pattern past end",
+			patterns: []mp4.SubSamplePattern{
+				{BytesOfClearData: 2, BytesOfProtectedData: 8},
+				{BytesOfClearData: 0, BytesOfProtectedData: 16},
+			},
+			wantErr: true,
+		},
+		{
+			desc:     "exactly filling the sample",
+			patterns: []mp4.SubSamplePattern{{BytesOfClearData: 2, BytesOfProtectedData: 8}},
+			wantErr:  false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			for _, f := range []struct {
+				name string
+				fn   func(sample []byte) error
+			}{
+				{"CryptSampleCenc", func(s []byte) error { return mp4.CryptSampleCenc(s, key, iv, c.patterns) }},
+				{"DecryptSampleCbcs", func(s []byte) error { return mp4.DecryptSampleCbcs(s, key, iv, c.patterns, tenc) }},
+				{"EncryptSampleCbcs", func(s []byte) error { return mp4.EncryptSampleCbcs(s, key, iv, c.patterns, tenc) }},
+			} {
+				err := f.fn(make([]byte, 10))
+				if c.wantErr && err == nil {
+					t.Errorf("%s: expected error, got nil", f.name)
+				}
+				if !c.wantErr && err != nil {
+					t.Errorf("%s: unexpected error: %s", f.name, err)
+				}
+			}
+		})
+	}
+}
+
+// TestDecryptFragmentSencSampleCountMismatch checks that a senc box with
+// subsample information for a different number of samples than the trun
+// declares gives an error instead of a panic.
+func TestDecryptFragmentSencSampleCountMismatch(t *testing.T) {
+	frag, err := mp4.CreateFragment(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		frag.AddFullSample(mp4.FullSample{
+			Sample:     mp4.Sample{Flags: mp4.SyncSampleFlags, Dur: 1024, Size: 16},
+			DecodeTime: uint64(i * 1024),
+			Data:       make([]byte, 16),
+		})
+	}
+	// senc for one sample only, while the trun has three
+	senc := mp4.CreateSencBox()
+	err = senc.AddSample(mp4.SencSample{
+		IV:         make([]byte, 16),
+		SubSamples: []mp4.SubSamplePattern{{BytesOfClearData: 0, BytesOfProtectedData: 16}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := frag.Moof.Traf.AddChild(senc); err != nil {
+		t.Fatal(err)
+	}
+
+	di := mp4.DecryptInfo{
+		TrackInfos: []mp4.DecryptTrackInfo{{
+			TrackID: 1,
+			Sinf: &mp4.SinfBox{
+				Schm: &mp4.SchmBox{SchemeType: "cenc"},
+				Schi: &mp4.SchiBox{Tenc: &mp4.TencBox{
+					DefaultPerSampleIVSize: 16,
+					DefaultKID:             mp4.UUID(make([]byte, 16)),
+				}},
+			},
+		}},
+	}
+	if err := mp4.DecryptFragment(frag, di, make([]byte, 16)); err == nil {
+		t.Error("expected error for senc subsample count mismatch, got nil")
+	}
+}

--- a/mp4/ctts.go
+++ b/mp4/ctts.go
@@ -127,7 +127,8 @@ func (b *CttsBox) AddSampleCountsAndOffset(counts []uint32, offsets []int32) err
 	return nil
 }
 
-// GetCompositionTimeOffset - composition time offset for (one-based) sampleNr in track timescale
+// GetCompositionTimeOffset - composition time offset for (one-based) sampleNr in track timescale.
+// Returns 0 for a sampleNr beyond the samples covered by this box.
 func (b *CttsBox) GetCompositionTimeOffset(sampleNr uint32) int32 {
 	if sampleNr == 0 {
 		// This is bad index input. Should never happen
@@ -143,6 +144,12 @@ func (b *CttsBox) GetCompositionTimeOffset(sampleNr uint32) int32 {
 		} else {
 			j = h
 		}
+	}
+	// Nothing ties the ctts entries to the number of samples in stsz, so a
+	// sampleNr beyond what this box covers (or an empty box) must not index
+	// outside SampleOffset. Such a sample has no offset, which is 0.
+	if i == 0 || i > len(b.SampleOffset) {
+		return 0
 	}
 	return b.SampleOffset[i-1]
 }

--- a/mp4/ctts_test.go
+++ b/mp4/ctts_test.go
@@ -48,3 +48,33 @@ func TestGetCompositionTimeOffset(t *testing.T) {
 		}
 	}
 }
+
+// TestGetCompositionTimeOffsetOutsideBox checks that samples not covered by
+// the ctts box give offset 0 instead of panicking. Nothing ties the number of
+// ctts entries to the number of samples in stsz, so a corrupt file can have a
+// ctts covering fewer samples than the track has.
+func TestGetCompositionTimeOffsetOutsideBox(t *testing.T) {
+	shortCtts := &mp4.CttsBox{}
+	if err := shortCtts.AddSampleCountsAndOffset([]uint32{2}, []int32{1000}); err != nil {
+		t.Fatal(err)
+	}
+	for _, sampleNr := range []uint32{3, 4, 1000} {
+		if cto := shortCtts.GetCompositionTimeOffset(sampleNr); cto != 0 {
+			t.Errorf("sampleNr %d: got cto %d instead of 0", sampleNr, cto)
+		}
+	}
+	// The covered samples still work.
+	if cto := shortCtts.GetCompositionTimeOffset(1); cto != 1000 {
+		t.Errorf("sampleNr 1: got cto %d instead of 1000", cto)
+	}
+
+	emptyCtts := &mp4.CttsBox{}
+	if cto := emptyCtts.GetCompositionTimeOffset(1); cto != 0 {
+		t.Errorf("empty ctts: got cto %d instead of 0", cto)
+	}
+	// A decoded ctts with entryCount == 0 has one EndSampleNr entry and no offsets.
+	decodedEmpty := &mp4.CttsBox{EndSampleNr: []uint32{0}}
+	if cto := decodedEmpty.GetCompositionTimeOffset(1); cto != 0 {
+		t.Errorf("decoded empty ctts: got cto %d instead of 0", cto)
+	}
+}

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -623,7 +623,6 @@ func (f *File) CopySampleData(w io.Writer, rs io.ReadSeeker, trak *TrakBox,
 	if mdat.IsLazy() && rs == nil {
 		return fmt.Errorf("no ReadSeeker for lazy mdat")
 	}
-	mdatPayloadStart := mdat.PayloadAbsoluteOffset()
 
 	if trak.Mdia == nil || trak.Mdia.Minf == nil || trak.Mdia.Minf.Stbl == nil {
 		return fmt.Errorf("trak does not have a complete mdia/minf/stbl structure")
@@ -708,12 +707,11 @@ func (f *File) CopySampleData(w io.Writer, rs io.ReadSeeker, trak *TrakBox,
 				}
 			}
 		} else {
-			offsetInMdatData := offset - mdatPayloadStart
-			n, err := w.Write(mdat.Data[offsetInMdatData : offsetInMdatData+uint64(size)])
+			n, err := mdat.CopyData(int64(offset), size, rs, w)
 			if err != nil {
-				return err
+				return fmt.Errorf("copyData: %w", err)
 			}
-			if int64(n) != size {
+			if n != size {
 				return fmt.Errorf("copied %d bytes instead of %d", n, size)
 			}
 		}

--- a/mp4/file_test.go
+++ b/mp4/file_test.go
@@ -503,3 +503,54 @@ func TestUpdateSidxNilMvex(t *testing.T) {
 		t.Error("expected error for nil mvex")
 	}
 }
+
+// TestCopySampleDataCorruptTables checks that chunk offsets or sample sizes
+// pointing outside the mdat data give an error instead of a panic.
+func TestCopySampleDataCorruptTables(t *testing.T) {
+	cases := []struct {
+		desc    string
+		corrupt func(stbl *mp4.StblBox)
+	}{
+		{
+			desc: "chunk offset beyond mdat",
+			corrupt: func(stbl *mp4.StblBox) {
+				for i := range stbl.Stco.ChunkOffset {
+					stbl.Stco.ChunkOffset[i] += 1 << 28
+				}
+			},
+		},
+		{
+			desc: "chunk offset before mdat payload",
+			corrupt: func(stbl *mp4.StblBox) {
+				for i := range stbl.Stco.ChunkOffset {
+					stbl.Stco.ChunkOffset[i] = 0
+				}
+			},
+		},
+		{
+			desc: "sample size beyond mdat",
+			corrupt: func(stbl *mp4.StblBox) {
+				stbl.Stsz.SampleSize[0] = 0xffffffff
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			fd, err := os.Open("testdata/bbb_prog_10s.mp4")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fd.Close()
+			f, err := mp4.DecodeFile(fd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			trak := f.Moov.Trak
+			c.corrupt(trak.Mdia.Minf.Stbl)
+			var buf bytes.Buffer
+			if err := f.CopySampleData(&buf, fd, trak, 1, 10, nil); err == nil {
+				t.Error("expected error for corrupt sample tables, got nil")
+			}
+		})
+	}
+}

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -204,20 +204,7 @@ func (m *MdatBox) ReadData(start, size int64, rs io.ReadSeeker) ([]byte, error) 
 	}
 
 	// Otherwise, all Mdat data is in memory, either as parts or as one big slice
-	mdatPayloadStart := m.PayloadAbsoluteOffset()
-	offsetInMdatData := uint64(start) - mdatPayloadStart
-	endIndexInMdatData := offsetInMdatData + uint64(size)
-
-	// validate if indexes are valid to avoid panics
-	dataLen := m.DataLength()
-	if offsetInMdatData >= dataLen || endIndexInMdatData >= dataLen {
-		return nil, fmt.Errorf("normal mdat mode - invalid range provided")
-	}
-	if len(m.DataParts) > 0 {
-		return nil, fmt.Errorf("extraction of range from dataParts not yet implemented")
-	}
-	return m.Data[offsetInMdatData : offsetInMdatData+uint64(size)], nil
-
+	return m.dataRange(start, size)
 }
 
 // CopyData - copy data range from mdat to w.
@@ -237,19 +224,33 @@ func (m *MdatBox) CopyData(start, size int64, rs io.ReadSeeker, w io.Writer) (nr
 	}
 
 	// Otherwise, all Mdat data is in memory
-	mdatPayloadStart := m.PayloadAbsoluteOffset()
-	offsetInMdatData := uint64(start) - mdatPayloadStart
-	endIndexInMdatData := offsetInMdatData + uint64(size)
+	data, err := m.dataRange(start, size)
+	if err != nil {
+		return 0, err
+	}
+	n, err := w.Write(data)
+	return int64(n), err
+}
 
-	// validate if indexes are valid to avoid panics
-	dataLen := m.DataLength()
-	if offsetInMdatData >= dataLen || endIndexInMdatData >= dataLen {
-		return 0, fmt.Errorf("normal mdat mode - invalid range provided")
+// dataRange returns the in-memory mdat payload for the absolute file range
+// [start, start+size). An error is returned if the range is not fully inside
+// the mdat payload, so that a bad chunk offset or sample size in a corrupt
+// file results in an error instead of a panic.
+func (m *MdatBox) dataRange(start, size int64) ([]byte, error) {
+	if start < 0 || size < 0 {
+		return nil, fmt.Errorf("negative start %d or size %d", start, size)
 	}
 	if len(m.DataParts) > 0 {
-		return 0, fmt.Errorf("extraction of range from dataParts not yet implemented")
+		return nil, fmt.Errorf("extraction of range from dataParts not yet implemented")
 	}
-	var n int
-	n, err = w.Write(m.Data[offsetInMdatData : offsetInMdatData+uint64(size)])
-	return int64(n), err
+	payloadStart := m.PayloadAbsoluteOffset()
+	if uint64(start) < payloadStart {
+		return nil, fmt.Errorf("start %d is before mdat payload start %d", start, payloadStart)
+	}
+	offset := uint64(start) - payloadStart
+	end := offset + uint64(size) // cannot overflow since both are non-negative int64
+	if dataLen := m.DataLength(); end > dataLen {
+		return nil, fmt.Errorf("range %d-%d is outside mdat data (size %d)", offset, end, dataLen)
+	}
+	return m.Data[offset:end], nil
 }

--- a/mp4/mdat_test.go
+++ b/mp4/mdat_test.go
@@ -230,3 +230,54 @@ func TestMdatHeaderSizeForLargeLazyPayload(t *testing.T) {
 		}
 	}
 }
+
+func TestMdatDataRangeChecks(t *testing.T) {
+	// Payload of 7 bytes starting 8 bytes into the file.
+	newMdat := func() *mp4.MdatBox {
+		return &mp4.MdatBox{
+			StartPos: 0,
+			Data:     []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+		}
+	}
+	cases := []struct {
+		desc    string
+		start   int64
+		size    int64
+		wantErr bool
+	}{
+		{desc: "full payload", start: 8, size: 7, wantErr: false},
+		{desc: "last byte", start: 14, size: 1, wantErr: false},
+		{desc: "empty range at end", start: 15, size: 0, wantErr: false},
+		{desc: "one byte too far", start: 8, size: 8, wantErr: true},
+		{desc: "start at end with size", start: 15, size: 1, wantErr: true},
+		{desc: "start before payload", start: 0, size: 4, wantErr: true},
+		{desc: "start far beyond payload", start: 1 << 28, size: 4, wantErr: true},
+		{desc: "negative size", start: 8, size: -1, wantErr: true},
+		{desc: "negative start", start: -8, size: 4, wantErr: true},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			mdat := newMdat()
+			data, err := mdat.ReadData(c.start, c.size, nil)
+			switch {
+			case c.wantErr && err == nil:
+				t.Errorf("ReadData: expected error, got %v", data)
+			case !c.wantErr && err != nil:
+				t.Errorf("ReadData: unexpected error: %v", err)
+			case !c.wantErr && int64(len(data)) != c.size:
+				t.Errorf("ReadData: got %d bytes instead of %d", len(data), c.size)
+			}
+
+			var buf bytes.Buffer
+			n, err := mdat.CopyData(c.start, c.size, nil, &buf)
+			switch {
+			case c.wantErr && err == nil:
+				t.Errorf("CopyData: expected error, wrote %d bytes", n)
+			case !c.wantErr && err != nil:
+				t.Errorf("CopyData: unexpected error: %v", err)
+			case !c.wantErr && n != c.size:
+				t.Errorf("CopyData: wrote %d bytes instead of %d", n, c.size)
+			}
+		})
+	}
+}

--- a/mp4/stsc.go
+++ b/mp4/stsc.go
@@ -179,10 +179,13 @@ func (b *StscBox) AddEntry(firstChunk, samplesPerChunk, sampleDescriptionID uint
 }
 
 // GetSampleDescriptionID returns the sample description ID from common or individual values for chunk.
-// chunkNr is 1-based.
+// chunkNr is 1-based. Returns 0 (not a valid ID) if chunkNr is out of range.
 func (b *StscBox) GetSampleDescriptionID(chunkNr int) uint32 {
 	if b.singleSampleDescriptionID != 0 {
 		return b.singleSampleDescriptionID
+	}
+	if chunkNr < 1 || chunkNr > len(b.SampleDescriptionID) {
+		return 0
 	}
 	return b.SampleDescriptionID[chunkNr-1]
 }
@@ -196,7 +199,10 @@ func (b *StscBox) SetSingleSampleDescriptionID(sampleDescriptionID uint32) {
 // ChunkNrFromSampleNr - get chunk number from sampleNr (one-based)
 func (b *StscBox) ChunkNrFromSampleNr(sampleNr int) (chunkNr, firstSampleInChunk int, err error) {
 	entryNr := b.FindEntryNrForSampleNr(uint32(sampleNr), 0)
-	entry := b.Entries[entryNr]
+	entry, err := b.entry(entryNr)
+	if err != nil {
+		return 0, 0, fmt.Errorf("sampleNr %d: %w", sampleNr, err)
+	}
 	nrInEntry := (uint32(sampleNr) - entry.FirstSampleNr) / entry.SamplesPerChunk
 	chunkNr = int(entry.FirstChunk + nrInEntry)
 	firstSampleInChunk = int(entry.FirstSampleNr + nrInEntry*entry.SamplesPerChunk)
@@ -221,10 +227,19 @@ func (b *StscBox) GetContainingChunks(startSampleNr, endSampleNr uint32) ([]Chun
 	startEntryNr := b.FindEntryNrForSampleNr(startSampleNr, 0)
 	endEntryNr := b.FindEntryNrForSampleNr(endSampleNr, startEntryNr)
 
-	startEntry := b.Entries[startEntryNr]
-	endEntry := b.Entries[endEntryNr]
+	startEntry, err := b.entry(startEntryNr)
+	if err != nil {
+		return nil, fmt.Errorf("startSampleNr %d: %w", startSampleNr, err)
+	}
+	endEntry, err := b.entry(endEntryNr)
+	if err != nil {
+		return nil, fmt.Errorf("endSampleNr %d: %w", endSampleNr, err)
+	}
 	startChunkNr := (startSampleNr-startEntry.FirstSampleNr)/startEntry.SamplesPerChunk + startEntry.FirstChunk
 	endChunkNr := (endSampleNr-endEntry.FirstSampleNr)/endEntry.SamplesPerChunk + endEntry.FirstChunk
+	if endChunkNr < startChunkNr {
+		return nil, fmt.Errorf("stsc entries give decreasing chunk range %d-%d", startChunkNr, endChunkNr)
+	}
 
 	chunks := make([]Chunk, 0, endChunkNr-startChunkNr+1)
 
@@ -244,9 +259,9 @@ func (b *StscBox) GetContainingChunks(startSampleNr, endSampleNr uint32) ([]Chun
 }
 
 // GetChunk returns chunk for chunkNr (one-based).
-func (b *StscBox) GetChunk(chunkNr uint32) Chunk {
+func (b *StscBox) GetChunk(chunkNr uint32) (Chunk, error) {
 	if chunkNr == 0 {
-		panic("ChunkNr set to 0 but is one-based")
+		return Chunk{}, fmt.Errorf("chunkNr is 0, but is one-based")
 	}
 	chunk := Chunk{
 		ChunkNr:       chunkNr,
@@ -254,14 +269,33 @@ func (b *StscBox) GetChunk(chunkNr uint32) Chunk {
 		NrSamples:     0,
 	}
 	entryNr := b.findEntryNrForChunkNr(chunkNr)
-	entry := b.Entries[entryNr]
+	entry, err := b.entry(entryNr)
+	if err != nil {
+		return Chunk{}, fmt.Errorf("chunkNr %d: %w", chunkNr, err)
+	}
 	chunk.NrSamples = entry.SamplesPerChunk
 	chunk.StartSampleNr = (chunkNr-entry.FirstChunk)*entry.SamplesPerChunk + entry.FirstSampleNr
-	return chunk
+	return chunk, nil
+}
+
+// entry returns the entry for a 0-based entryNr from one of the find methods.
+// An error is returned if entryNr is outside the entries, which is the case for
+// an empty stsc box or a chunkNr/sampleNr before the first entry, and if the
+// entry has samplesPerChunk == 0, which cannot be used for any lookup.
+func (b *StscBox) entry(entryNr uint32) (StscEntry, error) {
+	if entryNr >= uint32(len(b.Entries)) {
+		return StscEntry{}, fmt.Errorf("no stsc entry found among %d entries", len(b.Entries))
+	}
+	entry := b.Entries[entryNr]
+	if entry.SamplesPerChunk == 0 {
+		return StscEntry{}, fmt.Errorf("stsc entry %d has samplesPerChunk == 0", entryNr+1)
+	}
+	return entry, nil
 }
 
 // findEntryNrForChunkNr returns the entry where chunkNr belongs.
-// The resulting entryNr is 0-based index.
+// The resulting entryNr is 0-based index. It is outside the entries if
+// chunkNr is before the first entry, so use entry() to look it up.
 func (b *StscBox) findEntryNrForChunkNr(chunkNr uint32) uint32 {
 	// The following is essentially the sort.Search() code specialized to this case
 	low, high := 0, len(b.Entries)
@@ -278,7 +312,8 @@ func (b *StscBox) findEntryNrForChunkNr(chunkNr uint32) uint32 {
 }
 
 // FindEntryNrForSampleNr returns the entry where sampleNr belongs. lowEntryIdx is entry index (zero-based).
-// The resulting entryNr is 0-based index.
+// The resulting entryNr is 0-based index. It is outside the entries if
+// sampleNr is before the first entry, so check it before indexing Entries.
 func (b *StscBox) FindEntryNrForSampleNr(sampleNr, lowEntryIdx uint32) uint32 {
 	// The following is essentially the sort.Search() code specialized to this case
 	low, high := lowEntryIdx, uint32(len(b.Entries))

--- a/mp4/stsc_test.go
+++ b/mp4/stsc_test.go
@@ -167,7 +167,11 @@ func TestGetChunk(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		gotChunk := stsc.GetChunk(tc.chunkNr)
+		gotChunk, err := stsc.GetChunk(tc.chunkNr)
+		if err != nil {
+			t.Errorf("ChunkNr %d: unexpected error: %s", tc.chunkNr, err)
+			continue
+		}
 		if gotChunk != tc.wantedChunk {
 			t.Errorf("ChunkNr %d: Got %#v instead of %#v", tc.chunkNr, gotChunk, tc.wantedChunk)
 		}
@@ -189,5 +193,74 @@ func TestBadSizeStsc(t *testing.T) {
 	_, err := mp4.DecodeBox(0, buf)
 	if err == nil {
 		t.Error("expected invalid size error")
+	}
+}
+
+// TestStscBadEntries checks that a corrupt stsc box gives errors instead of
+// panicking with index out of range or integer divide by zero. An empty stsc
+// is valid (init segments have one), so the lookups must handle it.
+func TestStscBadEntries(t *testing.T) {
+	cases := []struct {
+		desc string
+		stsc *mp4.StscBox
+	}{
+		{
+			desc: "no entries",
+			stsc: &mp4.StscBox{},
+		},
+		{
+			desc: "samplesPerChunk == 0",
+			stsc: &mp4.StscBox{Entries: []mp4.StscEntry{{FirstChunk: 1, SamplesPerChunk: 0, FirstSampleNr: 1}}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			if _, err := c.stsc.GetContainingChunks(1, 2); err == nil {
+				t.Error("GetContainingChunks: expected error, got nil")
+			}
+			if _, _, err := c.stsc.ChunkNrFromSampleNr(1); err == nil {
+				t.Error("ChunkNrFromSampleNr: expected error, got nil")
+			}
+			if _, err := c.stsc.GetChunk(1); err == nil {
+				t.Error("GetChunk: expected error, got nil")
+			}
+		})
+	}
+}
+
+// TestStscGetChunkBeforeFirstEntry covers a chunkNr below the FirstChunk of the
+// first entry. DecodeStscSR does not require the first entry to start at chunk
+// 1, and the entry search then reports an entryNr outside the entries.
+func TestStscGetChunkBeforeFirstEntry(t *testing.T) {
+	stsc := &mp4.StscBox{Entries: []mp4.StscEntry{{FirstChunk: 5, SamplesPerChunk: 2, FirstSampleNr: 1}}}
+	if _, err := stsc.GetChunk(1); err == nil {
+		t.Error("expected error for chunkNr before first entry, got nil")
+	}
+	if _, err := stsc.GetChunk(5); err != nil {
+		t.Errorf("unexpected error for chunkNr 5: %s", err)
+	}
+}
+
+func TestStscGetChunkZero(t *testing.T) {
+	stsc := &mp4.StscBox{}
+	if err := stsc.AddEntry(1, 2, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stsc.GetChunk(0); err == nil {
+		t.Error("expected error for chunkNr 0, got nil")
+	}
+}
+
+func TestStscGetSampleDescriptionIDOutOfRange(t *testing.T) {
+	stsc := &mp4.StscBox{}
+	for _, e := range []struct{ firstChunk, samplesPerChunk, sdid uint32 }{{1, 2, 1}, {2, 2, 2}} {
+		if err := stsc.AddEntry(e.firstChunk, e.samplesPerChunk, e.sdid); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, chunkNr := range []int{0, -1, 3, 1000} {
+		if sdid := stsc.GetSampleDescriptionID(chunkNr); sdid != 0 {
+			t.Errorf("chunkNr %d: got sampleDescriptionID %d instead of 0", chunkNr, sdid)
+		}
 	}
 }

--- a/mp4/stsz.go
+++ b/mp4/stsz.go
@@ -135,9 +135,11 @@ func (b *StszBox) GetNrSamples() uint32 {
 	return uint32(len(b.SampleSize))
 }
 
-// GetSampleSize returns the size (in bytes) of a sample
+// GetSampleSize returns the size (in bytes) of a sample.
+// The sample number i is one-based. SampleUniformSize is returned if i is
+// outside the individual sizes, which is 0 for a box with individual sizes.
 func (b *StszBox) GetSampleSize(i int) uint32 {
-	if i > len(b.SampleSize) { // One-based
+	if i < 1 || i > len(b.SampleSize) { // One-based
 		return b.SampleUniformSize
 	}
 	return b.SampleSize[i-1]
@@ -145,8 +147,8 @@ func (b *StszBox) GetSampleSize(i int) uint32 {
 
 // GetTotalSampleSize - get total size of a range [startNr, endNr] of samples
 func (b *StszBox) GetTotalSampleSize(startNr, endNr uint32) (uint64, error) {
-	if startNr <= 0 || endNr > b.SampleNumber {
-		return 0, fmt.Errorf("startNr or calculated endNr outside range 1-%d", b.SampleNumber)
+	if startNr <= 0 || endNr > b.GetNrSamples() {
+		return 0, fmt.Errorf("startNr or calculated endNr outside range 1-%d", b.GetNrSamples())
 	}
 	if endNr < startNr {
 		return 0, nil

--- a/mp4/stsz_test.go
+++ b/mp4/stsz_test.go
@@ -63,3 +63,30 @@ func TestStszGetTotalSize(t *testing.T) {
 		}
 	}
 }
+
+func TestStszGetSampleSizeOutOfRange(t *testing.T) {
+	individual := &mp4.StszBox{SampleNumber: 2, SampleSize: []uint32{4, 8}}
+	for _, sampleNr := range []int{0, -1, 3, 1000} {
+		if size := individual.GetSampleSize(sampleNr); size != 0 {
+			t.Errorf("sampleNr %d: got size %d instead of 0", sampleNr, size)
+		}
+	}
+	if size := individual.GetSampleSize(2); size != 8 {
+		t.Errorf("sampleNr 2: got size %d instead of 8", size)
+	}
+	uniform := &mp4.StszBox{SampleNumber: 2, SampleUniformSize: 4}
+	if size := uniform.GetSampleSize(0); size != 4 {
+		t.Errorf("uniform sampleNr 0: got size %d instead of 4", size)
+	}
+}
+
+func TestStszGetTotalSampleSizeShortTable(t *testing.T) {
+	// SampleNumber disagrees with the number of individual sizes.
+	stsz := &mp4.StszBox{SampleNumber: 10, SampleSize: []uint32{1, 2}}
+	if _, err := stsz.GetTotalSampleSize(1, 10); err == nil {
+		t.Error("expected error when SampleNumber exceeds the individual sizes, got nil")
+	}
+	if size, err := stsz.GetTotalSampleSize(1, 2); err != nil || size != 3 {
+		t.Errorf("got size %d, err %v; expected 3, nil", size, err)
+	}
+}

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -146,8 +146,10 @@ func createSampleFlagsFromProgressiveBoxes(stss *StssBox, sdtp *SdtpBox, sampleN
 			sampleFlags.SampleDependsOn = 2 //2 = does not depend on others (I-picture). May be overridden by sdtp entry
 		}
 	}
-	if sdtp != nil {
-		entry := sdtp.Entries[uint32(sampleNr)-1] // table starts at 0, but sampleNr is one-based
+	// Nothing ties the number of sdtp entries to the number of samples in
+	// stsz, so a short sdtp must not be indexed outside its entries.
+	if sdtp != nil && sampleNr >= 1 && int(sampleNr) <= len(sdtp.Entries) {
+		entry := sdtp.Entries[sampleNr-1] // table starts at 0, but sampleNr is one-based
 		sampleFlags.IsLeading = entry.IsLeading()
 		sampleFlags.SampleDependsOn = entry.SampleDependsOn()
 		sampleFlags.SampleHasRedundancy = entry.SampleHasRedundancy()

--- a/mp4/trak_test.go
+++ b/mp4/trak_test.go
@@ -61,3 +61,59 @@ func TestTrakSampleFunctions(t *testing.T) {
 		t.Fatalf("expected 1 range, got %d", len(ranges))
 	}
 }
+
+// TestGetSampleDataShortTables checks that a ctts or sdtp box covering fewer
+// samples than stsz declares does not panic. Nothing in the box definitions
+// ties these tables to the same sample count, so a corrupt file can disagree.
+func TestGetSampleDataShortTables(t *testing.T) {
+	cases := []struct {
+		desc    string
+		corrupt func(stbl *mp4.StblBox)
+	}{
+		{
+			desc: "ctts covering two samples",
+			corrupt: func(stbl *mp4.StblBox) {
+				stbl.Ctts = &mp4.CttsBox{}
+				if err := stbl.Ctts.AddSampleCountsAndOffset([]uint32{2}, []int32{1000}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			desc: "empty ctts",
+			corrupt: func(stbl *mp4.StblBox) {
+				stbl.Ctts = &mp4.CttsBox{EndSampleNr: []uint32{0}}
+			},
+		},
+		{
+			desc: "sdtp with two entries",
+			corrupt: func(stbl *mp4.StblBox) {
+				stbl.Sdtp = &mp4.SdtpBox{Entries: []mp4.SdtpEntry{
+					mp4.NewSdtpEntry(0, 2, 0, 0), mp4.NewSdtpEntry(0, 2, 0, 0),
+				}}
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			fd, err := os.Open("testdata/bbb_prog_10s.mp4")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fd.Close()
+			f, err := mp4.DecodeFile(fd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			trak := f.Moov.Trak
+			c.corrupt(trak.Mdia.Minf.Stbl)
+			samples, err := trak.GetSampleData(1, 10)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if len(samples) != 10 {
+				t.Errorf("got %d samples instead of 10", len(samples))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #564. That PR fixed the `trun` case of a general problem: the box
decoders are hardened (size checks, `SliceReader` accumulating errors), but the
layer above them — the accessors that walk the sample tables and the sample
data — trusts whatever the boxes contain. The existing fuzz targets only cover
`FuzzDecodeBox` and the codec parameter-set parsers, which is why this layer
went unexercised.

Sweeping for the same shape found panics reachable from file input in four
areas. Each is one commit, and every new test was checked to panic or fail
against the pre-fix code.

Three of these are crashes of the shipped tools on a real mp4 with one or two
fields patched:

| tool | crafted input | before |
| --- | --- | --- |
| `mp4ff-nallister` | chunk offsets in `stco` bumped by 2^28 | `slice bounds out of range [:268436217] with capacity 409600` |
| `mp4ff-nallister` | `ctts` truncated to one entry | `index out of range [1] with length 1` |
| `mp4ff-crop` | `ctts` truncated to one entry | `index out of range [2] with length 2` |
| `mp4ff-decrypt` | one `senc` `BytesOfProtectedData` bumped | `slice bounds out of range [:4026532612] with capacity 114688` |

## `fix(mp4): error instead of panic when sample tables point outside mdat`

The progressive counterpart of #564. `File.CopySampleData` sliced `mdat.Data`
with a chunk offset from `stco`/`co64` and a size from `stsz`, unchecked. An
offset below the mdat payload start also underflowed in uint64 and produced a
huge index.

The bounds check now lives in a shared `MdatBox.dataRange` used by both
`ReadData` and `CopyData`. That also fixes an off-by-one in the other
direction: the old guard was `endIndexInMdatData >= dataLen`, so reading the
whole payload or its last byte failed with `invalid range provided`.

`mp4ff-nallister`, `mp4ff-pslister`, `mp4ff-subslister` and the segmenter
example each repeated the same unchecked offset arithmetic and now go through
`MdatBox.ReadData`.

## `fix(mp4): error instead of panic when sample tables disagree`

Nothing in the box definitions ties the entry counts of `ctts`, `sdtp`, `stsc`
and `stsz` to each other, so a corrupt file can have tables that disagree on
how many samples the track has. The per-sample accessors panicked with index
out of range, and an `stsc` entry with `samplesPerChunk == 0` divided by zero.

Where an accessor has no error return and the box is optional, the sample
degrades gracefully: `CttsBox.GetCompositionTimeOffset` returns 0 for a sample
it does not cover, and `TrakBox.GetSampleData` leaves the flags from a missing
`sdtp` entry at their default. A sample outside these tables genuinely has no
offset or flags, and this matches what `StszBox.GetSampleSize` already does.
The `stsc` lookups return an error instead, since an unusable sample-to-chunk
mapping cannot be degraded past.

`mp4ff-crop` cropped the same tables with the same assumptions and panicked on
the same files. It also collected cropping errors in a variable that each
following track overwrote, so only the last error was ever reported.

**Breaking:** `StscBox.GetChunk(chunkNr uint32) Chunk` →
`(Chunk, error)`. It already panicked deliberately for `chunkNr == 0` and had
no way to report an entry it could not find. Two in-repo callers, both in
`mp4ff-crop`.

I deliberately did **not** add decode-time validation here, though
`DecodeStscSR` already rejects `sampleDescriptionID == 0` and that would have
been the tidier kill. An `stsc` with no entries is valid — every init segment
built by `CreateEmptyInit` has one — and rejecting at decode would stop
`mp4ff-info` from dumping exactly the corrupt files you want to inspect. All
the hardening sits at the use sites, as in #564.

## `fix(mp4): error instead of panic on senc subsample counts outside sample`

The subsample byte counts in a `senc` box are not tied to the actual sample
sizes, so `CryptSampleCenc`, `DecryptSampleCbcs` and `EncryptSampleCbcs` sliced
outside the sample. Counts close to 2^32 also wrapped when added to the
position. Ranges are now computed in uint64 and checked in one helper shared by
the cenc and cbcs paths.

`decryptSamplesInPlace` indexed `senc.SubSamples` with the sample index while
only checking that it was non-empty, so a `senc` with fewer subsample entries
than the trun sample count panicked. A mismatch is now an error rather than
silently applying subsample information belonging to another sample. The `IVs`
check just above it stays as it is — falling back to the tenc constant IV is
intentional there.

## `fix(avc,hevc): error instead of panic on bad nalu length fields`

The functions that scan a sample by following its 4-byte nalu length fields
trusted those fields. A length past the end of the sample made them slice
outside it, and a length close to 2^32 wrapped when added to the position,
which defeated the checks `avc.GetNalusFromSample` and the protect-range
functions already had. The loop limit was written `pos < uint32(length-4)`,
which underflows for a sample shorter than 4 bytes; `avc.ContainsNaluType`
lacked the separate short-sample guard its siblings have and read outside a
2-byte sample.

The limit is now `pos+4 < uint32(length)` and each length field is checked
against the sample size in uint64 before use, via a small `naluFits` helper per
package. Scanning stops at a bad length field, so callers get the nalus up to
that point.

Affected: `FindNaluTypes`, `FindNaluTypesUpToFirstVideoNALU`/`...Nalu`,
`ContainsNaluType`, `IsIDRSample`, `IsRAPSample`, `HasParameterSets`,
`GetParameterSets`, `GetNalusFromSample`, `ConvertSampleToByteStream`,
`GetAVCProtectRanges` and `GetHEVCProtectRanges`.

## Tests

Regression tests per family, each verified to panic or fail without its fix:

- `mp4`: `TestMdatDataRangeChecks`, `TestCopySampleDataCorruptTables`,
  `TestGetCompositionTimeOffsetOutsideBox`, `TestGetSampleDataShortTables`,
  `TestStscBadEntries`, `TestStscGetChunkBeforeFirstEntry`,
  `TestStscGetChunkZero`, `TestStscGetSampleDescriptionIDOutOfRange`,
  `TestStszGetSampleSizeOutOfRange`, `TestStszGetTotalSampleSizeShortTable`,
  `TestCryptSampleBadSubSamplePatterns`,
  `TestDecryptFragmentSencSampleCountMismatch`,
  `TestProtectRangesBadNaluLength`
- `avc`/`hevc`: `TestScanBadSamples`, `TestGetParameterSetsBadLength`,
  `TestGetNalusFromSampleBadLength`
- CLI, corrupting a real testdata file into a temp dir and running the tool's
  entry point: `mp4ff-nallister/TestBadChunkOffsets`,
  `mp4ff-crop/TestTruncatedCtts`, `mp4ff-decrypt/TestBadSubSamplePattern`

## Not included

Panics only reachable by constructing boxes in code, not by decoding a file,
where the decoders' size checks keep the tables consistent:
`StscBox.EncodeSW` panics if `Entries` is assigned without a sample
description ID. The deliberate `panic` calls for `sampleNr == 0` in
`SttsBox.GetDur` and `CttsBox.GetCompositionTimeOffset` are left alone — they
fire on a caller bug, never on file data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
