### PR TITLE
perf(mp4): buffer output writes in commands and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The commands and examples that create their own output file now buffer their
+  writes, like `WriteToFile` already does. `Encode` makes about one write call
+  per box, so writing straight to a file cost a syscall per box: affects
+  `mp4ff-encrypt`, `mp4ff-decrypt`, `mp4ff-crop`, `mp4ff-mvhevc` and the
+  `add-sidx`, `combine-segs`, `initcreator`, `ivf-to-mp4`, `resegmenter` and
+  `segmenter` examples. Output bytes are unchanged
+- New package documentation section "Writing files and segments efficiently"
+  covering when to use a buffered `Encode` and when a reused
+  `bits.FixedSliceWriter` with `EncodeSW` is better
 - `WriteToFile` buffers its output instead of writing straight to the file.
   The many small boxes of a moof cost one write syscall each without it, while
   a large mdat payload is unaffected, since a write larger than the buffer goes

--- a/cmd/mp4ff-crop/main.go
+++ b/cmd/mp4ff-crop/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"fmt"
@@ -96,11 +97,12 @@ func run(args []string, stdout io.Writer) error {
 	}
 	defer ofh.Close()
 
-	err = cropMP4(parsedMp4, int(o.durationMS), ofh, ifh)
+	ow := bufio.NewWriter(ofh)
+	err = cropMP4(parsedMp4, int(o.durationMS), ow, ifh)
 	if err != nil {
 		return fmt.Errorf("error cropping mp4 file: %w", err)
 	}
-	return nil
+	return ow.Flush()
 }
 
 func cropMP4(inMP4 *mp4.File, durationMS int, w io.Writer, ifh io.ReadSeeker) error {

--- a/cmd/mp4ff-decrypt/main.go
+++ b/cmd/mp4ff-decrypt/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -165,11 +166,12 @@ func run(args []string) error {
 		defer inith.Close()
 	}
 
-	err = decryptFileWithKeyMap(ifh, inith, ofh, key, keysByKID, strictKIDMode)
+	ow := bufio.NewWriter(ofh)
+	err = decryptFileWithKeyMap(ifh, inith, ow, key, keysByKID, strictKIDMode)
 	if err != nil {
 		return fmt.Errorf("decryptFile: %w", err)
 	}
-	return nil
+	return ow.Flush()
 }
 
 func decryptFileWithKeyMap(r, initR io.Reader, w io.Writer, key []byte, keysByKID map[string][]byte, strictKIDMode bool) error {

--- a/cmd/mp4ff-encrypt/main.go
+++ b/cmd/mp4ff-encrypt/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -129,11 +130,12 @@ func run(args []string) error {
 		}
 	}
 
-	err = encryptFile(ifh, ofh, initSeg, opts.scheme, opts.kidStr, opts.keyStr, opts.ivHex, psshData)
+	ow := bufio.NewWriter(ofh)
+	err = encryptFile(ifh, ow, initSeg, opts.scheme, opts.kidStr, opts.keyStr, opts.ivHex, psshData)
 	if err != nil {
 		return fmt.Errorf("encryptFile: %w", err)
 	}
