### PR TITLE
chore: add union merge driver for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Changelog entries from different branches are appended at the same place,
+# so keep both sides instead of conflicting on every rebase.
+#
+# Note: GitHub does not honour this server-side when computing pull request
+# mergeability, so PRs can still show a CHANGELOG conflict that resolves
+# cleanly on a local rebase.
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Problem

Every branch appends its entries to the same place in `CHANGELOG.md`, so a rebase onto an updated `master` conflicts there almost every time, even though the correct resolution is invariably "keep both sides". PR #578 is a current example: the Go changes rebase cleanly and only the changelog collides.

## Change

Adds a tracked `.gitattributes` marking `CHANGELOG.md` with git's built-in `union` merge driver, so overlapping regions keep both sides' lines instead of producing conflict markers.

## Caveats, recorded in the file itself

- GitHub does **not** honour `.gitattributes` merge drivers server-side when computing pull request mergeability ([community discussion #9288](https://github.com/orgs/community/discussions/9288)). A PR can therefore still show a CHANGELOG conflict that rebases cleanly locally. This only helps whoever performs the rebase.
- `union` resolves silently and cannot deduplicate. Appending bullets under an existing `### Fixed` is always right, but if two branches each add a section heading that does not exist yet, or both add a new `## [x.y.z]` heading at release time, the result contains it twice with no warning. Worth a glance at the `## [Unreleased]` headings after a changelog rebase.

This rule previously existed only as an untracked `.git/info/attributes` in one local clone, which made that clone report a clean merge while GitHub reported a conflict. Tracking it makes the behaviour shared and visible instead of a silent per-clone difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)