### PR TITLE
fix(hevc): reject num_ref_idx values outside the spec range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HEVC slice header and PPS parsing accepted `num_ref_idx_l0_active_minus1`,
+  `num_ref_idx_l1_active_minus1` and their PPS defaults outside the range 0 to
+  14 that the spec allows. The values were stored in a `uint8` without a check,
+  so a stream declaring 255 made `parsePredWeightTable` allocate a
+  zero-length slice while its loop guard still ran, and parsing panicked with
+  an index out of range. All four read sites now check the bound and return an
+  error naming the syntax element, its value and the legal range
 - `IsSyncSampleFlags` only inspected `sample_depends_on` and ignored
   `sample_is_non_sync_sample`, so flags that mark a sample non-sync while also
   saying `sample_depends_on = 2` were reported as a sync sample. It now

--- a/hevc/pps.go
+++ b/hevc/pps.go
@@ -202,9 +202,14 @@ func ParsePPSNALUnit(data []byte, spsMap map[uint32]*SPS) (*PPS, error) {
 	pps.NumExtraSliceHeaderBits = uint8(r.Read(3))
 	pps.SignDataHidingEnabledFlag = r.ReadFlag()
 	pps.CabacInitPresentFlag = r.ReadFlag()
-	// value shall be in the range of 0 to 14, inclusive
-	pps.NumRefIdxL0DefaultActiveMinus1 = uint8(r.ReadExpGolomb())
-	pps.NumRefIdxL1DefaultActiveMinus1 = uint8(r.ReadExpGolomb())
+	pps.NumRefIdxL0DefaultActiveMinus1, err = readNumRefIdxActiveMinus1(r, "num_ref_idx_l0_default_active_minus1")
+	if err != nil {
+		return pps, err
+	}
+	pps.NumRefIdxL1DefaultActiveMinus1, err = readNumRefIdxActiveMinus1(r, "num_ref_idx_l1_default_active_minus1")
+	if err != nil {
+		return pps, err
+	}
 	// value shall be in the range of −( 26 + QpBdOffsetY ) to +25, inclusive
 	pps.InitQpMinus26 = int8(r.ReadSignedGolomb())
 	pps.ConstrainedIntraPredFlag = r.ReadFlag()

--- a/hevc/pps_test.go
+++ b/hevc/pps_test.go
@@ -1,10 +1,12 @@
 package hevc
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"testing"
 
+	"github.com/Eyevinn/mp4ff/bits"
 	"github.com/go-test/deep"
 )
 
