### PR TITLE
feat(mp4): CloneBox for deep-copying a box tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version 0 form with the esds as a direct child. Entries without a reachable
   esds, and wave boxes holding anything besides their recognized decoder-init
   atoms, are left untouched
+- `CloneBox` returns a deep copy of a box (via an encode/decode round trip),
+  so a box tree that shares parts with another structure can be mutated
+  safely — for example handing `InitProtect` (which rewrites the stsd sample
+  entry in place) an init segment built from a cached, shared trak
 
 ### Changed
 

--- a/mp4/clone.go
+++ b/mp4/clone.go
@@ -1,0 +1,37 @@
+package mp4
+
+import (
+	"fmt"
+
+	"github.com/Eyevinn/mp4ff/bits"
+)
+
+// CloneBox returns a deep copy of a box, made by encoding it and decoding the
+// bytes back into a fresh box tree. Nothing in the returned box aliases the
+// original, so either of the two can be mutated without affecting the other.
+//
+// The typical use is protecting a shared box tree from functions that modify
+// boxes in place: a caller that builds init segments from a cached moov can
+// hand InitProtect a clone of the shared stsd instead of the original, since
+// InitProtect rewrites the sample entry (avc1 -> encv etc.) in place.
+//
+// The clone is what a fresh decode of the box would give, so decode-time
+// state is reset: StartPos fields reflect a decode at position 0, and a senc
+// box needs its usual deferred parsing again. A lazy mdat (payload not held
+// in memory) cannot be cloned this way and returns an error.
+func CloneBox(b Box) (Box, error) {
+	if m, ok := b.(*MdatBox); ok && m.IsLazy() {
+		return nil, fmt.Errorf("cannot clone lazy mdat box")
+	}
+	size := b.Size()
+	sw := bits.NewFixedSliceWriter(int(size))
+	if err := b.EncodeSW(sw); err != nil {
+		return nil, fmt.Errorf("encode %s: %w", b.Type(), err)
+	}
+	sr := bits.NewFixedSliceReader(sw.Bytes())
+	clone, err := DecodeBoxSR(0, sr)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", b.Type(), err)
+	}
+	return clone, nil
+}

