### PR TITLE
chore: enforce codespell as a pre-commit hook and fix two typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,17 @@
+[codespell]
+# Shared by the Makefile target and the pre-commit hook so the two cannot drift.
+skip = ./venv,*/venv/*,./references,*/references/*,testdata,*/testdata/*,*.mp4,*.m4s,*.264,*.265
+# Terms codespell mistakes for misspellings. Most are ISOBMFF box names or
+# bitstream syntax elements, the rest are identifiers spelled that way on
+# purpose.
+#   trun, truns  - Track Fragment Run box
+#   fiel         - Field Ordering (QuickTime) box
+#   nam          - the iTunes (c)nam metadata atom
+#   ue           - ue(v), unsigned exponential-Golomb syntax element
+#   acn          - Ambisonic Channel Number (IAMF)
+#   te, toi, vie - fragments of sample text in tests
+#   testin       - the testIn identifier
+#   prevend      - the prevEnd identifier
+#   datas        - plural of data, used for slices of sample payloads
+#   re-declare*  - deliberate hyphenation in the defragmenter
+ignore-words-list = trun,truns,fiel,nam,ue,acn,te,toi,vie,testin,prevend,datas,re-declare,re-declares,re-declared,re-declaring

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
       - id: go-fmt
       - id: golangci-lint
       - id: go-unit-tests
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.18.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ venv:
 	python3 -m venv venv
 	venv/bin/pip install --upgrade pip
 	venv/bin/pip install pre-commit==4.2.0
-	venv/bin/pip install codespell
+	venv/bin/pip install codespell==2.4.1
 
 .PHONY: pre-commit-install
 pre-commit-install: venv
@@ -56,7 +56,7 @@ pre-commit: venv
 
 .PHONY: codespell
 codespell: venv
-	venv/bin/codespell -S testdata,references,./venv -L trun,te,truns,nam,toi,vie,testIn
+	venv/bin/codespell
 
 .PHONY: check
 check: prepare pre-commit codespell

--- a/iamf/parser.go
+++ b/iamf/parser.go
@@ -158,7 +158,7 @@ var scalableChannelLayouts = []channelLayout{
 
 	// 10-14: Reserved for future use
 
-	// 15: Expanded channel layouts - defined in expanded_loudspeaker_layout field bellow
+	// 15: Expanded channel layouts - defined in expanded_loudspeaker_layout field below
 }
 
 func expanded(index int, channels int, mask channelMask) channelLayout {

--- a/mp4/uuid.go
+++ b/mp4/uuid.go
@@ -58,7 +58,7 @@ const (
 )
 
 // NewTfrfBox creates a new TfrfBox with values.
-// fragmentCount is the number of fragments, andb both
+// fragmentCount is the number of fragments, and both
 // fragmentAbsoluteTimes and fragmentAbsoluteDurations must be slices of that length.
 func NewTfrfBox(fragmentCount byte, fragmentAbsoluteTimes, fragmentAbsoluteDurations []uint64) *UUIDBox {
 	return &UUIDBox{


### PR DESCRIPTION
## Problem

The repo already had a `codespell` make target, but nothing ever ran it — it is
not in `.pre-commit-config.yaml` and not in any workflow, so it only fired if
someone typed `make check` by hand. Its inline ignore list had gone stale in the
meantime, so `make check` fails today:

```
$ make codespell
... 71 findings, exit 65
```

Every one of those 71 is a false positive except a single real typo. The bulk
are ISOBMFF box names and bitstream syntax that codespell reads as English:
`trun` → *turn* (334 hits across the repo), `fiel` → *field*, `ue` → *use*,
`acn`, plus identifiers like `prevEnd` and `datas` and the deliberate
hyphenation in `re-declared`.

## Fix

Move the settings out of the Makefile recipe into a `.codespellrc` that both the
make target and a new pre-commit hook read, so the two cannot drift, and pin
codespell to the 2.4.1 that `make venv` already installs.

One subtlety worth recording: the old `-S testdata` skip works when codespell
walks the tree itself, but **not** under pre-commit, which passes explicit paths
like `mp4/testdata/fuzz/...` that a bare directory name does not match. The first
version of this hook failed on exactly those fuzz corpus files. The skip patterns
are therefore written as path globs (`testdata,*/testdata/*`) and verified in
both invocation modes.

The ignore list is commented with what each term actually is, so the next person
does not have to re-derive that `fiel` is a box name.

## Typo fixes

- `iamf/parser.go`: `bellow` → `below` — the one genuine typo codespell found.
- `mp4/uuid.go`: `andb` → `and` in the `NewTfrfBox` comment. codespell does
  *not* flag this one: a four-letter token like `andb` is not in its dictionary,
  by design, since listing it would cause false positives on identifiers and hex.
  It is fixed here because it was noticed, not because tooling caught it.

## Validation

- `codespell` clean in both modes: tree walk, and explicit paths via `git ls-files | xargs`.
- `pre-commit run codespell --all-files` passes.
- Positive control: a scratch file containing `occured`/`recieved` is correctly
  rejected by the hook, so it is not passing vacuously.
- `go build`, `go vet`, `gofmt`, full `go test ./...`, and the complete
  pre-commit suite all pass.

No CHANGELOG entry: tooling chore plus comment typos, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
