### PR TITLE
docs(mp4): fix Defragment doc wording and CHANGELOG wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Fragment-format brands (dash, cmfc, isml, and friends) are removed from
   the output ftyp. Per-sample encryption auxiliary information (senc or
   saiz/saio; constant-IV full-sample encryption without such data passes
-  through losslessly), unsupported edit lists, zero
-  timescales, truncated byte ranges, and payloads larger than the input
-  file are rejected
+  through losslessly), unsupported edit lists, zero timescales, truncated
+  byte ranges, and payloads larger than the input file are rejected
 - `mp4.Defragment` and `mp4.DefragmentTracks` resolve overlapping fragments:
   when a fragment's tfdt re-declares an earlier decode time (a
   retransmission), the fragment appearing later in the file wins and the

--- a/mp4/defragmenter.go
+++ b/mp4/defragmenter.go
@@ -29,8 +29,9 @@ import (
 // be superseded the same way. Every abandoned time range must be declared
 // again by surviving fragments, so no declared content is ever silently
 // dropped; overlaps that cannot be resolved exactly are rejected, as are
-// per-sample encryption auxiliary information (senc or saiz/saio, which the
-// progressive sample tables cannot carry) and edits that cannot be shifted.
+// edits that cannot be shifted and per-sample encryption auxiliary
+// information (senc or saiz/saio, which the progressive sample tables
+// cannot carry).
 // Full-sample encryption with a constant IV has no such auxiliary data and
 // passes through losslessly, keeping the sinf of the sample description.
 func Defragment(f *File, rs io.ReadSeeker, w io.Writer) error {


### PR DESCRIPTION
Two cosmetic follow-ups to #561, which landed as `8e35af6`. Comments and documentation only — no behaviour change.

### 1. `Defragment` doc comment

The sentence hung `as are` off the mass noun *per-sample encryption auxiliary information*:

> overlaps that cannot be resolved exactly are rejected, **as are** per-sample encryption auxiliary **information** (senc or saiz/saio, which the progressive sample tables cannot carry) **and edits** that cannot be shifted.

Reordering so the plural *edits* leads makes the agreement read naturally, and keeps the parenthetical next to the term it explains.

### 2. `CHANGELOG.md`

The paragraph edited by #561 was left with a ragged wrap (`...unsupported edit lists, zero` / `timescales, truncated byte ranges...`). Rewrapped to the surrounding line width.

### Validation

`go build`, `go vet`, `gofmt`, and the full test suite pass; pre-commit (golangci-lint, go-unit-tests) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)