### PR TITLE
fix(mp4): IsSyncSampleFlags ignored the non-sync flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `IsSyncSampleFlags` only inspected `sample_depends_on` and ignored
+  `sample_is_non_sync_sample`, so flags that mark a sample non-sync while also
+  saying `sample_depends_on = 2` were reported as a sync sample. It now
+  requires both indications to agree, like `Sample.IsSync` always has, and no
+  longer accepts the reserved `sample_depends_on = 3`. `Sample.IsSync` is
+  unchanged in behaviour and now delegates to it, so the two cannot drift
+  apart again
 - The mdat payload is now the concatenation of its data parts and its
   monolithic data, so the two can be combined in any order and are written in
   the order they were added. Adding a part on top of monolithic data no longer

--- a/mp4/sample.go
+++ b/mp4/sample.go
@@ -20,8 +20,7 @@ func NewSample(flags uint32, dur uint32, size uint32, compositionTimeOffset int3
 
 // IsSync - check sync by masking flags including dependsOn
 func (s *Sample) IsSync() bool {
-	decFlags := DecodeSampleFlags(s.Flags)
-	return !decFlags.SampleIsNonSync && (decFlags.SampleDependsOn == 2)
+	return IsSyncSampleFlags(s.Flags)
 }
 
 // FullSample - include accumulated time and data. Times in mdhd timescale

--- a/mp4/sampleflags.go
+++ b/mp4/sampleflags.go
@@ -39,9 +39,15 @@ const NonSyncSampleFlags uint32 = 0x00010000
 // SampleDependsOn1 - this sample depends on others (not an I picture)
 const SampleDependsOn1 uint32 = 0x01000000
 
-// IsSyncSampleFlags - flags is set correctly for sync sample
+// sampleDependsOnMask - the two-bit sample_depends_on field
+const sampleDependsOnMask uint32 = 0x03000000
+
+// IsSyncSampleFlags - flags is set correctly for sync sample.
+// Both indications must agree: sample_depends_on must be 2 (an I picture)
+// and sample_is_non_sync_sample must be 0. A sample explicitly marked
+// non-sync is not a sync sample whatever sample_depends_on says.
 func IsSyncSampleFlags(flags uint32) bool {
-	return flags&SyncSampleFlags == SyncSampleFlags
+	return flags&sampleDependsOnMask == SyncSampleFlags && flags&NonSyncSampleFlags == 0
 }
 
 // SetSyncSampleFlags - return flags with syncsample pattern

--- a/mp4/sampleflags_test.go
+++ b/mp4/sampleflags_test.go
@@ -61,3 +61,37 @@ func TestSetSyncAndNonSyncFlags(t *testing.T) {
 			redundancyFlags, nonSyncWithRedundancy, expectedNonSyncWithRedundancy)
 	}
 }
+
+// TestIsSyncSampleFlags checks that the sync predicate requires both
+// indications to agree: sample_depends_on == 2 and sample_is_non_sync_sample
+// == 0. Every other bit of sample_flags must be ignored, which is asserted by
+// repeating each case with all of them set.
+func TestIsSyncSampleFlags(t *testing.T) {
+	// Every bit outside the sample_depends_on field and the non-sync bit.
+	const otherBits = ^uint32(0x03010000)
+
+	for dependsOn := uint32(0); dependsOn < 4; dependsOn++ {
+		for nonSync := uint32(0); nonSync < 2; nonSync++ {
+			flags := dependsOn<<24 | nonSync<<16
+			want := dependsOn == 2 && nonSync == 0
+			for _, f := range []uint32{flags, flags | otherBits} {
+				if got := mp4.IsSyncSampleFlags(f); got != want {
+					t.Errorf("IsSyncSampleFlags(0x%08x) = %v, want %v (dependsOn=%d nonSync=%d)",
+						f, got, want, dependsOn, nonSync)
+				}
+				s := mp4.Sample{Flags: f}
+				if got := s.IsSync(); got != want {
+					t.Errorf("Sample{0x%08x}.IsSync() = %v, want %v", f, got, want)
+				}
+			}
+		}
+	}
+
+	// The exported patterns must agree with the predicate.
+	if !mp4.IsSyncSampleFlags(mp4.SyncSampleFlags) {
+		t.Error("SyncSampleFlags is not recognized as a sync sample")
+	}
+	if mp4.IsSyncSampleFlags(mp4.SetNonSyncSampleFlags(0)) {
+		t.Error("SetNonSyncSampleFlags(0) is recognized as a sync sample")
+	}
+}


### PR DESCRIPTION
## What

`IsSyncSampleFlags` inspected only `sample_depends_on` and ignored
`sample_is_non_sync_sample`:

```go
return flags&SyncSampleFlags == SyncSampleFlags
```

So flags that explicitly mark a sample non-sync while also carrying
`sample_depends_on = 2` were reported as a sync sample. Measured before the
fix, on `0x02010000`:

| predicate | result |
|---|---|
| `Sample.IsSync()` | false |
| `IsSyncSampleFlags()` | **true** |

The library had two disagreeing notions of the same thing, and the one that
could return the dangerous answer was the exported bit-level helper. Its only
in-tree caller, `cmd/mp4ff-mvhevc/main.go:326`, builds the sync-frame list from
it, so such a file got a wrong set of sync frames.

This is the same bug class as two earlier fixes in this area — one indication
consulted or written, the other dropped:

- `d66186c` "non-sync sample" fixed `SetNonSyncSampleFlags`, which used `&`
  where it needed `|` (so it never actually set the non-sync bit) and did not
  set `sample_depends_on` at all; that commit added `SampleDependsOn1`.
- `039fb00` fixed `NewSdtpEntry`, which packed `sampleDependedOn` into both
  two-bit fields and dropped `sampleDependsOn`.

## Change

One definition instead of two. `IsSyncSampleFlags` now requires both
indications to agree, and `Sample.IsSync` delegates to it, so they cannot
drift apart again:

```go
func IsSyncSampleFlags(flags uint32) bool {
	return flags&sampleDependsOnMask == SyncSampleFlags && flags&NonSyncSampleFlags == 0
}

func (s *Sample) IsSync() bool {
	return IsSyncSampleFlags(s.Flags)
}
```

Masking the full two-bit field also stops the reserved `sample_depends_on = 3`
from passing, which the old bit test accepted and `Sample.IsSync` never did.

`Sample.IsSync` is unchanged in behaviour.

## Tests

`TestIsSyncSampleFlags` walks the only input space that matters — the four
values of `sample_depends_on` crossed with the two values of
`sample_is_non_sync_sample` — and repeats each case with every other bit of
`sample_flags` set, which pins the mask constants against overlapping a
neighbouring field. It then checks the exported `SyncSampleFlags` and
`SetNonSyncSampleFlags` patterns against the predicate.

I confirmed it catches both ways this can break, by mutating the source:
widening `sampleDependsOnMask` to overlap `is_leading` fails 2 assertions, and
dropping the `NonSyncSampleFlags` condition fails 4.

Full suite, `go vet` and `golangci-lint` clean.

## Note for reviewers of #557

The defragmenter in #557 has a third variant of this predicate, using
`sample_is_non_sync_sample` alone. That one is deliberate and should stay:
CMAF 9.2.6 makes `sample_is_non_sync_sample` normative ("shall be 0 for SAP
type 1 or 2, and 1 otherwise") while `sample_depends_on` is only a "should", so
requiring `sample_depends_on = 2` there would misclassify every sample in a
conformant file that omits it, emit an `stss` listing nothing, and make the
output unseekable. Worth a comment there rather than a change.
