### PR TITLE
fix(mp4): error instead of panic when stts does not cover the sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `SttsBox.GetDecodeTime` returns an error instead of panicking with index out
+  of range when the stts entries cover fewer samples than the requested sample
+  number (a file whose stts and stsz disagree), or when called with sampleNr 0.
+  Signature change: `GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32)`
+  → `GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32, err error)`.
+  `SttsBox.GetSampleNrAtTime` returns an error instead of panicking for an
+  stts box without entries
 - `TrunBox.GetFullSamples` returns an error when the trun-declared sample
   sizes point outside the mdat data (a truncated or corrupt file), instead
   of panicking with index out of range. Signature change:

--- a/cmd/mp4ff-crop/main.go
+++ b/cmd/mp4ff-crop/main.go
@@ -172,7 +172,10 @@ func findEndTime(moov *mp4.MoovBox, durationMS int) (endTime, endTimescale uint6
 			return 0, 0, fmt.Errorf("did not find any syncframe at or after time")
 		}
 	}
-	lastTime, lastDur := stts.GetDecodeTime(lastSampleNr)
+	lastTime, lastDur, err := stts.GetDecodeTime(lastSampleNr)
+	if err != nil {
+		return 0, 0, err
+	}
 	endTime = lastTime + uint64(lastDur)
 
 	return endTime, endTimescale, nil
