### PR TITLE
fix(hevc): parse multilayer extension SPS and VPS rep_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `hevc.ParseSPSNALUnitWithVPS` parses an SPS with a map of the VPSs it may
+  refer to, so that a multilayer extension SPS gets the chroma format, picture
+  size, conformance window and bit depths that it does not signal itself
+  inherited from the `rep_format()` of its VPS. `hevc.ParseSPSNALUnit` is
+  unchanged and leaves those values unset, since the SPS payload can be parsed
+  without them
+- `hevc.SPS` exposes `NuhLayerID`, `ExtOrMaxSubLayersMinus1`,
+  `MultiLayerExtSpsFlag`, `UpdateRepFormatFlag`, `SpsRepFormatIdx`,
+  `InferScalingListFlag` and `ScalingListRefLayerID`, and `hevc.RepFormat`
+  exposes `SeparateColourPlaneFlag`, `ConformanceWindowFlag` and
+  `ConformanceWindow`
 - `AudioSampleEntryBox.NormalizeQuickTime` rewrites a QuickTime-shaped audio
   sample entry (sound sample description version 1 or 2, QuickTime residue in
   the version 0 reserved fields, or a wave-wrapped esds) to the plain ISO
@@ -125,6 +136,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   zero-length slice while its loop guard still ran, and parsing panicked with
   an index out of range. All four read sites now check the bound and return an
   error naming the syntax element, its value and the legal range
+- `hevc.ParseSPSNALUnit` misparsed a non-base-layer SPS that uses the
+  multilayer extension form, as MV-HEVC and SHVC enhancement layers do. Such an
+  SPS signals `sps_ext_or_max_sub_layers_minus1` instead of
+  `sps_max_sub_layers_minus1` and then omits `profile_tier_level()`, the chroma
+  format, the picture size, the conformance window and the bit depths, and it
+  carries `sps_infer_scaling_list_flag`. The parser always took the base-layer
+  branch, so it read those absent fields from the following bits and typically
+  failed with `EOF`. `nuh_layer_id` is now taken from the NAL unit header and
+  the two forms are parsed accordingly
+- `rep_format()` in the VPS extension dropped `separate_colour_plane_vps_flag`
+  and the conformance window, and left the chroma format and bit depths unset
+  for a `rep_format()` with `chroma_and_bit_depth_vps_present_flag` equal to
+  zero instead of inferring them from the preceding one
 - `IsSyncSampleFlags` only inspected `sample_depends_on` and ignored
   `sample_is_non_sync_sample`, so flags that mark a sample non-sync while also
   saying `sample_depends_on = 2` were reported as a sync sample. It now