@@ -71,6 +73,66 @@ func TestPPSParser(t *testing.T) {
 			}
 			if diff := deep.Equal(&tc.wanted, got); diff != nil {
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestPPSNumRefIdxDefaultRange(t *testing.T) {
+	spsMap := map[uint32]*SPS{0: {SpsID: 0}}
+	cases := []struct {
+		nrRefIdxMinus1 uint
+		wantErr        string
+	}{
+		{0, ""},
+		{14, ""},
+		{15, "num_ref_idx_l0_default_active_minus1 = 15 is outside the range 0 to 14"},
+		{255, "num_ref_idx_l0_default_active_minus1 = 255 is outside the range 0 to 14"},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("num_ref_idx_l0_default_active_minus1=%d", c.nrRefIdxMinus1), func(t *testing.T) {
+			buf := bytes.Buffer{}
+			w := bits.NewEBSPWriter(&buf)
+			w.Write(uint(NALU_PPS)<<9|0x01, 16) // nal_unit_header
+			w.WriteExpGolomb(0)                 // pps_pic_parameter_set_id
+			w.WriteExpGolomb(0)                 // pps_seq_parameter_set_id
+			w.Write(0, 1)                       // dependent_slice_segments_enabled_flag
+			w.Write(0, 1)                       // output_flag_present_flag
+			w.Write(0, 3)                       // num_extra_slice_header_bits
+			w.Write(0, 1)                       // sign_data_hiding_enabled_flag
+			w.Write(0, 1)                       // cabac_init_present_flag
+			w.WriteExpGolomb(c.nrRefIdxMinus1)  // num_ref_idx_l0_default_active_minus1
+			w.WriteExpGolomb(0)                 // num_ref_idx_l1_default_active_minus1
+			w.WriteExpGolomb(0)                 // init_qp_minus26
+			w.Write(0, 3)                       // constrained_intra_pred, transform_skip, cu_qp_delta_enabled
+			w.WriteExpGolomb(0)                 // pps_cb_qp_offset
+			w.WriteExpGolomb(0)                 // pps_cr_qp_offset
+			w.Write(0, 6)                       // slice_chroma_qp_offsets_present .. entropy_coding_sync_enabled
+			w.Write(0, 1)                       // pps_loop_filter_across_slices_enabled_flag
+			w.Write(0, 1)                       // deblocking_filter_control_present_flag
+			w.Write(0, 1)                       // pps_scaling_list_data_present_flag
+			w.Write(0, 1)                       // lists_modification_present_flag
+			w.WriteExpGolomb(0)                 // log2_parallel_merge_level_minus2
+			w.Write(0, 1)                       // slice_segment_header_extension_present_flag
+			w.Write(0, 1)                       // pps_extension_present_flag
+			w.WriteRbspTrailingBits()
+			if w.AccError() != nil {
+				t.Fatal(w.AccError())
+			}
+
+			pps, err := ParsePPSNALUnit(buf.Bytes(), spsMap)
+			if c.wantErr != "" {
+				if err == nil || err.Error() != c.wantErr {
+					t.Errorf("got error %v, wanted %q", err, c.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if uint(pps.NumRefIdxL0DefaultActiveMinus1) != c.nrRefIdxMinus1 {
+				t.Errorf("NumRefIdxL0DefaultActiveMinus1 = %d, wanted %d",
+					pps.NumRefIdxL0DefaultActiveMinus1, c.nrRefIdxMinus1)
 			}
 		})
 	}

--- a/hevc/slice.go
+++ b/hevc/slice.go
@@ -258,10 +258,16 @@ func ParseSliceHeader(nalu []byte, spsMap map[uint32]*SPS, ppsMap map[uint32]*PP
 			sh.NumRefIdxL1ActiveMinus1 = pps.NumRefIdxL1DefaultActiveMinus1
 			// 0 specifies that the syntax elements num_ref_idx_l0_active_minus1 and num_ref_idx_l1_active_minus1 are not present.
 			if sh.NumRefIdxActiveOverrideFlag {
-				// value shall be in the range of 0 to 14, inclusive
-				sh.NumRefIdxL0ActiveMinus1 = uint8(r.ReadExpGolomb())
+				var err error
+				sh.NumRefIdxL0ActiveMinus1, err = readNumRefIdxActiveMinus1(r, "num_ref_idx_l0_active_minus1")
+				if err != nil {
+					return sh, err
+				}
 				if sh.SliceType == SLICE_B {
-					sh.NumRefIdxL1ActiveMinus1 = uint8(r.ReadExpGolomb())
+					sh.NumRefIdxL1ActiveMinus1, err = readNumRefIdxActiveMinus1(r, "num_ref_idx_l1_active_minus1")
+					if err != nil {
+						return sh, err
+					}
 				}
 			}
 
@@ -391,6 +397,19 @@ func ParseSliceHeader(nalu []byte, spsMap map[uint32]*SPS, ppsMap map[uint32]*PP
 	sh.Size = uint32(r.NrBytesRead())
 
 	return sh, nil
+}
+
+// maxNumRefIdxActiveMinus1 is the upper bound of num_ref_idx_lX_active_minus1 and
+// num_ref_idx_lX_default_active_minus1 according to Sections 7.4.7.1 and 7.4.3.3.
+const maxNumRefIdxActiveMinus1 = 14
+
+// readNumRefIdxActiveMinus1 reads a num_ref_idx value and checks it against the spec range.
+func readNumRefIdxActiveMinus1(r *bits.EBSPReader, name string) (uint8, error) {
+	value := r.ReadExpGolomb()
+	if value > maxNumRefIdxActiveMinus1 {
+		return 0, fmt.Errorf("%s = %d is outside the range 0 to %d", name, value, maxNumRefIdxActiveMinus1)
+	}
+	return uint8(value), nil
 }
 
 func parseRefPicListsModification(r *bits.EBSPReader, sliceType SliceType,

--- a/hevc/slice_test.go
+++ b/hevc/slice_test.go
@@ -1,10 +1,13 @@
 package hevc
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/bits"
 
 	"github.com/go-test/deep"
 )
@@ -241,5 +244,67 @@ func TestParseSliceHeaderDeblockingOffsetsInheritedFromPPS(t *testing.T) {
 	}
 	if nrSliceHeaders != 1 {
 		t.Errorf("got %d slice headers, wanted 1", nrSliceHeaders)
+	}
+}
+
+// makePSliceNalu builds a complete P-slice header NAL unit that carries
+// num_ref_idx_l0_active_minus1 = nrRefIdxMinus1 and a matching pred_weight_table.
+func makePSliceNalu(t *testing.T, nrRefIdxMinus1 uint) []byte {
+	t.Helper()
+	buf := bytes.Buffer{}
+	w := bits.NewEBSPWriter(&buf)
+	w.Write(uint(NALU_IDR_W_RADL)<<9|0x01, 16) // nal_unit_header
+	w.Write(1, 1)                              // first_slice_segment_in_pic_flag
+	w.Write(0, 1)                              // no_output_of_prior_pics_flag
+	w.WriteExpGolomb(0)                        // slice_pic_parameter_set_id
+	w.WriteExpGolomb(uint(SLICE_P))            // slice_type
+	w.Write(1, 1)                              // num_ref_idx_active_override_flag
+	w.WriteExpGolomb(nrRefIdxMinus1)           // num_ref_idx_l0_active_minus1
+	w.WriteExpGolomb(0)                        // luma_log2_weight_denom
+	for i := uint(0); i <= nrRefIdxMinus1; i++ {
+		w.Write(0, 1) // luma_weight_l0_flag[i]
+	}
+	w.WriteExpGolomb(0) // five_minus_max_num_merge_cand
+	w.WriteExpGolomb(0) // slice_qp_delta
+	w.WriteRbspTrailingBits()
+	if w.AccError() != nil {
+		t.Fatal(w.AccError())
+	}
+	return buf.Bytes()
+}
+
+func TestParseSliceHeaderNumRefIdxRange(t *testing.T) {
+	spsMap := map[uint32]*SPS{0: {SpsID: 0}}
+	ppsMap := map[uint32]*PPS{0: {PicParameterSetID: 0, SeqParameterSetID: 0, WeightedPredFlag: true}}
+
+	cases := []struct {
+		nrRefIdxMinus1 uint
+		wantErr        string
+	}{
+		{0, ""},
+		{14, ""},
+		{15, "num_ref_idx_l0_active_minus1 = 15 is outside the range 0 to 14"},
+		{255, "num_ref_idx_l0_active_minus1 = 255 is outside the range 0 to 14"},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("num_ref_idx_l0_active_minus1=%d", c.nrRefIdxMinus1), func(t *testing.T) {
+			nalu := makePSliceNalu(t, c.nrRefIdxMinus1)
+			hdr, err := ParseSliceHeader(nalu, spsMap, ppsMap)
+			if c.wantErr != "" {
+				if err == nil || err.Error() != c.wantErr {
+					t.Errorf("got error %v, wanted %q", err, c.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if uint(hdr.NumRefIdxL0ActiveMinus1) != c.nrRefIdxMinus1 {
+				t.Errorf("NumRefIdxL0ActiveMinus1 = %d, wanted %d", hdr.NumRefIdxL0ActiveMinus1, c.nrRefIdxMinus1)
+			}
+			if got := len(hdr.PredWeightTable.WeightsL0); uint(got) != c.nrRefIdxMinus1+1 {
+				t.Errorf("len(WeightsL0) = %d, wanted %d", got, c.nrRefIdxMinus1+1)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`ParseSliceHeader` panics on an HEVC slice header with `num_ref_idx_l0_active_minus1 == 255`.

```
nalu = 26 01 ea 01 00 80  (6 bytes)
panic: runtime error: index out of range [0] with length 0
	hevc.parsePredWeightTable(...) hevc/slice.go:441
	hevc.ParseSliceHeader(...)     hevc/slice.go:300
```

`sh.NumRefIdxL0ActiveMinus1` is a `uint8`, and the allocation adds one in that width:

```go
pwt.WeightsL0 = make([]WeightingFactors, refIdxL0Minus1+1)
for i := uint8(0); i <= refIdxL0Minus1; i++ {
```

At 255, `refIdxL0Minus1+1` is 0, so the slice is empty - but `i <= 255` is still true for `i == 0`,
so the first iteration indexes into it. `parseRefPicListsModification` has the same shape, and both
repeat for L1.

### The change

Per @tobbee's review this now enforces the spec bounds instead of widening the arithmetic.

`num_ref_idx_l0_active_minus1` and `num_ref_idx_l1_active_minus1` shall be in the range 0 to 14
(Section 7.4.7.1), as do `num_ref_idx_l0/l1_default_active_minus1` in the PPS (Section 7.4.3.3) -
the comments at the old read sites already said so, they just were not enforced. All four now go
through one helper (`hevc/slice.go:407`):

```go
const maxNumRefIdxActiveMinus1 = 14

func readNumRefIdxActiveMinus1(r *bits.EBSPReader, name string) (uint8, error) {
	value := r.ReadExpGolomb()
	if value > maxNumRefIdxActiveMinus1 {
		return 0, fmt.Errorf("%s = %d is outside the range 0 to %d", name, value, maxNumRefIdxActiveMinus1)
	}
	return uint8(value), nil
}
```

so the crashing input now reports
`num_ref_idx_l0_active_minus1 = 255 is outside the range 0 to 14`.

The PPS defaults (`hevc/pps.go:205`, `:209`) need the same check, not just the slice-header override
at `hevc/slice.go:262`. When `num_ref_idx_active_override_flag` is 0 the header inherits them at
`hevc/slice.go:257`, and those were an unchecked `uint8(r.ReadExpGolomb())` too - so guarding only
the override path would leave the identical panic reachable through a PPS. Guarding all four read
sites is what actually makes it unreachable.

**Observable change:** input that used to crash the process now returns an error. A stream that
declares more than 15 reference indices was already non-conforming and could not be decoded, so
nothing that parsed correctly before parses differently.

### Tests

`TestParseSliceHeaderNumRefIdxRange` (`hevc/slice_test.go:276`) and `TestPPSNumRefIdxDefaultRange`
(`hevc/pps_test.go:81`) build the NAL units with `bits.NewEBSPWriter` and table over 0, 14, 15 and
255 - accepted values assert the parsed field and the resulting `len(WeightsL0)`, rejected ones
assert the exact message.

Red/green on this tree: with `hevc/slice.go` and `hevc/pps.go` restored to master, the 15 case
reports `got error <nil>` and the 255 case panics at `hevc/slice.go:441`, which is the reported bug.

Mutation-checked three ways, and the two boundary mutations fail disjoint subtests:

- drop the check entirely -> the 15 and 255 subtests fail, 255 by the original panic
- loosen the bound to `value > 15` -> only the 15 subtests fail
- tighten it to `value > 13` -> only the 14 subtests fail

so 14 is pinned as exactly the last legal value rather than just "somewhere above the values we
happened to try".

`go test -count=1 ./...` passes across all packages, `go vet ./...` and `gofmt -l .` clean.
CHANGELOG entry added under Unreleased/Fixed.

---

Disclosure: found and prepared with AI assistance (Claude). The root cause, the NAL construction and
every figure above are mine and verified by hand on this branch.