@@ -239,7 +242,10 @@ func findTrakEnds(traks []*mp4.TrakBox, endTime, endTimescale uint64) (map[uint3
 		}
 		endSampleNr--
 		to.lastSampleNr = endSampleNr
-		decTime, dur := stts.GetDecodeTime(endSampleNr)
+		decTime, dur, err := stts.GetDecodeTime(endSampleNr)
+		if err != nil {
+			return nil, err
+		}
 		trackEndTime = decTime + uint64(dur)
 		tos[trackID].endTime = trackEndTime
 		stsc := stbl.Stsc

--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -200,7 +200,10 @@ func parseProgressiveMp4(w io.Writer, f *mp4.File, maxNrSamples int, codec strin
 			offset += int64(stbl.Stsz.GetSampleSize(sNr))
 		}
 		size := stbl.Stsz.GetSampleSize(sampleNr)
-		decTime, _ := stbl.Stts.GetDecodeTime(uint32(sampleNr))
+		decTime, _, err := stbl.Stts.GetDecodeTime(uint32(sampleNr))
+		if err != nil {
+			return fmt.Errorf("sample %d: %w", sampleNr, err)
+		}
 		var cto int64 = 0
 		if stbl.Ctts != nil {
 			cto = int64(stbl.Ctts.GetCompositionTimeOffset(uint32(sampleNr)))

--- a/cmd/mp4ff-subslister/main.go
+++ b/cmd/mp4ff-subslister/main.go
@@ -150,7 +150,10 @@ func parseProgressiveMp4(f *mp4.File, w io.Writer, trackID uint32, maxNrSamples 
 			offset += int64(stbl.Stsz.GetSampleSize(sNr))
 		}
 		size := stbl.Stsz.GetSampleSize(sampleNr)
-		decTime, dur := stbl.Stts.GetDecodeTime(uint32(sampleNr))
+		decTime, dur, err := stbl.Stts.GetDecodeTime(uint32(sampleNr))
+		if err != nil {
+			return fmt.Errorf("sample %d: %w", sampleNr, err)
+		}
 		// Skip checking compositionTimeOffset since not uset for subtitles
 		// Next find sample bytes as slice in mdat
 		sample, err := mdat.ReadData(offset, int64(size), nil)

--- a/examples/segmenter/main.go
+++ b/examples/segmenter/main.go
@@ -106,7 +106,10 @@ func run(args []string, outDir string) error {
 	if err != nil {
 		return fmt.Errorf("error creating segmenter: %w", err)
 	}
-	syncTimescale, segmentStarts := getSegmentStartsFromVideo(parsedMp4, uint32(o.chunkDurMS))
+	syncTimescale, segmentStarts, err := getSegmentStartsFromVideo(parsedMp4, uint32(o.chunkDurMS))
+	if err != nil {
+		return fmt.Errorf("error getting segment starts: %w", err)
+	}
 	fmt.Printf("segment starts in timescale %d: %v\n", syncTimescale, segmentStarts)
 	err = segmenter.SetTargetSegmentation(syncTimescale, segmentStarts)
 	if err != nil {

--- a/examples/segmenter/segment.go
+++ b/examples/segmenter/segment.go
@@ -102,7 +102,10 @@ func makeSingleTrackSegmentsLazyWrite(segmenter *Segmenter, parsedMp4 *mp4.File,
 				return err
 			}
 			seg.AddFragment(frag)
-			baseMediaDecodeTime, _ := tr.inTrak.Mdia.Minf.Stbl.Stts.GetDecodeTime(startSampleNr)
+			baseMediaDecodeTime, _, err := tr.inTrak.Mdia.Minf.Stbl.Stts.GetDecodeTime(startSampleNr)
+			if err != nil {
+				return err
+			}
 			for _, sample := range samples {
 				err = frag.AddSampleToTrack(sample, tr.trackID, baseMediaDecodeTime)
 				if err != nil {
@@ -196,7 +199,7 @@ type syncPoint struct {
 	presTime   uint64
 }
 
-func getSegmentStartsFromVideo(parsedMp4 *mp4.File, segDurMS uint32) (timeScale uint32, syncPoints []syncPoint) {
+func getSegmentStartsFromVideo(parsedMp4 *mp4.File, segDurMS uint32) (timeScale uint32, syncPoints []syncPoint, err error) {
 	var refTrak *mp4.TrakBox
 	for _, trak := range parsedMp4.Moov.Traks {
 		hdlrType := trak.Mdia.Hdlr.HandlerType
@@ -216,7 +219,10 @@ func getSegmentStartsFromVideo(parsedMp4 *mp4.File, segDurMS uint32) (timeScale 
 	var segmentStep = uint32(uint64(segDurMS) * uint64(timeScale) / 1000)
 	var nextSegmentStart uint32 = 0
 	for _, sampleNr := range stss.SampleNumber {
-		decodeTime, _ := stts.GetDecodeTime(sampleNr)
+		decodeTime, _, err := stts.GetDecodeTime(sampleNr)
+		if err != nil {
+			return 0, nil, err
+		}
 		presTime := int64(decodeTime)
 		if ctts != nil {
 			presTime += int64(ctts.GetCompositionTimeOffset(sampleNr))
@@ -226,7 +232,7 @@ func getSegmentStartsFromVideo(parsedMp4 *mp4.File, segDurMS uint32) (timeScale 
 			nextSegmentStart += segmentStep
 		}
 	}
-	return timeScale, syncPoints
+	return timeScale, syncPoints, nil
 }
 
 type sampleInterval struct {

--- a/examples/segmenter/segmenter.go
+++ b/examples/segmenter/segmenter.go
@@ -156,7 +156,10 @@ func (s *Segmenter) GetFullSamplesForInterval(mp4f *mp4.File, tr *Track, startSa
 			offset += int64(stbl.Stsz.GetSampleSize(sNr))
 		}
 		size := stbl.Stsz.GetSampleSize(int(sampleNr))
-		decTime, dur := stbl.Stts.GetDecodeTime(sampleNr)
+		decTime, dur, err := stbl.Stts.GetDecodeTime(sampleNr)
+		if err != nil {
+			return nil, fmt.Errorf("sample %d: %w", sampleNr, err)
+		}
 		var cto int32 = 0
 		if stbl.Ctts != nil {
 			cto = stbl.Ctts.GetCompositionTimeOffset(sampleNr)

--- a/mp4/stts.go
+++ b/mp4/stts.go
@@ -97,16 +97,20 @@ func (b *SttsBox) GetTimeCode(sample, timescale uint32) time.Duration {
 	return time.Second * time.Duration(units) / time.Duration(timescale)
 }
 
-// GetDecodeTime - decode time and duration for (one-based) sampleNr in track timescale
-func (b *SttsBox) GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32) {
+// GetDecodeTime - decode time and duration for (one-based) sampleNr in track timescale.
+// An error is returned if sampleNr is zero, or if the stts entries cover fewer samples
+// than sampleNr (a file whose stts and stsz disagree on the sample count).
+func (b *SttsBox) GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32, err error) {
 	if sampleNr == 0 {
-		// This is bad index input. Should never happen
-		panic("SttsBox.GetDecodeTime called with sampleNr == 0, although one-based")
+		return 0, 0, fmt.Errorf("sampleNr is 0, but sample numbers are one-based")
 	}
 	samplesRemaining := sampleNr - 1
 	decTime = 0
 	i := 0
 	for {
+		if i >= len(b.SampleTimeDelta) {
+			return 0, 0, fmt.Errorf("stts entries cover fewer samples than sampleNr %d", sampleNr)
+		}
 		dur = b.SampleTimeDelta[i]
 		if samplesRemaining >= b.SampleCount[i] {
 			decTime += uint64(b.SampleCount[i]) * uint64(dur)
@@ -119,7 +123,7 @@ func (b *SttsBox) GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32) {
 		}
 		i++
 	}
-	return decTime, dur
+	return decTime, dur, nil
 }
 
 // GetDur - get dur for a specific sample
@@ -194,6 +198,9 @@ func (b *SttsBox) GetSampleNrAtTime(sampleStartTime uint64) (sampleNr uint32, er
 	accTime := uint64(0)
 	accNr := uint32(0)
 	nrEntries := len(b.SampleCount)
+	if nrEntries == 0 {
+		return 0, fmt.Errorf("stts box has no entries")
+	}
 	for i := 0; i < nrEntries; i++ {
 		timeDelta := uint64(b.SampleTimeDelta[i])
 		if sampleStartTime < accTime+uint64(b.SampleCount[i])*timeDelta {

--- a/mp4/stts_test.go
+++ b/mp4/stts_test.go
@@ -77,19 +77,43 @@ func TestGetDecodeTime(t *testing.T) {
 		sampleNr    uint32
 		expectedDec uint64
 		expectedDur uint32
+		expectError bool
 	}{
-		{1, 0, 1024},
-		{3, 2 * 1024, 1024},
-		{4, 3 * 1024, 1025},
-		{5, 3*1024 + 1025, 1024},
+		{1, 0, 1024, false},
+		{3, 2 * 1024, 1024, false},
+		{4, 3 * 1024, 1025, false},
+		{5, 3*1024 + 1025, 1024, false},
+		{0, 0, 0, true},  // sample numbers are one-based
+		{6, 0, 0, true},  // beyond the 5 samples the entries cover
+		{99, 0, 0, true}, // far beyond the entries
 	}
 	for idx, tc := range testCases {
-		gotDec, gotDur := stts.GetDecodeTime(tc.sampleNr)
+		gotDec, gotDur, err := stts.GetDecodeTime(tc.sampleNr)
+		if tc.expectError {
+			if err == nil {
+				t.Errorf("test case %d: expected error for sampleNr %d, got none", idx, tc.sampleNr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("test case %d: unexpected error for sampleNr %d: %v", idx, tc.sampleNr, err)
+			continue
+		}
 		if gotDec != tc.expectedDec {
 			t.Errorf("test case %d: got dec %d instead of %d for sampleNr %d", idx, gotDec, tc.expectedDec, tc.sampleNr)
 		}
 		if gotDur != tc.expectedDur {
 			t.Errorf("test case %d: got dur %d instead of %d for sampleNr %d", idx, gotDur, tc.expectedDur, tc.sampleNr)
 		}
+	}
+}
+
+func TestSttsEmptyBox(t *testing.T) {
+	stts := mp4.SttsBox{}
+	if _, _, err := stts.GetDecodeTime(1); err == nil {
+		t.Error("expected error from GetDecodeTime on stts without entries, got none")
+	}
+	if _, err := stts.GetSampleNrAtTime(0); err == nil {
+		t.Error("expected error from GetSampleNrAtTime on stts without entries, got none")
 	}
 }


### PR DESCRIPTION
## What

`SttsBox.GetDecodeTime` walked the stts entries with no bounds check, so a file whose stts covers fewer samples than requested (an stts and stsz that disagree on the sample count — same corrupt-file family as the recent ctts/stsc/stsz hardening) panicked with index out of range. The explicit `panic` for sampleNr 0 goes the same way. `SttsBox.GetSampleNrAtTime` also panicked for an stts without entries (its final zero-duration check indexes `[nrEntries-1]`).

Both now return errors:

- Signature change (pre-1.0, same pattern as the recent `StscBox.GetChunk` and `TrunBox.GetFullSamples` changes): `GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32)` → `(decTime uint64, dur uint32, err error)`.
- `GetSampleNrAtTime` keeps its signature (already error-returning) and errors on an entry-less box.

All in-repo callers (mp4ff-crop, mp4ff-subslister, mp4ff-nallister, the segmenter example) propagate the error; every call site already sat in an error-returning path.

## Motivation

In a JIT packaging origin these accessors run behind caches on files fetched from remote storage; a truncated or inconsistent file must fail one request, not crash the process. We currently pre-validate stts coverage ourselves before calling `GetDecodeTime` precisely because of this panic.

## Tests

`TestGetDecodeTime` extended with the error cases (sampleNr 0, one past coverage, far past coverage), and a new `TestSttsEmptyBox` pins both functions on an entry-less stts. Existing valid-input expectations unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)