### PR TITLE
fix(mp4): combine mdat data parts and monolithic data instead of dropping one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The mdat payload is now the concatenation of its data parts and its
+  monolithic data, so the two can be combined in any order and are written in
+  the order they were added. Adding a part on top of monolithic data no longer
+  panics with "cannot mix sample parts with monolithic sample data", and data
+  added with `AddSampleData` on top of data parts is no longer silently
+  dropped at encode time, which produced a fragment whose trun declared
+  samples that were never written. `MdatBox.SetData` replaces the whole
+  payload and so now also drops any data parts
 - `NewSdtpEntry` packed the `sampleDependedOn` argument into both two-bit
   dependency fields and dropped `sampleDependsOn`, so every entry it built
   carried a wrong sample_depends_on value. Note that entries built with the

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -219,11 +219,10 @@ func (f *Fragment) AddFullSample(s FullSample) {
 // until the fragment has been encoded.
 //
 // If the mdat already holds monolithic data (from AddFullSample or SetData),
-// data parts cannot be mixed in, so the samples are instead copied into the
-// mdat data, which is grown once up front. Conversely, once AddFullSamples
-// has added data parts, further samples must be added with AddFullSamples
-// (or AddSampleInterval) rather than AddFullSample, since an mdat with data
-// parts encodes only those.
+// the samples are copied into it instead, growing it once up front, so that
+// the data already there is not made to alias the caller's buffers. Samples
+// may be added before or after with AddFullSample either way; the mdat keeps
+// the order in which data was added.
 func (f *Fragment) AddFullSamples(ss []FullSample) {
 	if len(ss) == 0 {
 		return

--- a/mp4/fragment_test.go
+++ b/mp4/fragment_test.go
@@ -349,3 +349,53 @@ func TestAddFullSamplesLargeSizeMdat(t *testing.T) {
 		}
 	}
 }
+
+// TestAddFullSamplesThenAddFullSample - adding single samples after a bulk
+// call must extend the fragment rather than being silently dropped. Before
+// mdat combined parts and monolithic data, the mdat encoded only the parts,
+// so the trun declared samples whose data was never written and the fragment
+// was rejected on decode.
+func TestAddFullSamplesThenAddFullSample(t *testing.T) {
+	bulk := fullSamplesFixture("contiguous", 8, 10000)
+	extra := fullSamplesFixture("scattered", 3, 10000+8*1024)
+	all := append(append([]mp4.FullSample{}, bulk...), extra...)
+	want := encodeFragment(t, fragmentFromLoop(t, all))
+
+	frag, err := mp4.CreateFragment(1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frag.AddFullSamples(bulk)
+	for _, s := range extra {
+		frag.AddFullSample(s)
+	}
+
+	var declared uint64
+	for _, s := range frag.Moof.Traf.Trun.Samples {
+		declared += uint64(s.Size)
+	}
+	if got := frag.Mdat.DataLength(); got != declared {
+		t.Errorf("mdat holds %d payload bytes but trun declares %d", got, declared)
+	}
+	if got := encodeFragment(t, frag); !bytes.Equal(got, want) {
+		t.Error("bulk followed by single samples does not encode identically to the loop")
+	}
+
+	// The fragment must survive a decode round trip with its samples intact.
+	decoded, err := mp4.DecodeFile(bytes.NewReader(encodeFragment(t, frag)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fss, err := decoded.Segments[0].Fragments[0].GetFullSamples(nil)
+	if err != nil {
+		t.Fatalf("GetFullSamples after mixed adds: %v", err)
+	}
+	if len(fss) != len(all) {
+		t.Fatalf("decoded %d samples, expected %d", len(fss), len(all))
+	}
+	for i := range fss {
+		if !bytes.Equal(fss[i].Data, all[i].Data) {
+			t.Errorf("sample %d data differs after round trip", i+1)
+		}
+	}
+}

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -10,8 +10,13 @@ import (
 
 // MdatBox - Media Data Box (mdat)
 // The mdat box contains media chunks/samples.
-// DataParts is to be able to gather output data without
-// new allocations
+//
+// The payload is the concatenation of DataParts followed by Data, so the two
+// can be combined freely: DataParts gathers output data without new
+// allocations by referencing the caller's buffers, while Data is an open tail
+// that AddSampleData appends (and thereby copies) into. Adding a part when a
+// tail is present closes the tail into a part first, so the order in which
+// data was added is always the order it is written.
 type MdatBox struct {
 	StartPos     uint64
 	Data         []byte
@@ -86,24 +91,31 @@ func (m *MdatBox) Size() uint64 {
 	return m.HeaderSize() + m.payloadSize()
 }
 
-// AddSampleData -  a sample data to an mdat box
+// AddSampleData - add sample data to an mdat box. The bytes are copied, so
+// the caller may reuse s. It is appended after any data parts already added.
 func (m *MdatBox) AddSampleData(s []byte) {
 	m.Data = append(m.Data, s...)
 }
 
-// SetData - set the mdat data to given slice. No copying is done
+// SetData - set the mdat data to given slice. No copying is done.
+// The payload becomes exactly data, so any data parts are dropped.
 func (m *MdatBox) SetData(data []byte) {
 	m.Data = data
+	m.DataParts = nil
 	m.lazyDataSize = 0
 }
 
-// AddSampleDataPart - add a data part (for output)
+// AddSampleDataPart - add a data part (for output). The slice is referenced,
+// not copied, so the caller must keep it unmodified until the box has been
+// encoded. Any data added with AddSampleData is closed into a part first, so
+// that this part is written after it.
 func (m *MdatBox) AddSampleDataPart(s []byte) {
-	if len(m.Data) != 0 {
-		panic("cannot mix sample parts with monolithic sample data")
-	}
 	if len(m.DataParts) == 0 {
 		m.DataParts = make([][]byte, 0, 8) // Reasonable size
+	}
+	if len(m.Data) != 0 {
+		m.DataParts = append(m.DataParts, m.Data)
+		m.Data = nil
 	}
 	m.DataParts = append(m.DataParts, s)
 }
@@ -114,14 +126,13 @@ func (m *MdatBox) Encode(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if len(m.DataParts) > 0 {
-		for _, dp := range m.DataParts {
-			_, err = w.Write(dp)
-			if err != nil {
-				return err
-			}
+	for _, dp := range m.DataParts {
+		_, err = w.Write(dp)
+		if err != nil {
+			return err
 		}
-	} else {
+	}
+	if len(m.Data) > 0 {
 		_, err = w.Write(m.Data)
 	}
 
@@ -134,25 +145,21 @@ func (m *MdatBox) EncodeSW(sw bits.SliceWriter) error {
 	if err != nil {
 		return err
 	}
-	if len(m.DataParts) > 0 {
-		for _, dp := range m.DataParts {
-			sw.WriteBytes(dp)
-		}
-	} else {
+	for _, dp := range m.DataParts {
+		sw.WriteBytes(dp)
+	}
+	if len(m.Data) > 0 {
 		sw.WriteBytes(m.Data)
 	}
 
 	return sw.AccError()
 }
 
-// DataLength - length of data stored in box either as one or multiple parts
+// DataLength - length of data stored in box, as parts and as a monolithic tail
 func (m *MdatBox) DataLength() uint64 {
 	dataLength := len(m.Data)
-	if len(m.DataParts) > 0 {
-		dataLength = 0
-		for i := range m.DataParts {
-			dataLength += len(m.DataParts[i])
-		}
+	for i := range m.DataParts {
+		dataLength += len(m.DataParts[i])
 	}
 	return uint64(dataLength)
 }

--- a/mp4/mdat_test.go
+++ b/mp4/mdat_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/Eyevinn/mp4ff/bits"
 	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/go-test/deep"
 )
@@ -279,5 +280,103 @@ func TestMdatDataRangeChecks(t *testing.T) {
 				t.Errorf("CopyData: wrote %d bytes instead of %d", n, c.size)
 			}
 		})
+	}
+}
+
+// TestMdatMixedDataAndParts - data added with AddSampleData and with
+// AddSampleDataPart can be combined in any order, and the payload is written
+// in the order it was added. Before, adding a part on top of monolithic data
+// panicked, and adding monolithic data on top of parts was silently dropped.
+func TestMdatMixedDataAndParts(t *testing.T) {
+	a := []byte{0, 1, 2}
+	b := []byte{3, 4}
+	c := []byte{5, 6, 7, 8}
+
+	cases := []struct {
+		name string
+		add  func(m *mp4.MdatBox)
+		want []byte
+	}{
+		{"dataOnly", func(m *mp4.MdatBox) {
+			m.AddSampleData(a)
+			m.AddSampleData(b)
+		}, []byte{0, 1, 2, 3, 4}},
+		{"partsOnly", func(m *mp4.MdatBox) {
+			m.AddSampleDataPart(a)
+			m.AddSampleDataPart(b)
+		}, []byte{0, 1, 2, 3, 4}},
+		{"dataThenPart", func(m *mp4.MdatBox) {
+			m.AddSampleData(a)
+			m.AddSampleDataPart(b)
+		}, []byte{0, 1, 2, 3, 4}},
+		{"partThenData", func(m *mp4.MdatBox) {
+			m.AddSampleDataPart(a)
+			m.AddSampleData(b)
+		}, []byte{0, 1, 2, 3, 4}},
+		{"interleaved", func(m *mp4.MdatBox) {
+			m.AddSampleData(a)
+			m.AddSampleDataPart(b)
+			m.AddSampleData(c)
+			m.AddSampleDataPart(a)
+		}, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mdat := &mp4.MdatBox{}
+			c.add(mdat)
+
+			if got := mdat.DataLength(); got != uint64(len(c.want)) {
+				t.Errorf("DataLength() is %d, expected %d", got, len(c.want))
+			}
+			if got, exp := mdat.Size(), mdat.HeaderSize()+uint64(len(c.want)); got != exp {
+				t.Errorf("Size() is %d, expected %d", got, exp)
+			}
+
+			var buf bytes.Buffer
+			if err := mdat.Encode(&buf); err != nil {
+				t.Fatal(err)
+			}
+			if got := uint64(buf.Len()); got != mdat.Size() {
+				t.Errorf("encoded %d bytes, but Size() is %d", got, mdat.Size())
+			}
+			payload := buf.Bytes()[mdat.HeaderSize():]
+			if !bytes.Equal(payload, c.want) {
+				t.Errorf("Encode payload is %v, expected %v", payload, c.want)
+			}
+
+			// The SliceWriter path must write the same bytes.
+			sw := bits.NewFixedSliceWriter(int(mdat.Size()))
+			if err := mdat.EncodeSW(sw); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(sw.Bytes(), buf.Bytes()) {
+				t.Error("EncodeSW and Encode wrote different bytes")
+			}
+		})
+	}
+}
+
+// TestMdatSetDataDropsParts - SetData replaces the whole payload, so earlier
+// parts are dropped. Before, the parts won and the new data was ignored.
+func TestMdatSetDataDropsParts(t *testing.T) {
+	mdat := &mp4.MdatBox{}
+	mdat.AddSampleDataPart([]byte{0, 1, 2})
+	mdat.AddSampleData([]byte{3, 4})
+
+	replacement := []byte{7, 7, 7, 7}
+	mdat.SetData(replacement)
+
+	if got := mdat.DataLength(); got != uint64(len(replacement)) {
+		t.Errorf("DataLength() is %d after SetData, expected %d", got, len(replacement))
+	}
+	if len(mdat.DataParts) != 0 {
+		t.Errorf("SetData left %d data parts", len(mdat.DataParts))
+	}
+	var buf bytes.Buffer
+	if err := mdat.Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+	if payload := buf.Bytes()[mdat.HeaderSize():]; !bytes.Equal(payload, replacement) {
+		t.Errorf("payload after SetData is %v, expected %v", payload, replacement)
 	}
 }


### PR DESCRIPTION
Fixes #572.

## Approach

The issue listed three options. This is option 3 (make the modes compose), with
one refinement: rather than having `AddSampleData` append its bytes *as a part*
— which would make it alias the caller's slice where it currently copies — the
payload becomes

```
concat(DataParts...) + Data
```

with `Data` as an open tail. That leaves `AddSampleData` untouched and keeps
both aliasing contracts intact: data parts reference the caller's buffers,
while `AddSampleData` still copies, so callers may reuse their scratch buffer
as before.

Changes to `MdatBox`:

- `AddSampleDataPart` closes any existing tail into a part before appending,
  instead of panicking. Order added is order written.
- `SetData` drops any data parts, since it sets the whole payload.
- `DataLength` sums parts and tail rather than preferring parts.
- `Encode`/`EncodeSW` write all parts and then the tail, rather than either/or.
- `AddSampleData` is unchanged.

`dataRange` still refuses a range extraction while parts are present, as
before, so `ReadData`/`CopyData` keep returning an error rather than wrong
bytes.

`Fragment.AddFullSamples` keeps copying into monolithic data when the mdat
already holds some, so that data does not retroactively start aliasing the
caller's buffers; only its doc comment changed, since the restriction it warned
about is gone.

## What this fixes

Both reproductions from the issue. Verified by restoring the old `mdat.go` and
`fragment.go` under the new tests:

- `TestAddFullSamplesThenAddFullSample` fails as
  `mdat holds 828 payload bytes but trun declares 1131` — the silent loss.
- `TestMdatMixedDataAndParts/dataThenPart` panics with
  `cannot mix sample parts with monolithic sample data`.

## Tests

- `TestMdatMixedDataAndParts` covers five add-orders (data only, parts only,
  data→part, part→data, and interleaved), asserting the payload bytes,
  `DataLength()`, `Size()` against the encoded length, and that `EncodeSW`
  writes the same bytes as `Encode`.
- `TestMdatSetDataDropsParts` covers the second reproduction.
- `TestAddFullSamplesThenAddFullSample` covers it at fragment level: the mdat
  payload length matches the trun-declared sample sizes, the output is
  byte-identical to adding every sample with `AddFullSample`, and a decode
  round trip returns all samples with correct data.

Full suite, `go vet` and `golangci-lint` clean.

## Follow-up not included

With parts and monolithic data now composable, `AddFullSamples` could always
take the zero-copy parts path instead of copying when monolithic data is
present. That is a performance change with an aliasing consequence for data
already in the mdat, so it belongs in its own PR.
