### PR TITLE
docs: name the documented function correctly and fix doc typos

### DIFF
--- a/avc/avcdecoderconfigurationrecord.go
+++ b/avc/avcdecoderconfigurationrecord.go
@@ -203,7 +203,7 @@ func (a *DecConfRec) Encode(w io.Writer) error {
 	return err
 }
 
-// Encode - write an AVCDecConfRec to w
+// EncodeSW - write an AVCDecConfRec to sw
 func (a *DecConfRec) EncodeSW(sw bits.SliceWriter) error {
 
 	var configurationVersion byte = 1

--- a/avc/sps.go
+++ b/avc/sps.go
@@ -252,7 +252,7 @@ func ParseSPSNALUnit(data []byte, parseVUIBeyondAspectRatio bool) (*SPS, error) 
 	return sps, reader.AccError()
 }
 
-// CpbDbpDelaysPresent signals if Cpb and Dbp can be found in Picture Timing SEI
+// CpbDpbDelaysPresent signals if Cpb and Dpb can be found in Picture Timing SEI
 func (s *SPS) CpbDpbDelaysPresent() bool {
 	if s.VUI == nil {
 		return false

--- a/hevc/sps.go
+++ b/hevc/sps.go
@@ -260,7 +260,7 @@ type SubLayerHrdParameters struct {
 	CbrFlag              bool
 }
 
-// BitstreamRestrictrictions - optional information
+// BitstreamRestrictions - optional information
 type BitstreamRestrictions struct {
 	TilesFixedStructureFlag     bool
 	MVOverPicBoundariesFlag     bool

--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -418,7 +418,7 @@ func (a *AudioSampleEntryBox) Encode(w io.Writer) error {
 	return err
 }
 
-// Encode - write box to sw
+// EncodeSW - write box to sw
 func (a *AudioSampleEntryBox) EncodeSW(sw bits.SliceWriter) error {
 	if err := a.validateQuickTime(); err != nil {
 		return err

--- a/mp4/av1c.go
+++ b/mp4/av1c.go
@@ -50,7 +50,7 @@ func (b *Av1CBox) Encode(w io.Writer) error {
 	return b.CodecConfRec.Encode(w)
 }
 
-// Encode - write box to sw
+// EncodeSW - write box to sw
 func (b *Av1CBox) EncodeSW(sw bits.SliceWriter) error {
 	err := EncodeHeaderSW(b, sw)
 	if err != nil {

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -314,7 +314,7 @@ func EncodeHeaderSW(b Box, sw bits.SliceWriter) error {
 	return nil
 }
 
-// EncodeHeaderWithSize - encode a box header to a writer and allow for largeSize
+// EncodeHeaderWithSizeSW - encode a box header to a SliceWriter and allow for largeSize
 func EncodeHeaderWithSizeSW(boxType string, boxSize uint64, largeSize bool, sw bits.SliceWriter) error {
 	if !largeSize && boxSize >= 1<<32 {
 		return fmt.Errorf("Box size %d is too big for normal 4-byte size field", boxSize)

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -261,7 +261,7 @@ func DecodeBoxBodySR(startPos uint64, hdr BoxHeader, sr bits.SliceReader) (Box, 
 	return b, nil
 }
 
-// DecodeFile - parse and decode a file from reader r with optional file options.
+// DecodeFileSR - parse and decode a file from SliceReader sr with optional file options.
 // For example, the file options overwrite the default decode or encode mode.
 func DecodeFileSR(sr bits.SliceReader, options ...Option) (*File, error) {
 	f := NewFile()

--- a/mp4/cdat.go
+++ b/mp4/cdat.go
@@ -25,7 +25,7 @@ func DecodeCdat(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	return b, nil
 }
 
-// DecodeCdat - box-specific decode
+// DecodeCdatSR - box-specific decode
 func DecodeCdatSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	b := &CdatBox{
 		Data: sr.ReadBytes(hdr.payloadLen()),

--- a/mp4/co64.go
+++ b/mp4/co64.go
@@ -29,7 +29,7 @@ func DecodeCo64(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	return DecodeCo64SR(hdr, startPos, sr)
 }
 
-// DecodeCo64 - box-specific decode
+// DecodeCo64SR - box-specific decode
 func DecodeCo64SR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	nrEntries := sr.ReadUint32()

--- a/mp4/ctts.go
+++ b/mp4/ctts.go
@@ -117,7 +117,7 @@ func (b *CttsBox) SampleCount(i int) uint32 {
 
 }
 
-// AddSampleCountsAndOffsets - populate this box with data. Need the same number of entries in both
+// AddSampleCountsAndOffset - populate this box with data. Need the same number of entries in both
 func (b *CttsBox) AddSampleCountsAndOffset(counts []uint32, offsets []int32) error {
 	if len(counts) != len(offsets) {
 		return fmt.Errorf("not same number of sampleCounts %d and sampleOffsets %d", len(counts), len(offsets))

--- a/mp4/dac3.go
+++ b/mp4/dac3.go
@@ -13,7 +13,7 @@ import (
 // Signaled in fscod - Sample rate code - 2 bits
 var AC3SampleRates = []int{48000, 44100, 32000}
 
-// AX3acmodChanneTable - channel configurations from ETSI TS 102 366 V1.4.1 (2017) section 4.4.2.3A
+// AC3acmodChannelTable - channel configurations from ETSI TS 102 366 V1.4.1 (2017) section 4.4.2.3A
 // Signaled in acmod - audio coding mode - 3 bits
 var AC3acmodChannelTable = []string{
 	"L/R", //Ch1 Ch2 dual mono but name them L R
@@ -124,7 +124,7 @@ func (b *Dac3Box) Encode(w io.Writer) error {
 	return err
 }
 
-// Encode - write box to sw
+// EncodeSW - write box to sw
 func (b *Dac3Box) EncodeSW(sw bits.SliceWriter) error {
 	err := EncodeHeaderSW(b, sw)
 	if err != nil {

--- a/mp4/dref.go
+++ b/mp4/dref.go
@@ -127,7 +127,7 @@ func (d *DrefBox) Encode(w io.Writer) error {
 	return err
 }
 
-// EncodeSW - write dref box to w including children
+// EncodeSW - write dref box to sw including children
 func (d *DrefBox) EncodeSW(sw bits.SliceWriter) error {
 	err := EncodeHeaderSW(d, sw)
 	if err != nil {

--- a/mp4/hvcc.go
+++ b/mp4/hvcc.go
@@ -65,7 +65,7 @@ func (b *HvcCBox) Encode(w io.Writer) error {
 	return b.DecConfRec.Encode(w)
 }
 
-// Encode - write box to w
+// EncodeSW - write box to sw
 func (b *HvcCBox) EncodeSW(sw bits.SliceWriter) error {
 	err := EncodeHeaderSW(b, sw)
 	if err != nil {

--- a/mp4/ilst.go
+++ b/mp4/ilst.go
@@ -63,7 +63,7 @@ func (b *IlstBox) Encode(w io.Writer) error {
 	return EncodeContainer(b, w)
 }
 
-// Encode - write ilst container to sw
+// EncodeSW - write ilst container to sw
 func (b *IlstBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(b, sw)
 }

--- a/mp4/kind.go
+++ b/mp4/kind.go
@@ -65,7 +65,7 @@ func (b *KindBox) Encode(w io.Writer) error {
 	return err
 }
 
-// Encode - write box to w
+// EncodeSW - write box to sw
 func (b *KindBox) EncodeSW(sw bits.SliceWriter) error {
 	err := EncodeHeaderSW(b, sw)
 	if err != nil {

--- a/mp4/ludt.go
+++ b/mp4/ludt.go
@@ -67,7 +67,7 @@ func (b *LudtBox) Encode(w io.Writer) error {
 	return EncodeContainer(b, w)
 }
 
-// Encode - write ludt container to sw
+// EncodeSW - write ludt container to sw
 func (b *LudtBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(b, sw)
 }

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -139,7 +139,7 @@ func (m *MdatBox) Encode(w io.Writer) error {
 	return err
 }
 
-// Encode - write box to sw. If m.lazyDataSize > 0, the mdat data needs to be written separately
+// EncodeSW - write box to sw. If m.lazyDataSize > 0, the mdat data needs to be written separately
 func (m *MdatBox) EncodeSW(sw bits.SliceWriter) error {
 	err := EncodeHeaderWithSizeSW("mdat", m.Size(), m.LargeSize, sw)
 	if err != nil {

--- a/mp4/mdhd.go
+++ b/mp4/mdhd.go
@@ -35,7 +35,7 @@ func DecodeMdhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	return DecodeMdhdSR(hdr, startPos, sr)
 }
 
-// DecodeMdhd - Decode box
+// DecodeMdhdSR - Decode box
 func DecodeMdhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)

--- a/mp4/minf.go
+++ b/mp4/minf.go
@@ -86,7 +86,7 @@ func (m *MinfBox) Encode(w io.Writer) error {
 	return EncodeContainer(m, w)
 }
 
-// Encode - write minf container to sw
+// EncodeSW - write minf container to sw
 func (m *MinfBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(m, sw)
 }

--- a/mp4/moof.go
+++ b/mp4/moof.go
@@ -114,7 +114,7 @@ func (m *MoofBox) Encode(w io.Writer) error {
 	return nil
 }
 
-// Encode - write moof after updating trun dataoffset
+// EncodeSW - write moof after updating trun dataoffset
 func (m *MoofBox) EncodeSW(sw bits.SliceWriter) error {
 	for _, trun := range m.Traf.Truns {
 		if trun.HasDataOffset() && trun.DataOffset == 0 {

--- a/mp4/moov.go
+++ b/mp4/moov.go
@@ -116,7 +116,7 @@ func (m *MoovBox) Encode(w io.Writer) error {
 	return EncodeContainer(m, w)
 }
 
-// Encode - write moov container to sw
+// EncodeSW - write moov container to sw
 func (m *MoovBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(m, sw)
 }

--- a/mp4/mvex.go
+++ b/mp4/mvex.go
@@ -50,7 +50,7 @@ func DecodeMvex(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	return m, nil
 }
 
-// DecodeMvex - box-specific decode
+// DecodeMvexSR - box-specific decode
 func DecodeMvexSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
@@ -83,7 +83,7 @@ func (m *MvexBox) Encode(w io.Writer) error {
 	return EncodeContainer(m, w)
 }
 
-// Encode - write mvex container to sw
+// EncodeSW - write mvex container to sw
 func (m *MvexBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(m, sw)
 }

--- a/mp4/pssh.go
+++ b/mp4/pssh.go
@@ -178,7 +178,7 @@ func (b *PsshBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 	return bd.err
 }
 
-// PsshBoxesFromDBytesextracts pssh boxes from slice of bytes
+// PsshBoxesFromBytes extracts pssh boxes from slice of bytes
 func PsshBoxesFromBytes(psshData []byte) ([]*PsshBox, error) {
 	psshBoxes := make([]*PsshBox, 0, 1)
 	sr := bits.NewFixedSliceReader(psshData)

--- a/mp4/sinf.go
+++ b/mp4/sinf.go
@@ -73,7 +73,7 @@ func (b *SinfBox) Encode(w io.Writer) error {
 	return EncodeContainer(b, w)
 }
 
-// Encode - write sinf container to sw
+// EncodeSW - write sinf container to sw
 func (b *SinfBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(b, sw)
 }

--- a/mp4/stbl.go
+++ b/mp4/stbl.go
@@ -126,7 +126,7 @@ func (s *StblBox) Encode(w io.Writer) error {
 	return EncodeContainer(s, w)
 }
 
-// Encode - write stbl container to sw
+// EncodeSW - write stbl container to sw
 func (b *StblBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(b, sw)
 }

--- a/mp4/tkhd.go
+++ b/mp4/tkhd.go
@@ -169,7 +169,7 @@ func (b *TkhdBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 	return bd.err
 }
 
-// CraetionTimeS returns the creation time in seconds since Jan 1, 1970
+// CreationTimeS returns the creation time in seconds since Jan 1, 1970
 func (b *TkhdBox) CreationTimeS() int64 {
 	return int64(b.CreationTime) - EpochDiffS
 }

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -109,7 +109,7 @@ func (t *TrakBox) Encode(w io.Writer) error {
 	return EncodeContainer(t, w)
 }
 
-// Encode - write trak container to sw
+// EncodeSW - write trak container to sw
 func (b *TrakBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(b, sw)
 }

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -83,7 +83,7 @@ func DecodeTrun(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	return t, nil
 }
 
-// DecodeTrun - box-specific decode
+// DecodeTrunSR - box-specific decode
 func DecodeTrunSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	sampleCount := sr.ReadUint32()
@@ -454,7 +454,7 @@ func (t *TrunBox) AddSample(s Sample) {
 	t.Samples = append(t.Samples, s)
 }
 
-// AddSamples - add a a slice of Sample
+// AddSamples - add a slice of Sample
 func (t *TrunBox) AddSamples(s []Sample) {
 	t.Samples = append(t.Samples, s...)
 }

--- a/mp4/udta.go
+++ b/mp4/udta.go
@@ -81,7 +81,7 @@ func (b *UdtaBox) Encode(w io.Writer) error {
 	return EncodeContainer(b, w)
 }
 
-// Encode - write udta container to sw
+// EncodeSW - write udta container to sw
 func (b *UdtaBox) EncodeSW(sw bits.SliceWriter) error {
 	return EncodeContainerSW(b, sw)
 }

--- a/mp4/uuid.go
+++ b/mp4/uuid.go
@@ -57,7 +57,7 @@ const (
 	UUIDSphericalVideoV1 = "ffcc8263-f855-4a93-8814-587a02521fdd"
 )
 
-// NewTrfrfBox creates a new TfrfBox with values.
+// NewTfrfBox creates a new TfrfBox with values.
 // fragmentCount is the number of fragments, andb both
 // fragmentAbsoluteTimes and fragmentAbsoluteDurations must be slices of that length.
 func NewTfrfBox(fragmentCount byte, fragmentAbsoluteTimes, fragmentAbsoluteDurations []uint64) *UUIDBox {
@@ -128,8 +128,8 @@ func (u *UUIDBox) UUID() string {
 	return u.uuid.String()
 }
 
-// UUID - Set UUID from string corresponding to 16 bytes.
-// The input should be a UUID-formatted hex string, plain hex or baset64 encoded.
+// SetUUID - Set UUID from string corresponding to 16 bytes.
+// The input should be a UUID-formatted hex string, plain hex or base64 encoded.
 func (u *UUIDBox) SetUUID(uuid string) (err error) {
 	u.uuid, err = createUUID(uuid)
 	return err


### PR DESCRIPTION
Second of two PRs from the repo-wide doc-comment audit. Where [#584](https://github.com/Eyevinn/mp4ff/pull/584) fixes comments that describe the *wrong thing*, this one fixes mechanical drift: comments that describe the right thing under the wrong name. Comments only, no behaviour change.

- **17 `EncodeSW` methods were documented as `Encode`** (of 141 total — the other 124 already lead correctly, so this is drift rather than house style). Several also said the box is written *"to w"* though the parameter is a `bits.SliceWriter`.
- **`Decode*SR` documented under their `io.Reader` names**: `DecodeMdhdSR`, `DecodeTrunSR`, `DecodeMvexSR`, `DecodeCo64SR`, `DecodeCdatSR`, `DecodeFileSR`. `DecodeFileSR` also claimed to read *"from reader r"*.
- **`EncodeHeaderWithSizeSW`** shared `EncodeHeaderWithSize`'s doc verbatim, including "to a writer".
- **Misspelled names**: `BitstreamRestrictrictions`, `CpbDbpDelaysPresent` (Dbp↔Dpb), `CraetionTimeS`, `AX3acmodChanneTable`, `NewTrfrfBox`, `PsshBoxesFromDBytesextracts` (also missing a space), `AddSampleCountsAndOffsets`, and the `SetUUID` doc starting with "UUID".
- **Typos**: "baset64" → "base64", "add a a slice of Sample".

The two PRs touch **disjoint sets of files**, so they can merge in either order without conflicting. One straggler, the second `EncodeSW` in `mp4/tref.go`, is left to #584 because that file belongs to it.

### Validation

`go build`, `go vet`, `gofmt`, full test suite, and pre-commit (golangci-lint, go-unit-tests) all pass. Verified that every changed line is a comment line and that no file overlaps #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)