--- a/cmd/mp4ff-pslister/main.go
+++ b/cmd/mp4ff-pslister/main.go
@@ -370,16 +370,18 @@ func printAvcPS(w io.Writer, spsNalus, ppsNalus [][]byte, verbose bool) error {
 }
 
 func printHevcPS(w io.Writer, vpsNalus, spsNalus, ppsNalus [][]byte, verbose bool) error {
+	vpsMap := make(map[byte]*hevc.VPS)
 	for i, vps := range vpsNalus {
 		vpsInfo, err := hevc.ParseVPSNALUnit(vps)
 		if err != nil {
 			return fmt.Errorf("ParseVPSNALUnit: %w", err)
 		}
 		printPS(w, "VPS", i+1, vps, vpsInfo, verbose)
+		vpsMap[vpsInfo.VpsID] = vpsInfo
 	}
 	spsMap := make(map[uint32]*hevc.SPS)
 	for i, sps := range spsNalus {
-		spsInfo, err := hevc.ParseSPSNALUnit(sps)
+		spsInfo, err := hevc.ParseSPSNALUnitWithVPS(sps, vpsMap)
 		if err != nil {
 			return fmt.Errorf("ParseSPSNALUnit: %w", err)
 		}
@@ -395,7 +397,7 @@ func printHevcPS(w io.Writer, vpsNalus, spsNalus, ppsNalus [][]byte, verbose boo
 	}
 
 	if len(spsNalus) > 0 {
-		sps, _ := hevc.ParseSPSNALUnit(spsNalus[0])
+		sps, _ := hevc.ParseSPSNALUnitWithVPS(spsNalus[0], vpsMap)
 		fmt.Fprintf(w, "Codecs parameter (assuming hvc1) from SPS id %d: %s\n", sps.SpsID, hevc.CodecString("hvc1", sps))
 	}
 	return nil

--- a/cmd/mp4ff-pslister/testdata/golden_hevc_mp4_verbose.txt
+++ b/cmd/mp4ff-pslister/testdata/golden_hevc_mp4_verbose.txt
@@ -39,8 +39,11 @@ VPS 1 len 24B: 40010c01ffff016000000300900000030000030078959809
 }
 SPS 1 len 45B: 420101016000000300900000030000030078a00502016965959a4932bc05a80808082000000300200000030321
 {
+  "NuhLayerID": 0,
   "VpsID": 0,
   "MaxSubLayersMinus1": 0,
+  "ExtOrMaxSubLayersMinus1": 0,
+  "MultiLayerExtSpsFlag": false,
   "TemporalIDNestingFlag": true,
   "ProfileTierLevel": {
     "GeneralProfileSpace": 0,
@@ -56,6 +59,8 @@ SPS 1 len 45B: 420101016000000300900000030000030078a00502016965959a4932bc05a8080
     "SubLayers": null
   },
   "SpsID": 0,
+  "UpdateRepFormatFlag": false,
+  "SpsRepFormatIdx": 0,
   "ChromaFormatIDC": 1,
   "SeparateColourPlaneFlag": false,
   "ConformanceWindowFlag": false,
@@ -85,6 +90,8 @@ SPS 1 len 45B: 420101016000000300900000030000030078a00502016965959a4932bc05a8080
   "MaxTransformHierarchyDepthInter": 0,
   "MaxTransformHierarchyDepthIntra": 0,
   "ScalingListEnabledFlag": false,
+  "InferScalingListFlag": false,
+  "ScalingListRefLayerID": 0,
   "ScalingListDataPresentFlag": false,
   "AmpEnabledFlag": false,
   "SampleAdaptiveOffsetEnabledFlag": true,

--- a/cmd/mp4ff-pslister/testdata/golden_hevc_vps_sps_pps.txt
+++ b/cmd/mp4ff-pslister/testdata/golden_hevc_vps_sps_pps.txt
@@ -38,8 +38,11 @@ VPS 1 len 24B: 40010c01ffff016000000300900000030000030078959809
 }
 SPS 1 len 45B: 420101016000000300900000030000030078a00502016965959a4932bc05a80808082000000300200000030321
 {
+  "NuhLayerID": 0,
   "VpsID": 0,
   "MaxSubLayersMinus1": 0,
+  "ExtOrMaxSubLayersMinus1": 0,
+  "MultiLayerExtSpsFlag": false,
   "TemporalIDNestingFlag": true,
   "ProfileTierLevel": {
     "GeneralProfileSpace": 0,
@@ -55,6 +58,8 @@ SPS 1 len 45B: 420101016000000300900000030000030078a00502016965959a4932bc05a8080
     "SubLayers": null
   },
   "SpsID": 0,
+  "UpdateRepFormatFlag": false,
+  "SpsRepFormatIdx": 0,
   "ChromaFormatIDC": 1,
   "SeparateColourPlaneFlag": false,
   "ConformanceWindowFlag": false,
@@ -84,6 +89,8 @@ SPS 1 len 45B: 420101016000000300900000030000030078a00502016965959a4932bc05a8080
   "MaxTransformHierarchyDepthInter": 0,
   "MaxTransformHierarchyDepthIntra": 0,
   "ScalingListEnabledFlag": false,
+  "InferScalingListFlag": false,
+  "ScalingListRefLayerID": 0,
   "ScalingListDataPresentFlag": false,
   "AmpEnabledFlag": false,
   "SampleAdaptiveOffsetEnabledFlag": true,

--- a/hevc/pps.go
+++ b/hevc/pps.go
@@ -175,7 +175,7 @@ type DeltaDlt struct {
 	DeltaValDiffMinusMin []uint
 }
 
-// ParsePPSNALUnit - Parse AVC PPS NAL unit starting with NAL header
+// ParsePPSNALUnit - Parse HEVC PPS NAL unit starting with NAL header
 func ParsePPSNALUnit(data []byte, spsMap map[uint32]*SPS) (*PPS, error) {
 	var err error
 

--- a/hevc/sps.go
+++ b/hevc/sps.go
@@ -12,11 +12,29 @@ import (
 // SPS - HEVC SPS parameters
 // ISO/IEC 23008-2 Sec. 7.3.2.2
 type SPS struct {
-	VpsID                                byte
-	MaxSubLayersMinus1                   byte
-	TemporalIDNestingFlag                bool
-	ProfileTierLevel                     ProfileTierLevel
-	SpsID                                byte
+	// NuhLayerID is nuh_layer_id from the NAL unit header. It is not part of the
+	// SPS payload, but decides whether the multilayer extension form is used.
+	NuhLayerID byte
+	VpsID      byte
+	// MaxSubLayersMinus1 is sps_max_sub_layers_minus1. For a multilayer
+	// extension SPS it is not signalled but inherited from the VPS.
+	MaxSubLayersMinus1 byte
+	// ExtOrMaxSubLayersMinus1 is sps_ext_or_max_sub_layers_minus1, which
+	// replaces sps_max_sub_layers_minus1 when NuhLayerID is non-zero.
+	ExtOrMaxSubLayersMinus1 byte
+	// MultiLayerExtSpsFlag tells whether this SPS uses the multilayer extension
+	// form, i.e. NuhLayerID != 0 && ExtOrMaxSubLayersMinus1 == 7. Such an SPS
+	// signals neither profile_tier_level nor the chroma format, picture size,
+	// conformance window and bit depths, but inherits them from the VPS.
+	MultiLayerExtSpsFlag  bool
+	TemporalIDNestingFlag bool
+	ProfileTierLevel      ProfileTierLevel
+	SpsID                 byte
+	// UpdateRepFormatFlag and SpsRepFormatIdx are only present for a multilayer
+	// extension SPS, and select which VPS rep_format() the inherited values come
+	// from.
+	UpdateRepFormatFlag                  bool
+	SpsRepFormatIdx                      byte
 	ChromaFormatIDC                      byte
 	SeparateColourPlaneFlag              bool
 	ConformanceWindowFlag                bool
@@ -35,6 +53,11 @@ type SPS struct {
 	MaxTransformHierarchyDepthInter      byte
 	MaxTransformHierarchyDepthIntra      byte
 	ScalingListEnabledFlag               bool
+	// InferScalingListFlag and ScalingListRefLayerID are only present for a
+	// multilayer extension SPS, and make it use the scaling list data of
+	// another layer instead of signalling its own.
+	InferScalingListFlag                 bool
+	ScalingListRefLayerID                byte
 	ScalingListDataPresentFlag           bool
 	AmpEnabledFlag                       bool
 	SampleAdaptiveOffsetEnabledFlag      bool
@@ -304,8 +327,20 @@ type SPSSccExtension struct {
 	IntraBoundaryFilteringDisabledFlag      bool
 }
 
-// ParseSPSNALUnit parses SPS NAL unit starting with NAL unit header
+// ParseSPSNALUnit parses SPS NAL unit starting with NAL unit header.
+// A non-base-layer SPS in the multilayer extension form (MV-HEVC, SHVC) does
+// not signal its chroma format, picture size, conformance window or bit depths,
+// and those fields are left at their zero values here. Use
+// ParseSPSNALUnitWithVPS to have them inherited from the VPS.
 func ParseSPSNALUnit(data []byte) (*SPS, error) {
+	return ParseSPSNALUnitWithVPS(data, nil)
+}
+
+// ParseSPSNALUnitWithVPS parses an SPS NAL unit starting with NAL unit header,
+// resolving the values that a multilayer extension SPS inherits from its VPS.
+// vpsMap maps vps_video_parameter_set_id to VPS and may be nil or incomplete,
+// in which case nothing is inherited.
+func ParseSPSNALUnitWithVPS(data []byte, vpsMap map[byte]*VPS) (*SPS, error) {
 
 	sps := &SPS{}
 
@@ -318,42 +353,67 @@ func ParseSPSNALUnit(data []byte) (*SPS, error) {
 	if naluType != NALU_SPS {
 		return nil, fmt.Errorf("NALU type is %s not SPS", naluType)
 	}
+	sps.NuhLayerID = byte((naluHdrBits >> 3) & 0x3f)
 	sps.VpsID = byte(r.Read(4))
-	sps.MaxSubLayersMinus1 = byte(r.Read(3))
-	sps.TemporalIDNestingFlag = r.ReadFlag()
-	sps.ProfileTierLevel = parseProfileTierLevel(r, true, sps.MaxSubLayersMinus1)
-	sps.SpsID = byte(r.ReadExpGolomb())
-	sps.ChromaFormatIDC = byte(r.ReadExpGolomb())
-	if sps.ChromaFormatIDC == 3 {
-		sps.SeparateColourPlaneFlag = r.ReadFlag()
-	}
-	sps.PicWidthInLumaSamples = uint32(r.ReadExpGolomb())
-	sps.PicHeightInLumaSamples = uint32(r.ReadExpGolomb())
-	sps.ConformanceWindowFlag = r.ReadFlag()
-	if sps.ConformanceWindowFlag {
-		sps.ConformanceWindow = ConformanceWindow{
-			LeftOffset:   uint32(r.ReadExpGolomb()),
-			RightOffset:  uint32(r.ReadExpGolomb()),
-			TopOffset:    uint32(r.ReadExpGolomb()),
-			BottomOffset: uint32(r.ReadExpGolomb()),
+	if sps.NuhLayerID == 0 {
+		sps.MaxSubLayersMinus1 = byte(r.Read(3))
+	} else {
+		sps.ExtOrMaxSubLayersMinus1 = byte(r.Read(3))
+		sps.MultiLayerExtSpsFlag = sps.ExtOrMaxSubLayersMinus1 == 7
+		if !sps.MultiLayerExtSpsFlag {
+			sps.MaxSubLayersMinus1 = sps.ExtOrMaxSubLayersMinus1
 		}
 	}
-	sps.BitDepthLumaMinus8 = byte(r.ReadExpGolomb())
-	sps.BitDepthChromaMinus8 = byte(r.ReadExpGolomb())
-	sps.Log2MaxPicOrderCntLsbMinus4 = byte(r.ReadExpGolomb())
-	sps.SubLayerOrderingInfoPresentFlag = r.ReadFlag()
-	startValue := sps.MaxSubLayersMinus1
-	if sps.SubLayerOrderingInfoPresentFlag {
-		startValue = 0
+	if !sps.MultiLayerExtSpsFlag {
+		sps.TemporalIDNestingFlag = r.ReadFlag()
+		sps.ProfileTierLevel = parseProfileTierLevel(r, true, sps.MaxSubLayersMinus1)
 	}
-	for i := startValue; i <= sps.MaxSubLayersMinus1; i++ {
-		sps.SubLayeringOrderingInfos = append(
-			sps.SubLayeringOrderingInfos,
-			SubLayerOrderingInfo{
-				MaxDecPicBufferingMinus1: byte(r.ReadExpGolomb()),
-				MaxNumReorderPics:        byte(r.ReadExpGolomb()),
-				MaxLatencyIncreasePlus1:  byte(r.ReadExpGolomb()),
-			})
+	sps.SpsID = byte(r.ReadExpGolomb())
+	if sps.MultiLayerExtSpsFlag {
+		sps.UpdateRepFormatFlag = r.ReadFlag()
+		if sps.UpdateRepFormatFlag {
+			sps.SpsRepFormatIdx = byte(r.Read(8))
+		}
+		// The values omitted above are inherited from the VPS. Do this before
+		// parsing on, since the rest of the SPS depends on them.
+		if err := sps.inheritFromVPS(vpsMap[sps.VpsID]); err != nil {
+			return sps, err
+		}
+	} else {
+		sps.ChromaFormatIDC = byte(r.ReadExpGolomb())
+		if sps.ChromaFormatIDC == 3 {
+			sps.SeparateColourPlaneFlag = r.ReadFlag()
+		}
+		sps.PicWidthInLumaSamples = uint32(r.ReadExpGolomb())
+		sps.PicHeightInLumaSamples = uint32(r.ReadExpGolomb())
+		sps.ConformanceWindowFlag = r.ReadFlag()
+		if sps.ConformanceWindowFlag {
+			sps.ConformanceWindow = ConformanceWindow{
+				LeftOffset:   uint32(r.ReadExpGolomb()),
+				RightOffset:  uint32(r.ReadExpGolomb()),
+				TopOffset:    uint32(r.ReadExpGolomb()),
+				BottomOffset: uint32(r.ReadExpGolomb()),
+			}
+		}
+		sps.BitDepthLumaMinus8 = byte(r.ReadExpGolomb())
+		sps.BitDepthChromaMinus8 = byte(r.ReadExpGolomb())
+	}
+	sps.Log2MaxPicOrderCntLsbMinus4 = byte(r.ReadExpGolomb())
+	if !sps.MultiLayerExtSpsFlag {
+		sps.SubLayerOrderingInfoPresentFlag = r.ReadFlag()
+		startValue := sps.MaxSubLayersMinus1
+		if sps.SubLayerOrderingInfoPresentFlag {
+			startValue = 0
+		}
+		for i := startValue; i <= sps.MaxSubLayersMinus1; i++ {
+			sps.SubLayeringOrderingInfos = append(
+				sps.SubLayeringOrderingInfos,
+				SubLayerOrderingInfo{
+					MaxDecPicBufferingMinus1: byte(r.ReadExpGolomb()),
+					MaxNumReorderPics:        byte(r.ReadExpGolomb()),
+					MaxLatencyIncreasePlus1:  byte(r.ReadExpGolomb()),
+				})
+		}
 	}
 	sps.Log2MinLumaCodingBlockSizeMinus3 = byte(r.ReadExpGolomb())
 	sps.Log2DiffMaxMinLumaCodingBlockSize = byte(r.ReadExpGolomb())
@@ -363,9 +423,16 @@ func ParseSPSNALUnit(data []byte) (*SPS, error) {
 	sps.MaxTransformHierarchyDepthIntra = byte(r.ReadExpGolomb())
 	sps.ScalingListEnabledFlag = r.ReadFlag()
 	if sps.ScalingListEnabledFlag {
-		sps.ScalingListDataPresentFlag = r.ReadFlag()
-		if sps.ScalingListDataPresentFlag {
-			readPastScalingListData(r)
+		if sps.MultiLayerExtSpsFlag {
+			sps.InferScalingListFlag = r.ReadFlag()
+		}
+		if sps.InferScalingListFlag {
+			sps.ScalingListRefLayerID = byte(r.Read(6))
+		} else {
+			sps.ScalingListDataPresentFlag = r.ReadFlag()
+			if sps.ScalingListDataPresentFlag {
+				readPastScalingListData(r)
+			}
 		}
 	}
 	sps.AmpEnabledFlag = r.ReadFlag()
@@ -478,6 +545,42 @@ func ParseSPSNALUnit(data []byte) (*SPS, error) {
 	}
 
 	return sps, nil
+}
+
+// inheritFromVPS fills in the values that a multilayer extension SPS does not
+// signal, taking them from the rep_format() of the VPS it refers to
+// (ISO/IEC 23008-2 Annex F.7.4.3.2.1). A nil vps leaves them at their zero
+// values, since the SPS payload can still be parsed without them.
+func (s *SPS) inheritFromVPS(vps *VPS) error {
+	if vps == nil {
+		return nil
+	}
+	s.MaxSubLayersMinus1 = vps.MaxSubLayersMinus1
+	if vps.Extension == nil {
+		return fmt.Errorf("VPS %d has no extension, so no rep_format() to inherit", s.VpsID)
+	}
+	ext := vps.Extension
+	repFormatIdx := s.SpsRepFormatIdx
+	if !s.UpdateRepFormatFlag {
+		repFormatIdx = ext.RepFormatIdx[ext.LayerIdInVps[s.NuhLayerID]]
+	}
+	if int(repFormatIdx) >= len(ext.RepFormats) {
+		return fmt.Errorf("rep_format index %d out of range for the %d rep formats of VPS %d",
+			repFormatIdx, len(ext.RepFormats), s.VpsID)
+	}
+	rf := ext.RepFormats[repFormatIdx]
+	if rf.BitDepthLuma < 8 || rf.BitDepthChroma < 8 {
+		return fmt.Errorf("rep_format %d of VPS %d has no bit depths", repFormatIdx, s.VpsID)
+	}
+	s.ChromaFormatIDC = rf.ChromaFormatIDC
+	s.SeparateColourPlaneFlag = rf.SeparateColourPlaneFlag
+	s.PicWidthInLumaSamples = uint32(rf.PicWidthLumaSamples)
+	s.PicHeightInLumaSamples = uint32(rf.PicHeightLumaSamples)
+	s.ConformanceWindowFlag = rf.ConformanceWindowFlag
+	s.ConformanceWindow = rf.ConformanceWindow
+	s.BitDepthLumaMinus8 = rf.BitDepthLuma - 8
+	s.BitDepthChromaMinus8 = rf.BitDepthChroma - 8
+	return nil
 }
 
 // ImageSize - calculated width and height using ConformanceWindow

--- a/hevc/sps_test.go
+++ b/hevc/sps_test.go
@@ -458,3 +458,118 @@ func TestSPSandPPS(t *testing.T) {
 	}
 
 }
+
+// The VPS and the layer-0 and layer-1 SPS of an MV-HEVC stereo bitstream, taken
+// from the hvcC and lhvC boxes of cmd/mp4ff-mvhevc/testdata/stereo_spatial.mp4.
+// The layer-1 SPS uses the multilayer extension form, so it does not signal the
+// chroma format, picture size, conformance window or bit depths itself.
+const (
+	mvhevcVpsNalu = ("40010c11ffff016000000300b0000003000003003c15c15b3c200028245970602000000b" +
+		"f800000300000303c8d00a00080a01e5c52bf708501010100080")
+	mvhevcSpsNaluLayer0 = "420101016000000300b0000003000003003ca01420207cb8815ee45951"
+	mvhevcSpsNaluLayer1 = "42090e822e458a9404"
+)
+
+// TestSPSParserMultiLayerExt verifies that a non-base-layer SPS in the
+// multilayer extension form is parsed, and that the values it does not signal
+// are inherited from the rep_format() of its VPS.
+func TestSPSParserMultiLayerExt(t *testing.T) {
+	vpsBytes, err := hex.DecodeString(mvhevcVpsNalu)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vps, err := ParseVPSNALUnit(vpsBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vpsMap := map[byte]*VPS{vps.VpsID: vps}
+	spsBytes, err := hex.DecodeString(mvhevcSpsNaluLayer1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sps, err := ParseSPSNALUnitWithVPS(spsBytes, vpsMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sps.NuhLayerID != 1 {
+		t.Errorf("nuh_layer_id is %d, wanted 1", sps.NuhLayerID)
+	}
+	if sps.ExtOrMaxSubLayersMinus1 != 7 || !sps.MultiLayerExtSpsFlag {
+		t.Errorf("sps_ext_or_max_sub_layers_minus1 is %d and MultiLayerExtSpsFlag %t, wanted 7 and true",
+			sps.ExtOrMaxSubLayersMinus1, sps.MultiLayerExtSpsFlag)
+	}
+	if sps.UpdateRepFormatFlag {
+		t.Error("update_rep_format_flag set, wanted the rep format index from the VPS")
+	}
+	// Inherited from rep_format() 0 of the VPS.
+	if sps.ChromaFormatIDC != 1 {
+		t.Errorf("chroma_format_idc is %d, wanted 1", sps.ChromaFormatIDC)
+	}
+	if sps.PicWidthInLumaSamples != 160 || sps.PicHeightInLumaSamples != 128 {
+		t.Errorf("picture size is %dx%d, wanted 160x128",
+			sps.PicWidthInLumaSamples, sps.PicHeightInLumaSamples)
+	}
+	if sps.BitDepthLumaMinus8 != 0 || sps.BitDepthChromaMinus8 != 0 {
+		t.Errorf("bit depths are %d/%d, wanted 8/8",
+			sps.BitDepthLumaMinus8+8, sps.BitDepthChromaMinus8+8)
+	}
+	if !sps.ConformanceWindowFlag || sps.ConformanceWindow.BottomOffset != 4 {
+		t.Errorf("conformance window is %t %+v, wanted a bottom offset of 4",
+			sps.ConformanceWindowFlag, sps.ConformanceWindow)
+	}
+	if w, h := sps.ImageSize(); w != 160 || h != 120 {
+		t.Errorf("image size is %dx%d, wanted 160x120", w, h)
+	}
+	// The two layers of the stereo pair share their coding structure, so the
+	// fields the layer-1 SPS does signal must match the layer-0 SPS.
+	layer0Bytes, err := hex.DecodeString(mvhevcSpsNaluLayer0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layer0, err := ParseSPSNALUnitWithVPS(layer0Bytes, vpsMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if layer0.MultiLayerExtSpsFlag {
+		t.Error("the layer-0 SPS should not use the multilayer extension form")
+	}
+	if sps.Log2MaxPicOrderCntLsbMinus4 != layer0.Log2MaxPicOrderCntLsbMinus4 {
+		t.Errorf("log2_max_pic_order_cnt_lsb_minus4 is %d, wanted %d as for layer 0",
+			sps.Log2MaxPicOrderCntLsbMinus4, layer0.Log2MaxPicOrderCntLsbMinus4)
+	}
+	if sps.Log2MinLumaCodingBlockSizeMinus3 != layer0.Log2MinLumaCodingBlockSizeMinus3 ||
+		sps.Log2DiffMaxMinLumaCodingBlockSize != layer0.Log2DiffMaxMinLumaCodingBlockSize {
+		t.Errorf("luma coding block sizes are %d/%d, wanted %d/%d as for layer 0",
+			sps.Log2MinLumaCodingBlockSizeMinus3, sps.Log2DiffMaxMinLumaCodingBlockSize,
+			layer0.Log2MinLumaCodingBlockSizeMinus3, layer0.Log2DiffMaxMinLumaCodingBlockSize)
+	}
+	if !sps.MultilayerExtensionFlag {
+		t.Error("sps_multilayer_extension_flag not set")
+	}
+}
+
+// TestSPSParserMultiLayerExtWithoutVPS verifies that a multilayer extension SPS
+// still parses without its VPS, since the payload can be read without it, and
+// that the values that would have been inherited are then left unset.
+func TestSPSParserMultiLayerExtWithoutVPS(t *testing.T) {
+	spsBytes, err := hex.DecodeString(mvhevcSpsNaluLayer1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sps, err := ParseSPSNALUnit(spsBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sps.MultiLayerExtSpsFlag {
+		t.Fatal("MultiLayerExtSpsFlag not set")
+	}
+	if sps.ChromaFormatIDC != 0 || sps.PicWidthInLumaSamples != 0 || sps.PicHeightInLumaSamples != 0 {
+		t.Errorf("inherited values are chroma %d and %dx%d, wanted them unset",
+			sps.ChromaFormatIDC, sps.PicWidthInLumaSamples, sps.PicHeightInLumaSamples)
+	}
+	// The signalled values must be the same as when the VPS is available.
+	if sps.Log2MaxPicOrderCntLsbMinus4 != 7 {
+		t.Errorf("log2_max_pic_order_cnt_lsb_minus4 is %d, wanted 7", sps.Log2MaxPicOrderCntLsbMinus4)
+	}
+}

--- a/hevc/vps.go
+++ b/hevc/vps.go
@@ -82,13 +82,18 @@ type VPSExtension struct {
 }
 
 // RepFormat holds resolution and format info for a layer (rep_format() in
-// ISO/IEC 23008-2 Annex F.7.3.2.1.2).
+// ISO/IEC 23008-2 Annex F.7.3.2.1.2). A non-base-layer SPS that uses the
+// multilayer extension form does not signal these values itself, but inherits
+// them from here.
 type RepFormat struct {
-	PicWidthLumaSamples  uint16
-	PicHeightLumaSamples uint16
-	ChromaFormatIDC      byte
-	BitDepthLuma         byte
-	BitDepthChroma       byte
+	PicWidthLumaSamples     uint16
+	PicHeightLumaSamples    uint16
+	ChromaFormatIDC         byte
+	SeparateColourPlaneFlag bool
+	BitDepthLuma            byte
+	BitDepthChroma          byte
+	ConformanceWindowFlag   bool
+	ConformanceWindow       ConformanceWindow
 }
 
 // GetNumLayers returns the number of layers signalled by this VPS.
@@ -582,7 +587,11 @@ func parseVPSExtension(vps *VPS, ext *VPSExtension, r *bits.EBSPReader) error {
 	// Rep formats
 	ext.NumRepFormats = int(r.ReadExpGolomb()) + 1
 	for i := 0; i < ext.NumRepFormats; i++ {
-		ext.RepFormats = append(ext.RepFormats, parseRepFormat(r))
+		var prev *RepFormat
+		if i > 0 {
+			prev = &ext.RepFormats[i-1]
+		}
+		ext.RepFormats = append(ext.RepFormats, parseRepFormat(r, prev))
 	}
 
 	repFormatIDXPresentFlag := false
@@ -608,23 +617,35 @@ func parseVPSExtension(vps *VPS, ext *VPSExtension, r *bits.EBSPReader) error {
 }
 
 // parseRepFormat parses rep_format() (ISO/IEC 23008-2 Annex F.7.3.2.1.2).
-func parseRepFormat(r *bits.EBSPReader) RepFormat {
+// prev is the previously parsed rep_format(), or nil for the first one. When
+// chroma_and_bit_depth_vps_present_flag is zero, the chroma format and the bit
+// depths are inferred from prev (Annex F.7.4.3.1.2). The flag shall be one for
+// the first rep_format(), so prev is only nil where nothing is inferred.
+func parseRepFormat(r *bits.EBSPReader, prev *RepFormat) RepFormat {
 	rf := RepFormat{}
 	rf.PicWidthLumaSamples = uint16(r.Read(16))
 	rf.PicHeightLumaSamples = uint16(r.Read(16))
 	if r.ReadFlag() { // chroma_and_bit_depth_vps_present_flag
 		rf.ChromaFormatIDC = byte(r.Read(2))
 		if rf.ChromaFormatIDC == 3 {
-			_ = r.ReadFlag() // separate_colour_plane_vps_flag
+			rf.SeparateColourPlaneFlag = r.ReadFlag() // separate_colour_plane_vps_flag
 		}
 		rf.BitDepthLuma = byte(r.Read(4)) + 8
 		rf.BitDepthChroma = byte(r.Read(4)) + 8
+	} else if prev != nil {
+		rf.ChromaFormatIDC = prev.ChromaFormatIDC
+		rf.SeparateColourPlaneFlag = prev.SeparateColourPlaneFlag
+		rf.BitDepthLuma = prev.BitDepthLuma
+		rf.BitDepthChroma = prev.BitDepthChroma
 	}
-	if r.ReadFlag() { // conformance_window_vps_flag
-		_ = r.ReadExpGolomb() // conf_win_vps_left_offset
-		_ = r.ReadExpGolomb() // conf_win_vps_right_offset
-		_ = r.ReadExpGolomb() // conf_win_vps_top_offset
-		_ = r.ReadExpGolomb() // conf_win_vps_bottom_offset
+	rf.ConformanceWindowFlag = r.ReadFlag() // conformance_window_vps_flag
+	if rf.ConformanceWindowFlag {
+		rf.ConformanceWindow = ConformanceWindow{
+			LeftOffset:   uint32(r.ReadExpGolomb()), // conf_win_vps_left_offset
+			RightOffset:  uint32(r.ReadExpGolomb()), // conf_win_vps_right_offset
+			TopOffset:    uint32(r.ReadExpGolomb()), // conf_win_vps_top_offset
+			BottomOffset: uint32(r.ReadExpGolomb()), // conf_win_vps_bottom_offset
+		}
 	}
 	return rf
 }


### PR DESCRIPTION
## Problem

`hevc.ParseSPSNALUnit` always took the base-layer branch of `seq_parameter_set_rbsp()`. A non-base-layer SPS in the multilayer extension form — what MV-HEVC and SHVC enhancement layers use — has a different syntax, decided by

```
MultiLayerExtSpsFlag = (nuh_layer_id != 0 && sps_ext_or_max_sub_layers_minus1 == 7)
```

Such an SPS signals `sps_ext_or_max_sub_layers_minus1` in place of `sps_max_sub_layers_minus1` and then omits `profile_tier_level()`, `chroma_format_idc`, `separate_colour_plane_flag`, the picture size, the conformance window, the bit depths and the sub-layer ordering info, and it carries `sps_infer_scaling_list_flag` / `sps_scaling_list_ref_layer_id` that a base-layer SPS does not. The parser read those absent fields from the following bits and typically ran off the end with `EOF`.

The MV-HEVC test content in this repo hits it: the `lhvC` of `cmd/mp4ff-mvhevc/testdata/stereo_spatial.mp4` holds a 9-byte layer-1 SPS with `nuh_layer_id = 1` and `sps_ext_or_max_sub_layers_minus1 = 7`, which fails to parse today. It has not surfaced because `cmd/mp4ff-mvhevc` only ever parses the base-layer SPS.

## Fix

`nuh_layer_id` is now taken from the NAL unit header and both forms are parsed. All four `MultiLayerExtSpsFlag` branches of Section 7.3.2.2.1 are handled, including the `sps_infer_scaling_list_flag` block.

The omitted values are inherited from the `rep_format()` of the active VPS (Annex F.7.4.3.2.1), which the new `ParseSPSNALUnitWithVPS(data, vpsMap)` resolves — by `sps_rep_format_idx` when `update_rep_format_flag` is set, else by `vps_rep_format_idx[LayerIdxInVps[nuh_layer_id]]`. `ParseSPSNALUnit` keeps its signature and delegates with a nil map: the payload parses fine without a VPS, the inherited fields are simply left unset.

Wiring that up exposed two bugs in the VPS extension parser, fixed here as well:

- `parseRepFormat` discarded `separate_colour_plane_vps_flag` and the entire conformance window.
- With `chroma_and_bit_depth_vps_present_flag` equal to zero it left the chroma format and bit depths at zero, instead of inferring them from the preceding `rep_format()`.

`cmd/mp4ff-pslister` now passes its VPS map into the SPS parse; it already parsed the VPSs first. The two regenerated HEVC golden files differ only by the added JSON fields — no value changed — which confirms base-layer parsing is untouched.

## Tests

`TestSPSParserMultiLayerExt` parses the layer-1 SPS from `stereo_spatial.mp4` with its VPS and checks the inherited values (4:2:0, 160x128, 8/8 bit depth, bottom crop 4, so a 160x120 image). It then asserts that the fields the layer-1 SPS *does* signal match the layer-0 SPS, since the two layers of a stereo pair share their coding structure — same `log2_max_pic_order_cnt_lsb`, same luma coding block sizes — and that `sps_multilayer_extension_flag` is set. The RBSP also ends exactly on its trailing bits, which the parser verifies.

`TestSPSParserMultiLayerExtWithoutVPS` covers the no-VPS path.

45s of `FuzzParseSPSNALUnit` found nothing.

Also included: a one-word doc-comment correction in `hevc/pps.go`, which said "Parse AVC PPS NAL unit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)