-	return nil
+	return ow.Flush()
 }
 
 func encryptFile(ifh io.Reader, ofh io.Writer, initSeg *mp4.InitSegment,

--- a/cmd/mp4ff-encrypt/main_test.go
+++ b/cmd/mp4ff-encrypt/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/Eyevinn/mp4ff/mp4"
 )
 
 func TestOptionCases(t *testing.T) {
@@ -125,4 +128,57 @@ func concatenateFiles(outFile string, inFiles ...string) error {
 	}
 
 	return nil
+}
+
+// TestEncryptedOutputMatchesDirectEncode checks that the file run writes is
+// exactly the bytes encryptFile produces, so any truncation of the output --
+// an unflushed write buffer, a short write -- fails here. The successful case
+// in TestOptionCases only checks that run returns no error, which a truncated
+// file would also do.
+//
+// Note that with this input the last thing written is a large mdat, which
+// bypasses the write buffer, so this input alone would not reveal a missing
+// Flush; it takes an output ending in a small box to lose bytes that way.
+func TestEncryptedOutputMatchesDirectEncode(t *testing.T) {
+	init := "../../mp4/testdata/init.mp4"
+	inSeg := "../../mp4/testdata/1.m4s"
+	psshPath := "../../mp4/testdata/pssh.bin"
+	key := "00112233445566778899aabbccddeeff"
+	tmpDir := t.TempDir()
+	combFile := path.Join(tmpDir, "combined.mp4")
+	outFile := path.Join(tmpDir, "encrypted.mp4")
+	if err := concatenateFiles(combFile, init, inSeg); err != nil {
+		t.Fatal(err)
+	}
+
+	args := []string{appName, "-key", key, "-iv", key, "-kid", key, "-pssh", psshPath, combFile, outFile}
+	if err := run(args); err != nil {
+		t.Fatal(err)
+	}
+	written, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The same encryption, straight into memory.
+	ifh, err := os.Open(combFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ifh.Close()
+	psshData, err := os.ReadFile(psshPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var want bytes.Buffer
+	if err := encryptFile(ifh, &want, nil, "cenc", key, key, key, psshData); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(written, want.Bytes()) {
+		t.Errorf("file written by run is %d bytes, direct encode gives %d",
+			len(written), want.Len())
+	}
+	if _, err := mp4.DecodeFile(bytes.NewReader(written)); err != nil {
+		t.Errorf("encrypted output does not decode: %v", err)
+	}
 }

--- a/cmd/mp4ff-mvhevc/main.go
+++ b/cmd/mp4ff-mvhevc/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -910,8 +911,12 @@ func buildAndWriteMp4(inp *mvhevcInput, outPath string, w io.Writer) error {
 		return fmt.Errorf("could not create output file: %w", err)
 	}
 	defer ofd.Close()
-	if err := outFile.Encode(ofd); err != nil {
+	ow := bufio.NewWriter(ofd)
+	if err := outFile.Encode(ow); err != nil {
 		return fmt.Errorf("encode error: %w", err)
+	}
+	if err := ow.Flush(); err != nil {
+		return fmt.Errorf("write error: %w", err)
 	}
 
 	fmt.Fprintf(w, "Wrote %s (%dx%d, %d samples, %d layers)\n",

--- a/examples/add-sidx/main.go
+++ b/examples/add-sidx/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"fmt"
@@ -111,7 +112,11 @@ func run(args []string, stdout io.Writer) error {
 		return fmt.Errorf("addSidx failed: %w", err)
 	}
 
-	return mp4Root.Encode(ofd)
+	ow := bufio.NewWriter(ofd)
+	if err := mp4Root.Encode(ow); err != nil {
+		return err
+	}
+	return ow.Flush()
 }
 
 func removeEncryptionBoxes(inFile *mp4.File) {

--- a/examples/combine-segs/main.go
+++ b/examples/combine-segs/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -132,8 +133,12 @@ func writeSeg(seg encoder, filename string) error {
 		return err
 	}
 	defer ofh.Close()
-	err = seg.Encode(ofh)
+	ow := bufio.NewWriter(ofh)
+	err = seg.Encode(ow)
 	if err != nil {
+		return err
+	}
+	if err = ow.Flush(); err != nil {
 		return err
 	}
 	fmt.Printf("wrote %s\n", filename)

--- a/examples/initcreator/main.go
+++ b/examples/initcreator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -178,6 +179,9 @@ func writeToFile(init *mp4.InitSegment, filePath string) error {
 		return err
 	}
 	defer ofd.Close()
-	err = init.Encode(ofd)
-	return err
+	ow := bufio.NewWriter(ofd)
+	if err := init.Encode(ow); err != nil {
+		return err
+	}
+	return ow.Flush()
 }

--- a/examples/ivf-to-mp4/main.go
+++ b/examples/ivf-to-mp4/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -92,7 +93,11 @@ func run(inPath, outPath string) error {
 		return err
 	}
 	defer out.Close()
-	return writeFragmentedMP4(out, init, frames, scale, isKey)
+	ow := bufio.NewWriter(out)
+	if err := writeFragmentedMP4(ow, init, frames, scale, isKey); err != nil {
+		return err
+	}
+	return ow.Flush()
 }
 
 // setupAV1 builds the init segment for an AV1 track from the sequence header in the first frame.

--- a/examples/resegmenter/main.go
+++ b/examples/resegmenter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"fmt"
@@ -93,5 +94,9 @@ func run(args []string, w io.Writer) error {
 		return fmt.Errorf("error creating file: %w", err)
 	}
 	defer ofd.Close()
-	return newMp4.Encode(ofd)
+	ow := bufio.NewWriter(ofd)
+	if err := newMp4.Encode(ow); err != nil {
+		return err
+	}
+	return ow.Flush()
 }

--- a/examples/segmenter/segment.go
+++ b/examples/segmenter/segment.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -118,13 +119,17 @@ func makeSingleTrackSegmentsLazyWrite(segmenter *Segmenter, parsedMp4 *mp4.File,
 				return err
 			}
 			defer ofh.Close()
-			err = seg.Encode(ofh)
+			ow := bufio.NewWriter(ofh)
+			err = seg.Encode(ow)
 			if err != nil {
 				return err
 			}
 			// Also write media data
-			err = copyMediaData(tr.inTrak, startSampleNr, endSampleNr, rs, ofh)
+			err = copyMediaData(tr.inTrak, startSampleNr, endSampleNr, rs, ow)
 			if err != nil {
+				return err
+			}
+			if err = ow.Flush(); err != nil {
 				return err
 			}
 			fmt.Printf("Generated %s\n", outPath)

--- a/mp4/doc.go
+++ b/mp4/doc.go
@@ -135,6 +135,27 @@ either of the interfaces. For benchmarks, see the [README.md of the mp4ff module
 Fur further reduction of memory allocation, use a buffered top-level reader, especially when
 when reading the [mp4.MdatBox] box of a progressive file.
 
+# Writing files and segments efficiently
+
+The Encode(w [io.Writer]) methods write roughly one Write call per box, since most boxes
+encode themselves into a small slice and write it in one go. Handed a bare [os.File],
+that is one write syscall per box, and a moof consists of a dozen or so small boxes.
+Wrapping the file in a [bufio.Writer] and flushing it is therefore several times faster
+for segment-shaped output, where box headers make up a larger share of the bytes than
+the media payload does. A large [mp4.MdatBox] payload is not slowed down by the buffer,
+since [bufio.Writer] passes a write larger than its buffer directly to the file once the
+buffer is empty. [mp4.WriteToFile] does this internally; code that opens its own file
+should do the same, and must not forget to Flush before closing.
+
+The EncodeSW(sw [bits.SliceWriter]) methods are an alternative: encode into a
+[bits.FixedSliceWriter] of Size() bytes and write it out with a single call. Note that
+the cost of this route is dominated by the per-call allocation and the zeroing of memory
+that is then overwritten in full, not by the encoding, so allocating a new slice writer
+for a single structure is not faster than a buffered Encode. It pays off when the same
+buffer is reused across many structures, for example when writing a sequence of segments,
+using [bits.NewFixedSliceWriterFromSlice] to wrap it. That call takes the size from the
+length of the slice, not its capacity, so it must be sliced to at least Size() bytes.
+
 # More about mp4 boxes
 
 The mp4 package contains a lot of box implementations.

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -460,6 +460,8 @@ func (f *File) AddSidx(sidx *SidxBox) {
 
 // Encode - encode a file to a Writer
 // Fragmented files are encoded based on InitSegment and MediaSegments, unless EncModeBoxTree is set.
+// One Write call is made per box, so a buffered writer should be used when w is a file.
+// See the package documentation section "Writing files and segments efficiently".
 func (f *File) Encode(w io.Writer) error {
 	if f.isFragmented {
 		switch f.FragEncMode {
@@ -517,6 +519,8 @@ func (f *File) Encode(w io.Writer) error {
 
 // EncodeSW - encode a file to a SliceWriter
 // Fragmented files are encoded based on InitSegment and MediaSegments, unless EncModeBoxTree is set.
+// See the package documentation section "Writing files and segments efficiently" for when this
+// is faster than Encode to a buffered writer.
 func (f *File) EncodeSW(sw bits.SliceWriter) error {
 	if f.isFragmented {
 		switch f.FragEncMode {

--- a/mp4/mediasegment.go
+++ b/mp4/mediasegment.go
@@ -92,7 +92,9 @@ func (s *MediaSegment) Size() uint64 {
 	return size
 }
 
-// Encode - Write MediaSegment via writer
+// Encode - Write MediaSegment via writer.
+// One Write call is made per box, so a buffered writer should be used when w is a file.
+// See the package documentation section "Writing files and segments efficiently".
 func (s *MediaSegment) Encode(w io.Writer) error {
 	if s.Styp != nil {
 		err := s.Styp.Encode(w)


### PR DESCRIPTION
Follow-up to #571, which buffered `WriteToFile`. This does the same for the ten
places that create their own output file, and documents the two write paths,
since neither was written down anywhere.

## Buffered call sites

`Encode` makes about one write call per box — most boxes encode into a small
slice and write it in one go — so writing straight to an `*os.File` costs a
syscall per box, and a moof is a dozen or so small boxes. Each site now wraps
the file in a `bufio.Writer` and flushes it:

`mp4ff-encrypt`, `mp4ff-decrypt`, `mp4ff-crop`, `mp4ff-mvhevc`, and the
`add-sidx`, `combine-segs`, `initcreator`, `ivf-to-mp4`, `resegmenter` and
`segmenter` examples.

Output bytes are unchanged. Every worker these hand the writer to already takes
`io.Writer` and none of them seek, so buffering is safe throughout. The
`segmenter` site is the one that needed care: it writes twice to the same
handle (`seg.Encode` then `copyMediaData`) inside a loop, so the flush goes at
the end of each iteration — the writer goes out of scope there, and a deferred
`Close` on the file does not flush it.

On #571's measurements this is worth 2.5x on a 416 KB progressive file and 3.7x
on a 25 KB segment, on the encode path with the file already open. These
commands run on real files rather than small fixtures.

## Documentation

New package doc section, "Writing files and segments efficiently":

- `Encode` writes about one call per box, so a buffered writer belongs between
  it and a file. `WriteToFile` does this for you. A large mdat payload is not
  slowed by the buffer, since `bufio.Writer` passes a write larger than its
  buffer straight through once the buffer is empty.
- `EncodeSW` into a `FixedSliceWriter` is the alternative, but its cost is
  dominated by the per-call allocation and the zeroing of memory that is then
  overwritten in full, not by the encoding — so a fresh slice writer for a
  single structure is not faster than a buffered `Encode`. It wins when one
  buffer is reused across many structures via `NewFixedSliceWriterFromSlice`,
  which takes its size from the slice's length, not its capacity.

Short pointers to that section were added to `File.Encode`, `File.EncodeSW`
and `MediaSegment.Encode`. I verified every doc link in the new section
resolves, by checking that `go doc` strips its brackets, with a deliberately
bogus link as a control.

## On test coverage

I checked which existing tests would catch a missing `Flush` by neutralising
all ten of them and running the suite. Three packages fail: `mp4ff-mvhevc`,
`add-sidx` and `ivf-to-mp4`. The other seven have no test that would notice a
truncated output file.

`TestEncryptedOutputMatchesDirectEncode` closes part of that for
`mp4ff-encrypt`: it asserts the file `run` writes is byte-for-byte what
`encryptFile` produces in memory, so any truncation or short write fails,
where the existing successful case only checks that `run` returns no error.

Worth being precise about what that test does not prove. With its input the
last thing written is a large mdat, which bypasses the buffer, so no bytes are
actually lost if the `Flush` is removed — I confirmed the output is
byte-identical either way. The flush is still required in general, since any
output ending in a small box would lose it; this input simply does not exercise
that. Covering the remaining sites properly wants outputs that end in a small
box, which is a bigger job than this PR.