--- a/mp4/clone.go
+++ b/mp4/clone.go
@@ -12,8 +12,8 @@ import (
 //
 // The typical use is protecting a shared box tree from functions that modify
 // boxes in place: a caller that builds init segments from a cached moov can
-// hand InitProtect a clone of the shared stsd instead of the original, since
-// InitProtect rewrites the sample entry (avc1 -> encv etc.) in place.
+// hand [InitProtect] a clone of the shared stsd instead of the original, since
+// it rewrites the sample entry (avc1 -> encv etc.) in place.
 //
 // The clone is what a fresh decode of the box would give, so decode-time
 // state is reset: StartPos fields reflect a decode at position 0, and a senc

--- a/mp4/clone_test.go
+++ b/mp4/clone_test.go
@@ -1,0 +1,76 @@
+package mp4_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/Eyevinn/mp4ff/bits"
+	"github.com/Eyevinn/mp4ff/mp4"
+)
+
+// encodeSW encodes a box to bytes for comparisons.
+func encodeSW(t *testing.T, b mp4.Box) []byte {
+	t.Helper()
+	sw := bits.NewFixedSliceWriter(int(b.Size()))
+	if err := b.EncodeSW(sw); err != nil {
+		t.Fatal(err)
+	}
+	return sw.Bytes()
+}
+
+func TestCloneBox(t *testing.T) {
+	raw, err := os.ReadFile("testdata/init.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := mp4.DecodeFileSR(bits.NewFixedSliceReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stsd := f.Init.Moov.Trak.Mdia.Minf.Stbl.Stsd
+
+	clone, err := mp4.CloneBox(stsd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stsdClone, ok := clone.(*mp4.StsdBox)
+	if !ok {
+		t.Fatalf("clone has type %T, not *mp4.StsdBox", clone)
+	}
+	if !bytes.Equal(encodeSW(t, stsd), encodeSW(t, stsdClone)) {
+		t.Error("clone does not encode to the same bytes as the original")
+	}
+
+	// The point of the clone: mutating it (as InitProtect does when it
+	// turns avc1 into encv) must not touch the original.
+	origEntry := stsd.Children[0].(*mp4.VisualSampleEntryBox)
+	cloneEntry := stsdClone.Children[0].(*mp4.VisualSampleEntryBox)
+	if origEntry == cloneEntry {
+		t.Fatal("clone shares its sample entry with the original")
+	}
+	cloneEntry.SetType("encv")
+	if origEntry.Type() != "avc1" {
+		t.Errorf("mutating the clone changed the original sample entry type to %q", origEntry.Type())
+	}
+
+	// A container box clones deeply too.
+	moovClone, err := mp4.CloneBox(f.Init.Moov)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(encodeSW(t, f.Init.Moov), encodeSW(t, moovClone)) {
+		t.Error("moov clone does not encode to the same bytes as the original")
+	}
+	if moovClone.(*mp4.MoovBox).Trak == f.Init.Moov.Trak {
+		t.Error("moov clone shares its trak with the original")
+	}
+}
+
+func TestCloneBoxLazyMdat(t *testing.T) {
+	mdat := &mp4.MdatBox{}
+	mdat.SetLazyDataSize(1000)
+	if _, err := mp4.CloneBox(mdat); err == nil {
+		t.Error("expected error cloning a lazy mdat, got none")
+	}
+}

--- a/mp4/crypto.go
+++ b/mp4/crypto.go
@@ -401,7 +401,7 @@ type InitProtectData struct {
 // InitProtect modifies the init segment to add protection information and return what is needed to encrypt fragments.
 // The stsd sample entry is rewritten in place (avc1 -> encv etc.), so if the init segment shares boxes
 // with another structure (for example a trak of a cached progressive file), clone the shared parts
-// first (see CloneBox) or the other structure is silently modified too.
+// first (see [CloneBox]) or the other structure is silently modified too.
 func InitProtect(init *InitSegment, key, iv []byte, scheme string, kid UUID, psshBoxes []*PsshBox) (*InitProtectData, error) {
 	ipd := InitProtectData{Scheme: scheme}
 	moov := init.Moov

--- a/mp4/crypto.go
+++ b/mp4/crypto.go
@@ -399,6 +399,9 @@ type InitProtectData struct {
 }
 
 // InitProtect modifies the init segment to add protection information and return what is needed to encrypt fragments.
+// The stsd sample entry is rewritten in place (avc1 -> encv etc.), so if the init segment shares boxes
+// with another structure (for example a trak of a cached progressive file), clone the shared parts
+// first (see CloneBox) or the other structure is silently modified too.
 func InitProtect(init *InitSegment, key, iv []byte, scheme string, kid UUID, psshBoxes []*PsshBox) (*InitProtectData, error) {
 	ipd := InitProtectData{Scheme: scheme}
 	moov := init.Moov


### PR DESCRIPTION
## What

Adds `mp4.CloneBox(b Box) (Box, error)`: a deep copy of any box, implemented as an encode/decode round trip (the one always-correct way to copy a box, since box types have no clone methods and contain nested children, slices, and unexported state). Nothing in the clone aliases the original. A lazy mdat (payload not in memory) is rejected with an error; the doc comment also notes that the clone is what a fresh decode gives (StartPos as of position 0, senc deferred parsing reset).

## Motivation

Functions like `InitProtect` modify boxes in place (the stsd sample entry is rewritten avc1 → encv). That is the right behavior for the init segment being protected — but a caller that builds init segments from a **shared** box tree (a trak of a cached progressive file, in our JIT packaging origin) gets its cached source silently corrupted, and only on the first encrypted request per track, which made this a genuinely painful bug to find. We ended up carrying a private stsd-clone helper doing exactly this round trip; a public general helper plus a warning in `InitProtect`'s doc comment (included in this PR) seems more useful to everyone.

InitProtect's own behavior is deliberately unchanged — cloning internally could surprise callers that hold references to the sample entry and expect to see the protection applied there.

## Tests

`TestCloneBox` clones a real stsd and a whole moov from `testdata/init.mp4`, asserts the clones encode byte-identically to the originals, then mutates the clone's sample entry (`SetType("encv")`, what InitProtect does) and asserts the original is untouched and shares no pointers. `TestCloneBoxLazyMdat` pins the lazy-mdat error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)