### PR TITLE
perf(mp4): AddFullSamples never copies sample data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entry in place) an init segment built from a cached, shared trak
 - `Fragment.AddFullSamples` adds many samples to a fragment at once. Adjacent
   sample slices (such as the output of `GetFullSamples`) are coalesced into
-  runs that are added as mdat data parts, so the payload is not copied at all
-  and contiguous input becomes a single part; the samples are copied only
-  when the mdat already holds monolithic data. The output is byte-identical
-  to adding the samples one by one with `AddFullSample`
+  runs that are added as mdat data parts, so the payload is never copied and
+  contiguous input becomes a single part. Any data already in the mdat is
+  closed into a part first, so samples can be added before or after with
+  `AddFullSample`. Since the samples are referenced rather than copied, their
+  buffers must be kept alive and unmodified until the fragment is encoded. The
+  output is byte-identical to adding the samples one by one with
+  `AddFullSample`
 
 ### Changed
 

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -218,11 +218,11 @@ func (f *Fragment) AddFullSample(s FullSample) {
 // time. The caller must therefore keep those buffers alive and unmodified
 // until the fragment has been encoded.
 //
-// If the mdat already holds monolithic data (from AddFullSample or SetData),
-// the samples are copied into it instead, growing it once up front, so that
-// the data already there is not made to alias the caller's buffers. Samples
-// may be added before or after with AddFullSample either way; the mdat keeps
-// the order in which data was added.
+// This holds however the fragment was built: any data already in the mdat is
+// closed into a data part first, so samples may be added before or after with
+// AddFullSample and the mdat keeps the order in which data was added. Since
+// the samples are never copied, a caller that needs to reuse its buffers must
+// add those samples with AddFullSample instead.
 func (f *Fragment) AddFullSamples(ss []FullSample) {
 	if len(ss) == 0 {
 		return
@@ -233,26 +233,10 @@ func (f *Fragment) AddFullSamples(ss []FullSample) {
 		copy(newSamples, trun.Samples)
 		trun.Samples = newSamples
 	}
-	mdat := f.Mdat
-	if len(mdat.Data) != 0 {
-		// Monolithic mdat: grow it once, then take the ordinary path.
-		totalSize := 0
-		for i := range ss {
-			totalSize += len(ss[i].Data)
-		}
-		if cap(mdat.Data)-len(mdat.Data) < totalSize {
-			newData := make([]byte, len(mdat.Data), len(mdat.Data)+totalSize)
-			copy(newData, mdat.Data)
-			mdat.Data = newData
-		}
-		for i := range ss {
-			f.AddFullSample(ss[i])
-		}
-		return
-	}
 	if trun.SampleCount() == 0 {
 		f.Moof.Traf.Tfdt.SetBaseMediaDecodeTime(ss[0].DecodeTime)
 	}
+	mdat := f.Mdat
 	var run []byte
 	for i := range ss {
 		trun.AddSample(ss[i].Sample)

--- a/mp4/fragment_test.go
+++ b/mp4/fragment_test.go
@@ -229,8 +229,9 @@ func TestAddFullSamplesMixing(t *testing.T) {
 	all := append(append([]mp4.FullSample{}, first...), second...)
 	want := encodeFragment(t, fragmentFromLoop(t, all))
 
-	// Monolithic data already present: the samples are copied in and the
-	// mdat stays monolithic, with the existing baseMediaDecodeTime kept.
+	// Monolithic data already present: it is closed into a data part and the
+	// bulk samples are added as parts after it, without being copied. The
+	// existing baseMediaDecodeTime is kept.
 	frag, err := mp4.CreateFragment(1, 1)
 	if err != nil {
 		t.Fatal(err)
@@ -242,8 +243,18 @@ func TestAddFullSamplesMixing(t *testing.T) {
 	if got := encodeFragment(t, frag); !bytes.Equal(got, want) {
 		t.Error("AddFullSamples after AddFullSample does not encode identically to the loop")
 	}
-	if len(frag.Mdat.DataParts) != 0 {
-		t.Error("expected monolithic mdat after AddFullSamples onto existing data")
+	if nr := len(frag.Mdat.DataParts); nr != 2 {
+		t.Errorf("got %d mdat data parts, expected 2 (closed monolithic data, then the bulk run)", nr)
+	}
+	if len(frag.Mdat.Data) != 0 {
+		t.Error("monolithic data should have been closed into a part")
+	}
+	// The bulk samples are referenced, not copied.
+	if &frag.Mdat.DataParts[1][0] != &second[0].Data[0] {
+		t.Error("second data part does not alias the first bulk sample's data")
+	}
+	if got := frag.Moof.Traf.Tfdt.BaseMediaDecodeTime(); got != 10000 {
+		t.Errorf("got baseMediaDecodeTime %d instead of 10000", got)
 	}
 
 	// Two bulk calls: both become parts, and the second keeps the first's


### PR DESCRIPTION
The follow-up noted in #573. Now that mdat data parts and monolithic data
compose, `AddFullSamples` no longer needs a separate copying path when the mdat
already holds monolithic data: `AddSampleDataPart` closes that data into a part
first, so the coalescing path works from any starting state. This deletes the
branch, 16 lines.

## Why, mainly

Not the speed. `AddFullSamples` had two behaviours a caller could not
distinguish without inspecting the mdat: usually it referenced their buffers,
sometimes it copied them. Since the documented contract already requires
callers to keep buffers alive and unmodified, the copying branch gave no
safety anyone could rely on — it was an invisible conditional optimisation.
Now the method is one predictable thing, and the doc comment states one
contract.

## Numbers anyway

The path this affects is a monolithic start followed by a bulk call: 8 samples
added one by one, then a bulk call of 88, ~676 KB total, darwin/arm64:

| mixed path | build | build + encode | bytes/op |
|---|---|---|---|
| before (copies into monolithic) | 64.9 µs | 66.2 µs | 887 KB |
| after (always parts) | **16.5 µs** | **19.0 µs** | **210 KB** |

The remaining 210 KB is the monolithic head from the `AddFullSample` calls,
which is unaffected.

Worth being clear that this path is uncommon: repeated bulk calls already took
the parts path, since after one the mdat holds no monolithic data. It needs a
caller that starts with `AddFullSample` (or `SetData`) and then switches to
`AddFullSamples` on the same fragment.

## Behaviour change

Bulk samples added onto an mdat that already holds monolithic data are now
referenced rather than copied. A caller doing that and then reusing its buffers
would previously have got away with it and now would not. Such a caller was
already violating the method's documented contract, but the removed paragraph
did explicitly promise a copy, so it is called out in the CHANGELOG. Callers
that need to reuse buffers should add those samples with `AddFullSample`, which
still copies.

Since `AddFullSamples` was added in the current unreleased cycle (#570), I
amended its existing "Added" entry rather than logging a change to behaviour
that was never released.

The other trade-off is that a pathological interleaving of single and bulk adds
now produces a data part per switch instead of one growing buffer, so more
write calls at encode time and no payload copying. After #571 and #574 every
write path in the library is buffered, which makes the extra calls cheap.

## Also considered and rejected

`ReadData`/`CopyData` refuse to extract a range while data parts are present,
so this makes those fail for more fragments in principle. In practice every
caller in the tree operates on decoded mdats — `stream.go`, `file.go`,
`mp4ff-pslister`, `-nallister`, `-subslister`, `-crop` and
`examples/segmenter` — and nothing reads back from an mdat it just built.

## Tests

`TestAddFullSamplesMixing` covered this case already and asserted the mdat
stayed monolithic; that assertion inverts to expecting two parts (the closed
monolithic data, then the bulk run), plus that the mdat holds no monolithic
data and that the second part aliases the caller's first bulk sample. Its
byte-identity assertion against the `AddFullSample` loop was untouched and
still passes, which is what shows the output has not changed.
