### PR TITLE
perf(mp4): buffer WriteToFile output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `WriteToFile` buffers its output instead of writing straight to the file.
+  The many small boxes of a moof cost one write syscall each without it, while
+  a large mdat payload is unaffected, since a write larger than the buffer goes
+  directly to the file. Output bytes are unchanged
 - `SttsBox.GetDecodeTime` returns an error instead of panicking with index out
   of range when the stts entries cover fewer samples than the requested sample
   number (a file whose stts and stsz disagree), or when called with sampleNr 0.

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -128,15 +129,22 @@ type BoxStructure interface {
 	Encode(w io.Writer) error
 }
 
-// WriteToFile - write a box structure to a file at filePath
+// WriteToFile - write a box structure to a file at filePath.
+// The output is buffered, since the many small boxes of a moof would
+// otherwise cost one write syscall each. A large mdat payload is not slowed
+// down by the buffer: once the buffer is empty, bufio.Writer passes a write
+// larger than the buffer directly to the file rather than copying it.
 func WriteToFile(boxStructure BoxStructure, filePath string) error {
 	ofd, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}
 	defer ofd.Close()
-	err = boxStructure.Encode(ofd)
-	return err
+	w := bufio.NewWriter(ofd)
+	if err := boxStructure.Encode(w); err != nil {
+		return err
+	}
+	return w.Flush()
 }
 
 // AddMediaSegment - add a mediasegment to file f

--- a/mp4/file_test.go
+++ b/mp4/file_test.go
@@ -554,3 +554,37 @@ func TestCopySampleDataCorruptTables(t *testing.T) {
 		})
 	}
 }
+
+// TestWriteToFile checks that WriteToFile produces exactly the bytes that
+// Encode does. A segment exercises the many small boxes of a moof, and a
+// progressive file exercises a large mdat payload. A missing Flush of the
+// write buffer would show up here as a truncated file.
+func TestWriteToFile(t *testing.T) {
+	for _, name := range []string{"1.m4s", "bbb_prog_10s.mp4"} {
+		t.Run(name, func(t *testing.T) {
+			raw, err := os.ReadFile(path.Join("testdata", name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			f, err := mp4.DecodeFile(bytes.NewReader(raw))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var buf bytes.Buffer
+			if err := f.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			outPath := path.Join(t.TempDir(), name)
+			if err := mp4.WriteToFile(f, outPath); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(outPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, buf.Bytes()) {
+				t.Errorf("WriteToFile gave %d bytes, Encode gave %d", len(got), len(buf.Bytes()))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`WriteToFile` wrote straight to the `*os.File`, so every box became its own
`write` syscall. A moof is a dozen small boxes, and most boxes encode as
"build a small slice, write it once", so a fragmented segment paid a syscall
per box before the mdat payload was written at all.

This wraps the file in a `bufio.Writer` and flushes it. Output bytes are
unchanged.

A large mdat payload is not penalised by the buffer: once the buffer is empty,
`bufio.Writer` hands a write larger than the buffer straight to the file
instead of copying it through.

## Numbers

darwin/arm64, medians of repeated runs. Two views, because they answer
different questions.

The part this change actually affects, with the file already open:

| encode + write | before | after |
|---|---|---|
| `testdata/bbb_prog_10s.mp4` (416 KB progressive) | 68.3 µs | **27.0 µs** |
| `testdata/1.m4s` (25 KB segment) | 11.3 µs | **3.0 µs** |

2.5x on the progressive file and 3.7x on the segment — the smaller file gains
more, since it is proportionally more box headers and less payload.

A whole `WriteToFile` call, which also creates and closes the file:

| whole call | before | after |
|---|---|---|
| 416 KB progressive | 1.75 ms | 1.57 ms |
| 25 KB segment | 1.56 ms | 1.53 ms |

About 10% and within noise respectively. The two tables differ because
`os.Create` plus `Close` costs roughly 1.5 ms on this machine (APFS) and
dominates everything else. That floor is platform-specific, so the first table
is the portable one; on a system with cheaper file creation the whole-call
figures approach it.

## Buffer size

I measured explicit sizes of 4, 16 and 64 KB against unbuffered and they were
indistinguishable from each other, so this uses `bufio.NewWriter` and its 4 KB
default rather than introducing a tuned constant. That keeps the extra
allocation per call to about 4 KB. An earlier revision of this PR had a
`writeBufferSize = 64 * 1024`, which cost 64 KB per call and bought nothing.

## Test

`TestWriteToFile` asserts that `WriteToFile` produces exactly the bytes that
`Encode` does, for a segment (many small moof boxes) and for a progressive file
(large mdat). I verified it has teeth by removing the `Flush` and watching both
subtests fail on truncated output.

## Scope

This only helps the `WriteToFile` convenience path, which creates the file
itself and so is the only place the library can buffer on the caller's behalf.
Callers that own their own writer already have the tools: `Encode(w io.Writer)`
with their own `bufio.Writer`, or `EncodeSW` into a `FixedSliceWriter`. The
latter is worth knowing about for anyone writing many segments in a loop —
reusing one buffer through `NewFixedSliceWriterFromSlice` matches the buffered
`Encode` on time at 64 B/op, since the cost of the `EncodeSW` route is the
per-call `make([]byte, Size())` and the zeroing of memory that is then
overwritten in full, not the encoding itself.

Neither is documented anywhere, which is worth fixing separately.

## Not included

Several commands and examples do their own `os.Create` followed by
`Encode(ofh)` and are unbuffered for the same reason: `mp4ff-encrypt`,
`mp4ff-decrypt`, `mp4ff-crop`, `mp4ff-mvhevc`, `examples/add-sidx`,
`examples/resegmenter`, `examples/combine-segs`, `examples/initcreator`,
`examples/ivf-to-mp4` and one site in `examples/segmenter`. On the first table's
evidence those stand to gain the same 2.5-3.7x, on files far larger than these
fixtures. Kept out of this PR to keep it to the library API.
